### PR TITLE
Simplifying AbstractController generic type

### DIFF
--- a/lib/AbstractController.ts
+++ b/lib/AbstractController.ts
@@ -1,20 +1,11 @@
 import type { RouteType } from '@lokalise/fastify-api-contracts'
-import type {
-  DeleteRouteDefinition,
-  GetRouteDefinition,
-  PayloadRouteDefinition,
-} from '@lokalise/universal-ts-utils/api-contracts/apiContracts'
+import type { CommonRouteDefinition } from '@lokalise/universal-ts-utils/api-contracts/apiContracts'
+
+// biome-ignore lint/suspicious/noExplicitAny: we don't care about specific generics here
+export type AnyCommonRouteDefinition = CommonRouteDefinition<any, any, any, any, any, any, any>
 
 export abstract class AbstractController<
-  APIContracts extends Record<
-    string,
-    // biome-ignore lint/suspicious/noExplicitAny: we don't care about specific generics here
-    | DeleteRouteDefinition<any, any, any, any, any, any, any>
-    // biome-ignore lint/suspicious/noExplicitAny: we don't care about specific generics here
-    | GetRouteDefinition<any, any, any, any, any, any, any>
-    // biome-ignore lint/suspicious/noExplicitAny: we don't care about specific generics here
-    | PayloadRouteDefinition<any, any, any, any, any, any, any, any>
-  >,
+  APIContracts extends Record<string, AnyCommonRouteDefinition>,
 > {
   public abstract buildRoutes(): Record<keyof APIContracts, RouteType>
 }


### PR DESCRIPTION
In follow-up PRs, I will try to improve `buildRoutes` type to have some kind of type validation there, but in the meantime I think this change is already beneficial as it improves the controller readability 