### PR TITLE
include response schemas in Fastify route schema for api-contracts

### DIFF
--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -263,10 +263,14 @@ describe('buildApiRoute — response schemas', () => {
     })
     const routeOptions = buildApiRoute(sseFirstContract, {
       nonSse: async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
-      sse: (_request, sse) => { sse.start('keepAlive') },
+      sse: (_request, sse) => {
+        sse.start('keepAlive')
+      },
     })
     expect(routeOptions).toEqual(
-      expect.objectContaining({ schema: expect.objectContaining({ response: { 200: userSchema } }) }),
+      expect.objectContaining({
+        schema: expect.objectContaining({ response: { 200: userSchema } }),
+      }),
     )
   })
 })

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -206,6 +206,51 @@ describe('buildApiRoute — SSE config via options', () => {
 })
 
 // ============================================================================
+// buildApiRoute — response schemas
+// ============================================================================
+
+describe('buildApiRoute — response schemas', () => {
+  it('includes JSON response schema for a GET route', () => {
+    const routeOptions = buildApiRoute(getUserContract, async () => ({
+      status: 200,
+      body: { id: '1', name: 'Alice' },
+    }))
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: { 200: userSchema } }) }),
+    )
+  })
+
+  it('includes JSON response schema for a POST route', () => {
+    const routeOptions = buildApiRoute(createUserContract, async () => ({
+      status: 201,
+      body: { id: '1', name: 'Alice' },
+    }))
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: { 201: userSchema } }) }),
+    )
+  })
+
+  it('omits ContractNoBody status codes from response schemas', () => {
+    const routeOptions = buildApiRoute(deleteUserContract, async () => ({
+      status: 204,
+      body: undefined,
+    }))
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
+    )
+  })
+
+  it('omits SSE-only status codes from response schemas', () => {
+    const routeOptions = buildApiRoute(sseOnlyContract, (_request, sse) => {
+      sse.start('keepAlive')
+    })
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
+    )
+  })
+})
+
+// ============================================================================
 // buildApiRoute — no-path-params contract
 // ============================================================================
 

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -216,7 +216,9 @@ describe('buildApiRoute — response schemas', () => {
       body: { id: '1', name: 'Alice' },
     }))
     expect(routeOptions).toEqual(
-      expect.objectContaining({ schema: expect.objectContaining({ response: { 200: userSchema } }) }),
+      expect.objectContaining({
+        schema: expect.objectContaining({ response: { 200: userSchema } }),
+      }),
     )
   })
 
@@ -226,7 +228,9 @@ describe('buildApiRoute — response schemas', () => {
       body: { id: '1', name: 'Alice' },
     }))
     expect(routeOptions).toEqual(
-      expect.objectContaining({ schema: expect.objectContaining({ response: { 201: userSchema } }) }),
+      expect.objectContaining({
+        schema: expect.objectContaining({ response: { 201: userSchema } }),
+      }),
     )
   })
 

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -252,6 +252,23 @@ describe('buildApiRoute — response schemas', () => {
       expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
     )
   })
+
+  it('picks the JSON schema from anyOfResponses even when SSE variant comes first', () => {
+    const sseFirstContract = defineApiContract({
+      method: 'get',
+      pathResolver: () => '/mixed',
+      responsesByStatusCode: {
+        200: anyOfResponses([sseResponse(sseEventsSchema), userSchema]),
+      },
+    })
+    const routeOptions = buildApiRoute(sseFirstContract, {
+      nonSse: async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      sse: (_request, sse) => { sse.start('keepAlive') },
+    })
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: { 200: userSchema } }) }),
+    )
+  })
 })
 
 // ============================================================================

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -88,7 +88,7 @@ function getSchemaForStatusCode(contract: ApiContract, status: number): z.ZodTyp
         isTextResponse(anyResponse) ||
         isBlobResponse(anyResponse)
       ) {
-        return null
+        continue
       }
       return anyResponse
     }

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -382,10 +382,7 @@ function buildBaseSchema(contract: ApiContract): Record<string, unknown> {
   if (contract.requestQuerySchema) schema.querystring = contract.requestQuerySchema
   if (contract.requestHeaderSchema) schema.headers = contract.requestHeaderSchema
 
-  if (
-    contract.requestBodySchema !== undefined &&
-    contract.requestBodySchema !== ContractNoBody
-  ) {
+  if (contract.requestBodySchema !== undefined && contract.requestBodySchema !== ContractNoBody) {
     schema.body = contract.requestBodySchema
   }
 

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -363,6 +363,19 @@ async function handleApiSseRoute(
 // Internal Helpers — Schema
 // ============================================================================
 
+function buildResponseSchemas(contract: ApiContract): Record<number, unknown> {
+  return Object.keys(contract.responsesByStatusCode).reduce<Record<number, unknown>>(
+    (acc, statusCode) => {
+      const schema = getSchemaForStatusCode(contract, Number(statusCode))
+      if (schema) {
+        acc[Number(statusCode)] = schema
+      }
+      return acc
+    },
+    {},
+  )
+}
+
 function buildBaseSchema(contract: ApiContract): Record<string, unknown> {
   const schema: Record<string, unknown> = {}
   if (contract.requestPathParamsSchema) schema.params = contract.requestPathParamsSchema
@@ -370,12 +383,13 @@ function buildBaseSchema(contract: ApiContract): Record<string, unknown> {
   if (contract.requestHeaderSchema) schema.headers = contract.requestHeaderSchema
 
   if (
-    'requestBodySchema' in contract &&
     contract.requestBodySchema !== undefined &&
     contract.requestBodySchema !== ContractNoBody
   ) {
     schema.body = contract.requestBodySchema
   }
+
+  schema.response = buildResponseSchemas(contract)
 
   return schema
 }


### PR DESCRIPTION
This PR adds `buildResponseSchemas` which maps `responsesByStatusCode` entries into Fastify's `schema.response` format for OpenAPI/Swagger doc generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for API response schema validation, ensuring proper schema mappings for standard responses and correct omission for no-body scenarios.

* **Refactor**
  * Improved API schema building with streamlined response schema generation and enhanced handling of different response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->