### PR TITLE
feat: gateway configuration metadata layer + Envoy/KrakenD/Kong generators

### DIFF
--- a/.github/workflows/gateway-acceptance.yml
+++ b/.github/workflows/gateway-acceptance.yml
@@ -1,0 +1,97 @@
+---
+name: gateway-acceptance
+
+# Acceptance tests boot real Envoy and KrakenD containers via docker compose,
+# render configs from each package's renderer, and drive traffic through the
+# gateway against a Node stub upstream. We only run them when gateway code
+# changes — they're slower than the unit suite and would be wasteful on
+# unrelated PRs.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'lib/gateway/**'
+      - 'packages/gateway-envoy/**'
+      - 'packages/gateway-krakend/**'
+      - 'packages/gateway-kong/**'
+      - '.github/workflows/gateway-acceptance.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'lib/gateway/**'
+      - 'packages/gateway-envoy/**'
+      - 'packages/gateway-krakend/**'
+      - 'packages/gateway-kong/**'
+      - '.github/workflows/gateway-acceptance.yml'
+
+jobs:
+  envoy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/gateway-envoy
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - name: Install root dependencies
+        run: npm install
+        working-directory: .
+      - name: Build root package
+        run: npm run build
+        working-directory: .
+      - name: Run unit tests
+        run: npm test
+      - name: Run acceptance tests (docker compose)
+        run: npm run test:acceptance
+
+  krakend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/gateway-krakend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - name: Install root dependencies
+        run: npm install
+        working-directory: .
+      - name: Build root package
+        run: npm run build
+        working-directory: .
+      - name: Run unit tests
+        run: npm test
+      - name: Run acceptance tests (docker compose)
+        run: npm run test:acceptance
+
+  kong:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/gateway-kong
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - name: Install root dependencies
+        run: npm install
+        working-directory: .
+      - name: Build root package
+        run: npm run build
+        working-directory: .
+      - name: Run unit tests
+        run: npm test
+      - name: Run acceptance tests (docker compose)
+        run: npm run test:acceptance

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dist
 .pnp.*
 /.idea/
 /package-lock.json
+
+# Generated gateway configs from acceptance tests
+packages/gateway-*/acceptance/generated/

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ Very opinionated DI framework for fastify, built on top of awilix
   - [Accept Header Routing](#accept-header-routing)
   - [Testing Dual-Mode Controllers](#testing-dual-mode-controllers)
 - [Gateway Configuration](#gateway-configuration)
-  - [Concepts](#concepts)
-  - [Attaching Gateway Metadata to a Route](#attaching-gateway-metadata-to-a-route)
-  - [Controller- and Service-Level Defaults](#controller--and-service-level-defaults)
-  - [Type-Safe Matching from the Contract](#type-safe-matching-from-the-contract)
-  - [Universal Metadata Reference](#universal-metadata-reference)
-  - [Building a Manifest](#building-a-manifest)
+  - [Quick Start](#quick-start)
+  - [Annotating Routes](#annotating-routes)
+  - [Avoiding Repetition With Defaults](#avoiding-repetition-with-defaults)
+  - [Type-Safe Matching](#type-safe-matching)
+  - [Field Reference](#field-reference)
   - [Generating Gateway Configs](#generating-gateway-configs)
-  - [Optional Fastify Plugin (`app.buildGatewayManifest`)](#optional-fastify-plugin-appbuildgatewaymanifest)
+  - [Inspecting the Manifest at Runtime](#inspecting-the-manifest-at-runtime)
+  - [What's Not Covered](#whats-not-covered)
 
 ## Basic usage
 
@@ -2810,61 +2810,26 @@ describe('DashboardDualModeController', () => {
 
 ## Gateway Configuration
 
-`opinionated-machine` lets you describe gateway-level routing concerns
-(timeouts, retries, rate limits, CORS, traffic matching, header transforms,
-caching, JWT auth) **next to your controller routes** instead of in
-hand-maintained Envoy / KrakenD / Kong configs that drift from the service
-code. You attach a small piece of metadata to a route, then run a generator
-package to emit the gateway-specific YAML/JSON.
+Most services keep two copies of every route's policy: one in code, another in
+a hand-edited Envoy / KrakenD / Kong config. They drift, and outages happen at
+the seam. This feature lets you declare routing policy — timeouts, retries,
+rate limits, CORS, JWT auth, caching, header transforms, traffic matching —
+**next to the controller route it applies to**, then generate the gateway
+config from a single source of truth.
 
-Generators ship as separate npm packages under `packages/`:
+Generators ship as separate npm packages so your service binary doesn't pull
+them in:
 
-| Gateway | Package | Format |
+| Gateway | Package | Output |
 | ------- | ------- | ------ |
 | Envoy   | [`@opinionated-machine/gateway-envoy`](./packages/gateway-envoy)     | static v3 YAML/JSON |
 | KrakenD | [`@opinionated-machine/gateway-krakend`](./packages/gateway-krakend) | declarative v3 JSON |
 | Kong    | [`@opinionated-machine/gateway-kong`](./packages/gateway-kong)       | DB-less declarative YAML/JSON |
 
-### Concepts
+### Quick Start
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│ Authoring  — withGatewayMetadata(contract, route, metadata)      │
-│              + AbstractController.gatewayDefaults                │
-└──────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ Collection — DIContext.buildGatewayManifest({ service, defaults})│
-│              walks every controller, merges defaults, validates  │
-│              and returns a versioned, JSON-serializable manifest │
-└──────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌──────────────────────────────────────────────────────────────────┐
-│ Generation — render(manifest, options) → config string           │
-│              one pure function per gateway, zero coupling to     │
-│              fastify, DI, or contracts                           │
-└──────────────────────────────────────────────────────────────────┘
-```
-
-Two design rules make the rest of the docs short:
-
-- **`buildRoutes()` is still the only place a route is declared.**
-  `buildFastifyRoute(...)` calls in private fields stay untouched. Gateway
-  metadata is applied at the `buildRoutes()` return — concentrated in one
-  scannable block per controller, mixable with un-annotated routes.
-- **The contract is the source of truth for matching.** `match.headers` and
-  `match.query` keys are typed against the contract's request schemas, so
-  typos and stale keys become compile errors. Explicit `customHeaders` /
-  `customQuery` are the escape hatches for headers / queries not in the
-  contract.
-
-Only REST controllers (`AbstractController`) and api-contract controllers
-(`AbstractApiController`) are covered in v1. SSE and dual-mode controllers
-appear in the manifest in a future release.
-
-### Attaching Gateway Metadata to a Route
+A complete round-trip in two steps. First, annotate routes in your existing
+controller:
 
 ```ts
 import { buildRestContract } from '@lokalise/api-contracts'
@@ -2875,195 +2840,203 @@ import {
   type GatewayMetadataValue,
   withGatewayMetadata,
 } from 'opinionated-machine'
+import { z } from 'zod/v4'
 
-class UsersController extends AbstractController<typeof UsersController.contracts> {
-  public static contracts = { getItem, deleteItem, updateItem, createItem } as const
+const getUser = buildRestContract({
+  method: 'get',
+  successResponseBodySchema: z.object({ id: z.string() }),
+  requestPathParamsSchema: z.object({ userId: z.string() }),
+  pathResolver: (p) => `/users/${p.userId}`,
+})
+const createUser = buildRestContract({
+  method: 'post',
+  requestBodySchema: z.object({ name: z.string() }),
+  successResponseBodySchema: z.object({ id: z.string() }),
+  pathResolver: () => '/users',
+})
 
-  // Route-handler fields are completely untouched — same buildFastifyRoute(...)
-  // calls you already write today.
-  private getItem    = buildFastifyRoute(UsersController.contracts.getItem,    async (req, reply) => { /* ... */ })
-  private deleteItem = buildFastifyRoute(UsersController.contracts.deleteItem, async (req, reply) => { /* ... */ })
-  private updateItem = buildFastifyRoute(UsersController.contracts.updateItem, async (req, reply) => { /* ... */ })
-  private createItem = buildFastifyRoute(UsersController.contracts.createItem, async (req, reply) => { /* ... */ })
+export class UsersController extends AbstractController<typeof UsersController.contracts> {
+  static readonly contracts = { getUser, createUser } as const
 
-  // Gateway annotations live in one block, alongside contract references for
-  // type-safety. Annotated and un-annotated routes mix freely.
-  public buildRoutes(): BuildRoutesReturnType<typeof UsersController.contracts> {
+  // Applies to every route in this controller; routes can override.
+  override readonly gatewayDefaults: GatewayMetadataValue = {
+    upstream: 'users-service',
+    timeouts: { request: '5s' },
+    auth: { required: true },
+  }
+
+  private getUser    = buildFastifyRoute(UsersController.contracts.getUser,    async (req, reply) => { /* … */ })
+  private createUser = buildFastifyRoute(UsersController.contracts.createUser, async (req, reply) => { /* … */ })
+
+  buildRoutes(): BuildRoutesReturnType<typeof UsersController.contracts> {
     return {
-      getItem: withGatewayMetadata(UsersController.contracts.getItem, this.getItem, {
+      getUser: withGatewayMetadata(UsersController.contracts.getUser, this.getUser, {
         cache: { ttl: '60s' },
-        match: { customHeaders: { 'x-tenant-id': { regex: '^t_' } } },
       }),
-      deleteItem: withGatewayMetadata(UsersController.contracts.deleteItem, this.deleteItem, {
-        retry: { attempts: 0 },
-        rateLimit: { requests: 5, per: '1m', key: 'ip' },
+      createUser: withGatewayMetadata(UsersController.contracts.createUser, this.createUser, {
+        rateLimit: { requests: 10, per: '1m', key: 'ip' },
       }),
-      updateItem: this.updateItem,  // un-annotated — inherits defaults only
-      createItem: this.createItem,
     }
   }
 }
 ```
 
-`withGatewayMetadata` returns the **same route reference** with metadata stamped
-via a non-enumerable `Symbol`. Fastify never sees it — `app.route()` walks own
-enumerable keys — so adding annotations cannot affect runtime behaviour.
+Then write a small script that turns the running service definition into a
+gateway config — wire it into your build / CI pipeline:
 
-The same helper works on `AbstractApiController.routes`:
+```ts
+// bin/render-envoy.ts
+import { writeFileSync } from 'node:fs'
+import { renderEnvoyConfig } from '@opinionated-machine/gateway-envoy'
+import { buildContext } from '../src/diContext.ts'   // your DIContext factory
+
+const ctx = await buildContext()
+const manifest = ctx.buildGatewayManifest({
+  service: 'users-api',
+  defaults: { cors: { origins: ['https://app.example.com'], credentials: true } },
+})
+
+const { yaml, warnings } = renderEnvoyConfig(manifest, {
+  listenPort: 8080,
+  clusters: { 'users-service': { hosts: ['users:8081'] } },
+})
+
+writeFileSync('envoy.yaml', yaml)
+if (warnings.length) console.warn('[envoy]', warnings)
+```
+
+```sh
+$ tsx bin/render-envoy.ts && envoy --mode validate -c envoy.yaml
+configuration 'envoy.yaml' OK
+```
+
+The rest of this section unpacks each piece in detail.
+
+### Annotating Routes
+
+`withGatewayMetadata(contract, route, metadata)` takes:
+
+- the **contract** — used purely for type inference on `match.headers`,
+  `match.query` and `rateLimit.key`,
+- the **route** built by `buildFastifyRoute(...)` (or `buildApiRoute(...)`),
+- the **metadata** — see [Field Reference](#field-reference).
+
+Apply it inside `buildRoutes()` (or in the `routes` array for
+`AbstractApiController`) so every route's gateway policy is in one scannable
+block. Annotated and un-annotated routes mix freely, and your existing
+`buildFastifyRoute(...)` calls don't change at all:
+
+```ts
+buildRoutes() {
+  return {
+    getUser:    withGatewayMetadata(c.getUser,    this.getUser,    { cache: { ttl: '60s' } }),
+    createUser: withGatewayMetadata(c.createUser, this.createUser, { rateLimit: { requests: 10, per: '1m', key: 'ip' } }),
+    deleteUser: this.deleteUser,    // no per-route policy; inherits defaults
+  }
+}
+```
+
+For api-contract controllers, drop it directly into `routes`:
 
 ```ts
 class UsersApiController extends AbstractApiController {
   readonly routes = [
-    withGatewayMetadata(getUser, buildApiRoute(getUser, async (req) => ({ status: 200, body: { id: req.params.id } })), {
-      cache: { ttl: '60s' },
-    }),
-    buildApiRoute(deleteUser, async (req) => ({ status: 204, body: undefined })),
+    withGatewayMetadata(getUser, buildApiRoute(getUser, async (req) => /* … */), { cache: { ttl: '60s' } }),
+    buildApiRoute(deleteUser, async (req) => /* … */),
   ]
 }
 ```
 
-### Controller- and Service-Level Defaults
+Annotations are invisible to Fastify — adding them never changes runtime
+behaviour, so you can introduce them gradually on an existing service.
 
-`gatewayDefaults` is an optional instance property on the abstract base class.
-Use it for fields that apply to every route in the controller:
+### Avoiding Repetition With Defaults
+
+Most fields you'd write per route — upstream, base timeouts, auth posture,
+shared tags — are the same across every route in a controller, or every route
+in a service. Declare them once:
+
+| Layer | Where | When to use |
+| ----- | ----- | ----------- |
+| Service-wide | `buildGatewayManifest({ defaults: … })` | Cross-cutting policy: CORS, idle timeouts, observability tags |
+| Controller   | `override readonly gatewayDefaults = { … }` | Per-controller upstream, auth posture, base timeouts |
+| Per-route    | `withGatewayMetadata(...)` | Anything specific to one endpoint |
+
+Layers deep-merge in that order: service → controller → route. **Arrays in
+later layers replace** (not append), which keeps `weights`, `tags`, and
+`match.headers` predictable.
 
 ```ts
-class UsersController extends AbstractController<typeof UsersController.contracts> {
-  public override readonly gatewayDefaults: GatewayMetadataValue = {
-    upstream: 'users-service',
-    timeouts: { request: '5s' },
-    auth: { required: true },
-    tags: ['users'],
-  }
-  // ...
-}
-```
-
-Service-wide defaults are passed at manifest collection time:
-
-```ts
-const manifest = context.buildGatewayManifest({
+context.buildGatewayManifest({
   service: 'users-api',
   defaults: {
     timeouts: { idle: '60s', connect: '1s' },
     cors: { origins: ['https://app.example.com'], credentials: true },
+    tags: ['users-api'],
   },
 })
 ```
 
-**Merge order**: `service defaults → controller.gatewayDefaults → per-route metadata`.
-Deep-merged via `ts-deepmerge`. **Arrays in later layers replace** (don't
-append) — predictable for `weights`, `tags`, `match.headers`.
-
-### Type-Safe Matching from the Contract
+### Type-Safe Matching
 
 `match.headers` and `match.query` keys are inferred from the contract's
-`requestHeaderSchema` / `requestQuerySchema`:
+`requestHeaderSchema` / `requestQuerySchema`. Typos and stale references
+become compile errors before you ever ship a config:
 
 ```ts
-const contract = buildRestContract({
+const getUser = buildRestContract({
   method: 'get',
-  successResponseBodySchema: z.object({ ok: z.boolean() }),
-  requestPathParamsSchema: z.object({ userId: z.string() }),
+  successResponseBodySchema: ResponseBody,
   requestHeaderSchema: z.object({ 'x-trace-id': z.string() }),
+  requestPathParamsSchema: z.object({ userId: z.string() }),
   pathResolver: (p) => `/users/${p.userId}`,
 })
 
-withGatewayMetadata(contract, route, {
+withGatewayMetadata(getUser, this.getUser, {
   match: {
     headers: {
-      'x-trace-id': { regex: '^[a-f0-9]+$' }, // ✅ valid, type-checked
-      'x-typo': 'foo',                         // ❌ compile error
+      'x-trace-id': { regex: '^[a-f0-9]+$' },   // ✅ type-checked against the contract
+      'x-typo':     'foo',                       // ❌ compile error
     },
     customHeaders: {
-      'x-cf-tenant': 'enterprise',             // ✅ explicit escape hatch for headers not in the contract
+      'x-cf-tenant': 'enterprise',               // ✅ explicit escape hatch for headers not in the contract
     },
   },
 })
 ```
 
-`rateLimit.key` is narrowed the same way — you can write `{ header: 'x-trace-id' }`
-when the header is in the contract, or fall back to `{ customHeader: 'x-cf-tenant' }`.
+`rateLimit.key` narrows the same way — `{ header: 'x-trace-id' }` only works
+if `'x-trace-id'` is in `requestHeaderSchema`; otherwise use
+`{ customHeader: '…' }`.
 
-### Universal Metadata Reference
+### Field Reference
 
-```ts
-type GatewayMetadata<Contract = unknown> = {
-  // Identity
-  id?: string                               // defaults to "<controller>.<routeKey>"
-  upstream?: string                         // logical cluster/backend name
-  visibility?: 'public' | 'internal' | 'admin'
-  tags?: string[]
+Every field is optional. The shapes below cover the common cases — see
+[`gatewayMetadata.ts`](./lib/gateway/gatewayMetadata.ts) for the complete Zod
+schema, which is also what produces precise validation errors at generation
+time.
 
-  // Matching (path + method come from the contract)
-  match?: {
-    headers?:       Partial<Record<ContractHeaderKey<Contract>, MatchRule>>
-    customHeaders?: Record<string, MatchRule>
-    query?:         Partial<Record<ContractQueryKey<Contract>, MatchRule>>
-    customQuery?:   Record<string, MatchRule>
-    host?:          string | string[]
-  }
-
-  // Path manipulation toward upstream
-  rewrite?: { stripPrefix?: string; replacePrefix?: { from: string; to: string } }
-
-  // Reliability
-  timeouts?:       { request?: Duration; idle?: Duration; connect?: Duration }
-  retry?:          { attempts?: number; on?: RetryCondition[]; perTryTimeout?: Duration; backoff?: { base?: Duration; max?: Duration } }
-  circuitBreaker?: { maxConnections?: number; maxPendingRequests?: number; maxRequests?: number; maxRetries?: number }
-
-  // Traffic policy
-  rateLimit?: { requests: number; per: Duration; key?: 'ip' | { header } | { customHeader } | { query } | { customQuery } }
-  traffic?:   { weights?: { upstream: string; weight: number }[]; shadow?: { upstream: string; percent: number } }
-
-  // Cross-cutting
-  cors?:  { origins; methods?; headers?; exposeHeaders?; credentials?; maxAge? }
-  auth?:  { required?: boolean; jwt?: { issuer; audiences?; jwksUri? }; mTLS?: boolean }
-  cache?: { ttl: Duration; methods?: ('GET' | 'HEAD')[]; vary?: string[] }
-
-  // Header transformations (typically inject infra headers not in the contract)
-  headers?: { request?: { add?; remove? }; response?: { add?; remove? } }
-
-  // Vendor-specific escape hatch
-  extensions?: { envoy?: object; krakend?: object; kong?: object; [vendor]: object }
-}
-
-type Duration = string  // "5s" | "300ms" | "1m" | "2h"
-type MatchRule = string | { exact: string } | { prefix: string } | { regex: string }
-```
-
-Every field is optional; the runtime is validated by a Zod schema at the
-manifest boundary, so a typo in any nested field surfaces as a clean error
-during generation rather than at deploy time.
-
-### Building a Manifest
-
-```ts
-const manifest = context.buildGatewayManifest({
-  service: 'users-api',
-  version: '2026.05.01',                   // optional — embedded for traceability
-  defaults: { /* service-wide GatewayMetadataValue */ },
-})
-// {
-//   manifestVersion: '1',
-//   service: 'users-api',
-//   version: '2026.05.01',
-//   generatedAt: '2026-05-06T12:34:56.789Z',
-//   routes: [
-//     { id, method, path: '/users/{userId}', controller, routeKey, metadata },
-//     ...
-//   ]
-// }
-```
-
-Paths are emitted in OpenAPI format (`{userId}`); each generator translates
-them to its own dialect. Routes are sorted by `(path, method)` for stable
-output.
-
-The manifest is JSON-serializable — write it to disk for inspection, ship it
-to a separate repo, or feed it directly to a generator.
+| Field | Example | Notes |
+| ----- | ------- | ----- |
+| `upstream` | `'users-service'` | Logical cluster name; resolved to a host by the generator |
+| `timeouts` | `{ request: '5s', idle: '60s', connect: '1s' }` | Duration units: `ms` / `s` / `m` / `h` |
+| `retry` | `{ attempts: 2, on: ['5xx', 'connect-failure'], perTryTimeout: '2s' }` | |
+| `rateLimit` | `{ requests: 100, per: '1m', key: 'ip' }` | `key`: `'ip'`, `{ header }`, `{ customHeader }`, `{ query }`, `{ customQuery }` |
+| `cache` | `{ ttl: '60s', methods: ['GET'], vary: ['Accept-Language'] }` | |
+| `cors` | `{ origins: ['https://app.example.com'], credentials: true }` | |
+| `auth` | `{ required: true, jwt: { issuer: '…', audiences: ['…'], jwksUri: '…' } }` | |
+| `circuitBreaker` | `{ maxRequests: 100, maxRetries: 3 }` | |
+| `match` | `{ headers, customHeaders, query, customQuery, host }` | Rule values: bare string (exact), `{ exact }`, `{ prefix }`, `{ regex }` |
+| `rewrite` | `{ stripPrefix: '/v2' }` or `{ replacePrefix: { from: '/v1', to: '/v2' } }` | |
+| `traffic` | `{ weights: [{ upstream: 'a', weight: 80 }, { upstream: 'b', weight: 20 }] }` | Also `shadow: { upstream, percent }` |
+| `headers` | `{ request: { add: { 'x-internal': 'true' }, remove: ['cookie'] }, response: … }` | Free-form keys; typically infra headers not in the contract |
+| `tags`, `visibility` | `tags: ['users']`, `visibility: 'internal'` | Documentation / partitioning |
+| `extensions` | `{ envoy: { … }, krakend: { … }, kong: { … } }` | Vendor escape hatch; merged onto the generated route last |
 
 ### Generating Gateway Configs
+
+Each generator is a pure function — manifest in, config out — so you typically
+call them from a small build-time script. Pick one or all:
 
 ```ts
 import { writeFileSync } from 'node:fs'
@@ -3073,63 +3046,72 @@ import { renderKongConfig }    from '@opinionated-machine/gateway-kong'
 
 const manifest = context.buildGatewayManifest({ service: 'users-api' })
 
-const envoy = renderEnvoyConfig(manifest, {
-  listenPort: 8080,
-  clusters: { 'users-service': { hosts: ['users:8081'] } },
-})
-writeFileSync('envoy.yaml', envoy.yaml)
+writeFileSync('envoy.yaml',
+  renderEnvoyConfig(manifest, {
+    listenPort: 8080,
+    clusters: { 'users-service': { hosts: ['users:8081'] } },
+  }).yaml)
 
-const krakend = renderKrakendConfig(manifest, {
-  port: 8080,
-  upstreams: { 'users-service': 'http://users:8081' },
-})
-writeFileSync('krakend.json', JSON.stringify(krakend.json, null, 2))
+writeFileSync('krakend.json',
+  JSON.stringify(renderKrakendConfig(manifest, {
+    port: 8080,
+    upstreams: { 'users-service': 'http://users:8081' },
+  }).json, null, 2))
 
-const kong = renderKongConfig(manifest, {
-  upstreams: { 'users-service': { url: 'http://users:8081' } },
-})
-writeFileSync('kong.yaml', kong.yaml)
-
-// Each result includes `warnings` for metadata fields the gateway can't
-// natively express — log them so you don't deploy with silently-dropped policy.
-console.warn(envoy.warnings, krakend.warnings, kong.warnings)
+writeFileSync('kong.yaml',
+  renderKongConfig(manifest, {
+    upstreams: { 'users-service': { url: 'http://users:8081' } },
+  }).yaml)
 ```
 
-Each generator is a **pure function**: same manifest in, same config out. They
-have zero coupling to Fastify, the DI container, or your application code —
-ideal for CI pipelines where the gateway config and the service binary are
-built independently.
+Each result includes `warnings: string[]` listing metadata fields the gateway
+can't natively express — log them so policy isn't silently dropped (e.g. Envoy
+doesn't ship an HTTP cache filter, so `cache.ttl` will appear in
+`warnings` under the Envoy generator). When you need a knob the universal
+model doesn't cover, hand-write it under `extensions.<vendor>` on the route —
+generators merge that block onto the rendered route last.
 
-For per-gateway field mappings and limitations, see the package READMEs:
+For each gateway's full mapping table and quirks:
 
 - [`@opinionated-machine/gateway-envoy`](./packages/gateway-envoy/README.md)
 - [`@opinionated-machine/gateway-krakend`](./packages/gateway-krakend/README.md)
 - [`@opinionated-machine/gateway-kong`](./packages/gateway-kong/README.md)
 
-### Optional Fastify Plugin (`app.buildGatewayManifest`)
+### Inspecting the Manifest at Runtime
 
-For convenient access to the manifest — typically from a CLI or a sibling
-process — register `fastifyGatewayPlugin`. It mirrors the spirit of
-`@fastify/swagger`'s `app.swagger()` and decorates the Fastify instance with
-a single explicit function: `app.buildGatewayManifest()`.
+When you want the manifest from outside Node — a deployment CLI written in
+another language, an ops dashboard, a debug-time `curl` — register
+`fastifyGatewayPlugin`. The running service then exposes its manifest both in
+code and over HTTP:
 
 ```ts
 import { fastifyGatewayPlugin } from 'opinionated-machine'
 
 await app.register(fastifyGatewayPlugin, {
-  context,                                  // your DIContext
-  defaults: { service: 'users-api' },       // BuildGatewayManifestOptions
-  // exposeRoute: '/_gateway/manifest',     // (default) HTTP route returning JSON; pass false to disable
+  context,                                    // your DIContext
+  defaults: { service: 'users-api' },         // service name + any service-wide defaults
+  // exposeRoute: '/_gateway/manifest',       // (default) HTTP route; set false to disable
 })
 
-// From anywhere in the app:
+// In code, e.g. in another plugin or a graceful-shutdown drain hook:
 const manifest = app.buildGatewayManifest()
-const overridden = app.buildGatewayManifest({ service: 'users-api-canary' })
 
-// Or fetch over HTTP from a CLI / sibling process:
-//   GET /_gateway/manifest
+// From the outside:
+//   curl http://localhost:8080/_gateway/manifest | jq '.routes'
 ```
 
 The manifest is rebuilt on every call, so it always reflects the current set
 of registered controllers.
+
+### What's Not Covered
+
+- **SSE and dual-mode controllers.** Only routes from `AbstractController` and
+  `AbstractApiController` appear in the manifest today. Streaming routes still
+  proxy through every gateway, but they aren't listed.
+- **Fields a particular gateway can't natively express.** They show up in
+  `result.warnings` rather than disappearing. Reach for `extensions.<vendor>`
+  to hand-write the missing piece on a per-route basis.
+- **Runtime drift detection.** The manifest is built from your code; the
+  gateway runs separately. The generators don't compare deployed gateway
+  state against the manifest.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ Very opinionated DI framework for fastify, built on top of awilix
   - [Registering Dual-Mode Controllers](#registering-dual-mode-controllers)
   - [Accept Header Routing](#accept-header-routing)
   - [Testing Dual-Mode Controllers](#testing-dual-mode-controllers)
+- [Gateway Configuration](#gateway-configuration)
+  - [Concepts](#concepts)
+  - [Attaching Gateway Metadata to a Route](#attaching-gateway-metadata-to-a-route)
+  - [Controller- and Service-Level Defaults](#controller--and-service-level-defaults)
+  - [Type-Safe Matching from the Contract](#type-safe-matching-from-the-contract)
+  - [Universal Metadata Reference](#universal-metadata-reference)
+  - [Building a Manifest](#building-a-manifest)
+  - [Generating Gateway Configs](#generating-gateway-configs)
+  - [Optional Fastify Plugin (`app.gateway`)](#optional-fastify-plugin-appgateway)
 
 ## Basic usage
 
@@ -2798,4 +2807,327 @@ describe('DashboardDualModeController', () => {
     sseClient.close()
   })
 })
+
+## Gateway Configuration
+
+`opinionated-machine` lets you describe gateway-level routing concerns
+(timeouts, retries, rate limits, CORS, traffic matching, header transforms,
+caching, JWT auth) **next to your controller routes** instead of in
+hand-maintained Envoy / KrakenD / Kong configs that drift from the service
+code. You attach a small piece of metadata to a route, then run a generator
+package to emit the gateway-specific YAML/JSON.
+
+Generators ship as separate npm packages under `packages/`:
+
+| Gateway | Package | Format |
+| ------- | ------- | ------ |
+| Envoy   | [`@opinionated-machine/gateway-envoy`](./packages/gateway-envoy)     | static v3 YAML/JSON |
+| KrakenD | [`@opinionated-machine/gateway-krakend`](./packages/gateway-krakend) | declarative v3 JSON |
+| Kong    | [`@opinionated-machine/gateway-kong`](./packages/gateway-kong)       | DB-less declarative YAML/JSON |
+
+### Concepts
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Authoring  — withGatewayMetadata(contract, route, metadata)      │
+│              + AbstractController.gatewayDefaults                │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Collection — DIContext.buildGatewayManifest({ service, defaults})│
+│              walks every controller, merges defaults, validates  │
+│              and returns a versioned, JSON-serializable manifest │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ Generation — render(manifest, options) → config string           │
+│              one pure function per gateway, zero coupling to     │
+│              fastify, DI, or contracts                           │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Two design rules make the rest of the docs short:
+
+- **`buildRoutes()` is still the only place a route is declared.**
+  `buildFastifyRoute(...)` calls in private fields stay untouched. Gateway
+  metadata is applied at the `buildRoutes()` return — concentrated in one
+  scannable block per controller, mixable with un-annotated routes.
+- **The contract is the source of truth for matching.** `match.headers` and
+  `match.query` keys are typed against the contract's request schemas, so
+  typos and stale keys become compile errors. Explicit `customHeaders` /
+  `customQuery` are the escape hatches for headers / queries not in the
+  contract.
+
+Only REST controllers (`AbstractController`) and api-contract controllers
+(`AbstractApiController`) are covered in v1. SSE and dual-mode controllers
+appear in the manifest in a future release.
+
+### Attaching Gateway Metadata to a Route
+
+```ts
+import { buildRestContract } from '@lokalise/api-contracts'
+import { buildFastifyRoute } from '@lokalise/fastify-api-contracts'
+import {
+  AbstractController,
+  type BuildRoutesReturnType,
+  type GatewayMetadataValue,
+  withGatewayMetadata,
+} from 'opinionated-machine'
+
+class UsersController extends AbstractController<typeof UsersController.contracts> {
+  public static contracts = { getItem, deleteItem, updateItem, createItem } as const
+
+  // Route-handler fields are completely untouched — same buildFastifyRoute(...)
+  // calls you already write today.
+  private getItem    = buildFastifyRoute(UsersController.contracts.getItem,    async (req, reply) => { /* ... */ })
+  private deleteItem = buildFastifyRoute(UsersController.contracts.deleteItem, async (req, reply) => { /* ... */ })
+  private updateItem = buildFastifyRoute(UsersController.contracts.updateItem, async (req, reply) => { /* ... */ })
+  private createItem = buildFastifyRoute(UsersController.contracts.createItem, async (req, reply) => { /* ... */ })
+
+  // Gateway annotations live in one block, alongside contract references for
+  // type-safety. Annotated and un-annotated routes mix freely.
+  public buildRoutes(): BuildRoutesReturnType<typeof UsersController.contracts> {
+    return {
+      getItem: withGatewayMetadata(UsersController.contracts.getItem, this.getItem, {
+        cache: { ttl: '60s' },
+        match: { customHeaders: { 'x-tenant-id': { regex: '^t_' } } },
+      }),
+      deleteItem: withGatewayMetadata(UsersController.contracts.deleteItem, this.deleteItem, {
+        retry: { attempts: 0 },
+        rateLimit: { requests: 5, per: '1m', key: 'ip' },
+      }),
+      updateItem: this.updateItem,  // un-annotated — inherits defaults only
+      createItem: this.createItem,
+    }
+  }
+}
+```
+
+`withGatewayMetadata` returns the **same route reference** with metadata stamped
+via a non-enumerable `Symbol`. Fastify never sees it — `app.route()` walks own
+enumerable keys — so adding annotations cannot affect runtime behaviour.
+
+The same helper works on `AbstractApiController.routes`:
+
+```ts
+class UsersApiController extends AbstractApiController {
+  readonly routes = [
+    withGatewayMetadata(getUser, buildApiRoute(getUser, async (req) => ({ status: 200, body: { id: req.params.id } })), {
+      cache: { ttl: '60s' },
+    }),
+    buildApiRoute(deleteUser, async (req) => ({ status: 204, body: undefined })),
+  ]
+}
+```
+
+### Controller- and Service-Level Defaults
+
+`gatewayDefaults` is an optional instance property on the abstract base class.
+Use it for fields that apply to every route in the controller:
+
+```ts
+class UsersController extends AbstractController<typeof UsersController.contracts> {
+  public override readonly gatewayDefaults: GatewayMetadataValue = {
+    upstream: 'users-service',
+    timeouts: { request: '5s' },
+    auth: { required: true },
+    tags: ['users'],
+  }
+  // ...
+}
+```
+
+Service-wide defaults are passed at manifest collection time:
+
+```ts
+const manifest = context.buildGatewayManifest({
+  service: 'users-api',
+  defaults: {
+    timeouts: { idle: '60s', connect: '1s' },
+    cors: { origins: ['https://app.example.com'], credentials: true },
+  },
+})
+```
+
+**Merge order**: `service defaults → controller.gatewayDefaults → per-route metadata`.
+Deep-merged via `ts-deepmerge`. **Arrays in later layers replace** (don't
+append) — predictable for `weights`, `tags`, `match.headers`.
+
+### Type-Safe Matching from the Contract
+
+`match.headers` and `match.query` keys are inferred from the contract's
+`requestHeaderSchema` / `requestQuerySchema`:
+
+```ts
+const contract = buildRestContract({
+  method: 'get',
+  successResponseBodySchema: z.object({ ok: z.boolean() }),
+  requestPathParamsSchema: z.object({ userId: z.string() }),
+  requestHeaderSchema: z.object({ 'x-trace-id': z.string() }),
+  pathResolver: (p) => `/users/${p.userId}`,
+})
+
+withGatewayMetadata(contract, route, {
+  match: {
+    headers: {
+      'x-trace-id': { regex: '^[a-f0-9]+$' }, // ✅ valid, type-checked
+      'x-typo': 'foo',                         // ❌ compile error
+    },
+    customHeaders: {
+      'x-cf-tenant': 'enterprise',             // ✅ explicit escape hatch for headers not in the contract
+    },
+  },
+})
+```
+
+`rateLimit.key` is narrowed the same way — you can write `{ header: 'x-trace-id' }`
+when the header is in the contract, or fall back to `{ customHeader: 'x-cf-tenant' }`.
+
+### Universal Metadata Reference
+
+```ts
+type GatewayMetadata<Contract = unknown> = {
+  // Identity
+  id?: string                               // defaults to "<controller>.<routeKey>"
+  upstream?: string                         // logical cluster/backend name
+  visibility?: 'public' | 'internal' | 'admin'
+  tags?: string[]
+
+  // Matching (path + method come from the contract)
+  match?: {
+    headers?:       Partial<Record<ContractHeaderKey<Contract>, MatchRule>>
+    customHeaders?: Record<string, MatchRule>
+    query?:         Partial<Record<ContractQueryKey<Contract>, MatchRule>>
+    customQuery?:   Record<string, MatchRule>
+    host?:          string | string[]
+  }
+
+  // Path manipulation toward upstream
+  rewrite?: { stripPrefix?: string; replacePrefix?: { from: string; to: string } }
+
+  // Reliability
+  timeouts?:       { request?: Duration; idle?: Duration; connect?: Duration }
+  retry?:          { attempts?: number; on?: RetryCondition[]; perTryTimeout?: Duration; backoff?: { base?: Duration; max?: Duration } }
+  circuitBreaker?: { maxConnections?: number; maxPendingRequests?: number; maxRequests?: number; maxRetries?: number }
+
+  // Traffic policy
+  rateLimit?: { requests: number; per: Duration; key?: 'ip' | { header } | { customHeader } | { query } | { customQuery } }
+  traffic?:   { weights?: { upstream: string; weight: number }[]; shadow?: { upstream: string; percent: number } }
+
+  // Cross-cutting
+  cors?:  { origins; methods?; headers?; exposeHeaders?; credentials?; maxAge? }
+  auth?:  { required?: boolean; jwt?: { issuer; audiences?; jwksUri? }; mTLS?: boolean }
+  cache?: { ttl: Duration; methods?: ('GET' | 'HEAD')[]; vary?: string[] }
+
+  // Header transformations (typically inject infra headers not in the contract)
+  headers?: { request?: { add?; remove? }; response?: { add?; remove? } }
+
+  // Vendor-specific escape hatch
+  extensions?: { envoy?: object; krakend?: object; kong?: object; [vendor]: object }
+}
+
+type Duration = string  // "5s" | "300ms" | "1m" | "2h"
+type MatchRule = string | { exact: string } | { prefix: string } | { regex: string }
+```
+
+Every field is optional; the runtime is validated by a Zod schema at the
+manifest boundary, so a typo in any nested field surfaces as a clean error
+during generation rather than at deploy time.
+
+### Building a Manifest
+
+```ts
+const manifest = context.buildGatewayManifest({
+  service: 'users-api',
+  version: '2026.05.01',                   // optional — embedded for traceability
+  defaults: { /* service-wide GatewayMetadataValue */ },
+})
+// {
+//   manifestVersion: '1',
+//   service: 'users-api',
+//   version: '2026.05.01',
+//   generatedAt: '2026-05-06T12:34:56.789Z',
+//   routes: [
+//     { id, method, path: '/users/{userId}', controller, routeKey, metadata },
+//     ...
+//   ]
+// }
+```
+
+Paths are emitted in OpenAPI format (`{userId}`); each generator translates
+them to its own dialect. Routes are sorted by `(path, method)` for stable
+output.
+
+The manifest is JSON-serializable — write it to disk for inspection, ship it
+to a separate repo, or feed it directly to a generator.
+
+### Generating Gateway Configs
+
+```ts
+import { writeFileSync } from 'node:fs'
+import { renderEnvoyConfig }   from '@opinionated-machine/gateway-envoy'
+import { renderKrakendConfig } from '@opinionated-machine/gateway-krakend'
+import { renderKongConfig }    from '@opinionated-machine/gateway-kong'
+
+const manifest = context.buildGatewayManifest({ service: 'users-api' })
+
+const envoy = renderEnvoyConfig(manifest, {
+  listenPort: 8080,
+  clusters: { 'users-service': { hosts: ['users:8081'] } },
+})
+writeFileSync('envoy.yaml', envoy.yaml)
+
+const krakend = renderKrakendConfig(manifest, {
+  port: 8080,
+  upstreams: { 'users-service': 'http://users:8081' },
+})
+writeFileSync('krakend.json', JSON.stringify(krakend.json, null, 2))
+
+const kong = renderKongConfig(manifest, {
+  upstreams: { 'users-service': { url: 'http://users:8081' } },
+})
+writeFileSync('kong.yaml', kong.yaml)
+
+// Each result includes `warnings` for metadata fields the gateway can't
+// natively express — log them so you don't deploy with silently-dropped policy.
+console.warn(envoy.warnings, krakend.warnings, kong.warnings)
+```
+
+Each generator is a **pure function**: same manifest in, same config out. They
+have zero coupling to Fastify, the DI container, or your application code —
+ideal for CI pipelines where the gateway config and the service binary are
+built independently.
+
+For per-gateway field mappings and limitations, see the package READMEs:
+
+- [`@opinionated-machine/gateway-envoy`](./packages/gateway-envoy/README.md)
+- [`@opinionated-machine/gateway-krakend`](./packages/gateway-krakend/README.md)
+- [`@opinionated-machine/gateway-kong`](./packages/gateway-kong/README.md)
+
+### Optional Fastify Plugin (`app.gateway`)
+
+For convenient access to the manifest — typically from a CLI or a sibling
+process — register `fastifyGatewayPlugin`. It mirrors the spirit of
+`@fastify/swagger`'s `app.swagger()`:
+
+```ts
+import { fastifyGatewayPlugin } from 'opinionated-machine'
+
+await app.register(fastifyGatewayPlugin, {
+  context,                                  // your DIContext
+  defaults: { service: 'users-api' },       // BuildGatewayManifestOptions
+  // exposeRoute: '/_gateway/manifest',     // (default) HTTP route returning JSON; pass false to disable
+})
+
+// From anywhere in the app:
+const manifest = app.gateway.getManifest()
+
+// Or fetch over HTTP from a CLI / sibling process:
+//   GET /_gateway/manifest
+```
+
+The manifest is rebuilt on every call, so it always reflects the current set
+of registered controllers.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Very opinionated DI framework for fastify, built on top of awilix
   - [Universal Metadata Reference](#universal-metadata-reference)
   - [Building a Manifest](#building-a-manifest)
   - [Generating Gateway Configs](#generating-gateway-configs)
-  - [Optional Fastify Plugin (`app.gateway`)](#optional-fastify-plugin-appgateway)
+  - [Optional Fastify Plugin (`app.buildGatewayManifest`)](#optional-fastify-plugin-appbuildgatewaymanifest)
 
 ## Basic usage
 
@@ -3106,11 +3106,12 @@ For per-gateway field mappings and limitations, see the package READMEs:
 - [`@opinionated-machine/gateway-krakend`](./packages/gateway-krakend/README.md)
 - [`@opinionated-machine/gateway-kong`](./packages/gateway-kong/README.md)
 
-### Optional Fastify Plugin (`app.gateway`)
+### Optional Fastify Plugin (`app.buildGatewayManifest`)
 
 For convenient access to the manifest — typically from a CLI or a sibling
 process — register `fastifyGatewayPlugin`. It mirrors the spirit of
-`@fastify/swagger`'s `app.swagger()`:
+`@fastify/swagger`'s `app.swagger()` and decorates the Fastify instance with
+a single explicit function: `app.buildGatewayManifest()`.
 
 ```ts
 import { fastifyGatewayPlugin } from 'opinionated-machine'
@@ -3122,7 +3123,8 @@ await app.register(fastifyGatewayPlugin, {
 })
 
 // From anywhere in the app:
-const manifest = app.gateway.getManifest()
+const manifest = app.buildGatewayManifest()
+const overridden = app.buildGatewayManifest({ service: 'users-api-canary' })
 
 // Or fetch over HTTP from a CLI / sibling process:
 //   GET /_gateway/manifest

--- a/README.md
+++ b/README.md
@@ -3090,14 +3090,17 @@ import { fastifyGatewayPlugin } from 'opinionated-machine'
 await app.register(fastifyGatewayPlugin, {
   context,                                    // your DIContext
   defaults: { service: 'users-api' },         // service name + any service-wide defaults
-  // exposeRoute: '/_gateway/manifest',       // (default) HTTP route; set false to disable
+  // exposeRoute: '/__gateway/manifest',      // opt-in HTTP route; omit to keep the manifest in-process only
 })
 
 // In code, e.g. in another plugin or a graceful-shutdown drain hook:
 const manifest = app.buildGatewayManifest()
 
-// From the outside:
-//   curl http://localhost:8080/_gateway/manifest | jq '.routes'
+// Optionally fetch over HTTP from a CLI / sibling process — only when you
+// set `exposeRoute` above. The plugin never registers an HTTP route by
+// default to avoid leaking internal routing topology to unauthenticated
+// callers; pair it with auth middleware appropriate for your service.
+//   curl http://localhost:8080/__gateway/manifest | jq '.routes'
 ```
 
 The manifest is rebuilt on every call, so it always reflects the current set

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -29,8 +29,8 @@
             }
         },
         {
-            // Stand-alone CLI build scripts — console output is intentional.
-            "includes": ["**/acceptance/render-config.mjs", "**/acceptance/upstream.mjs"],
+            // Stand-alone acceptance CLI scripts — console output is intentional.
+            "includes": ["**/acceptance/*.mjs"],
             "linter": {
                 "rules": {
                     "suspicious": {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -6,7 +6,7 @@
         "./node_modules/@lokalise/biome-config/configs/biome-package.jsonc"
     ],
     "files": {
-        "includes": ["**", "!**/dist", "!**/acceptance/generated"]
+        "includes": ["**", "!**/dist", "!**/coverage", "!**/acceptance/generated"]
     },
     "linter": {
         "rules": {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -5,6 +5,9 @@
         "./node_modules/@lokalise/biome-config/configs/biome-esm.jsonc",
         "./node_modules/@lokalise/biome-config/configs/biome-package.jsonc"
     ],
+    "files": {
+        "includes": ["**", "!**/dist", "!**/acceptance/generated"]
+    },
     "linter": {
         "rules": {
             "correctness": {
@@ -21,6 +24,17 @@
                 "rules": {
                     "correctness": {
                         "noUnusedPrivateClassMembers": "off"
+                    }
+                }
+            }
+        },
+        {
+            // Stand-alone CLI build scripts — console output is intentional.
+            "includes": ["**/acceptance/render-config.mjs", "**/acceptance/upstream.mjs"],
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "noConsole": "off"
                     }
                 }
             }

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,8 @@ export {
 } from './lib/diConfigUtils.js'
 // Dual-mode (SSE + JSON)
 export * from './lib/dualmode/index.js'
+// Gateway metadata & manifest
+export * from './lib/gateway/index.js'
 export * from './lib/resolverFunctions.js'
 // Routes (unified route builder)
 export * from './lib/routes/index.js'

--- a/lib/AbstractController.ts
+++ b/lib/AbstractController.ts
@@ -6,6 +6,7 @@ import type {
 } from '@lokalise/api-contracts'
 import type { buildFastifyRoute } from '@lokalise/fastify-api-contracts'
 import type { z } from 'zod/v4'
+import type { GatewayMetadataValue } from './gateway/gatewayMetadata.ts'
 
 // biome-ignore lint/suspicious/noExplicitAny: we don't care about specific generics here
 type AnyCommonRouteDefinition = CommonRouteDefinition<any, any, any, any, any, any, any, any>
@@ -120,4 +121,25 @@ export abstract class AbstractController<
   APIContracts extends Record<string, AnyCommonRouteDefinition>,
 > {
   public abstract buildRoutes(): BuildRoutesReturnType<APIContracts>
+
+  /**
+   * Optional controller-level defaults for gateway metadata.
+   *
+   * Merged underneath per-route metadata when `DIContext.buildGatewayManifest()`
+   * assembles a manifest. Use this for fields that apply to every route in the
+   * controller (e.g. `upstream`, `auth`, baseline `timeouts`).
+   *
+   * Service-wide defaults (passed to `buildGatewayManifest({ defaults })`) sit
+   * underneath these.
+   *
+   * @example
+   * ```ts
+   * public readonly gatewayDefaults: GatewayMetadataValue = {
+   *   upstream: 'users-service',
+   *   timeouts: { request: '5s' },
+   *   auth: { required: true },
+   * }
+   * ```
+   */
+  public readonly gatewayDefaults?: GatewayMetadataValue
 }

--- a/lib/DIContext.ts
+++ b/lib/DIContext.ts
@@ -14,6 +14,12 @@ import { mergeConfigAndDependencyOverrides, type NestedPartial } from './configU
 import type { ENABLE_ALL } from './diConfigUtils.js'
 import type { AbstractDualModeController } from './dualmode/AbstractDualModeController.js'
 import {
+  type BuildGatewayManifestOptions,
+  buildGatewayManifestFrom,
+  type CollectedController,
+  type GatewayManifest,
+} from './gateway/index.js'
+import {
   buildFastifyRoute,
   type RegisterDualModeRoutesOptions,
   type RegisterSSERoutesOptions,
@@ -50,7 +56,7 @@ export class DIContext<
   public readonly awilixManager: AwilixManager
   public readonly diContainer: AwilixContainer<Dependencies>
   // biome-ignore lint/suspicious/noExplicitAny: all controllers are controllers
-  private readonly controllerResolvers: Resolver<any>[]
+  private readonly controllerResolvers: Array<{ name: string; resolver: Resolver<any> }>
   // SSE controller dependency names (resolved from container to preserve singletons)
   private readonly sseControllerNames: string[]
   // Dual-mode controller dependency names (resolved from container to preserve singletons)
@@ -102,7 +108,7 @@ export class DIContext<
         // @ts-expect-error we can't really ensure type-safety here
         targetDiConfig[name] = resolver
       } else {
-        this.controllerResolvers.push(resolver as Resolver<unknown>)
+        this.controllerResolvers.push({ name, resolver: resolver as Resolver<unknown> })
       }
     }
   }
@@ -187,9 +193,9 @@ export class DIContext<
 
   // biome-ignore lint/suspicious/noExplicitAny: we don't care about what instance we get here
   registerRoutes(app: FastifyInstance<any, any, any, any>): void {
-    for (const controllerResolver of this.controllerResolvers) {
+    for (const { resolver } of this.controllerResolvers) {
       // biome-ignore lint/suspicious/noExplicitAny: any controller works here
-      const controller: AbstractController<any> = controllerResolver.resolve(this.diContainer)
+      const controller: AbstractController<any> = resolver.resolve(this.diContainer)
       const routes = controller.buildRoutes()
       for (const route of Object.values(routes)) {
         // Cast needed: GET/DELETE routes have body:undefined, POST/PATCH have body:unknown
@@ -205,6 +211,46 @@ export class DIContext<
         app.route(route)
       }
     }
+  }
+
+  /**
+   * Build a vendor-neutral gateway manifest from all registered REST and
+   * api-contract controllers. Routes carrying gateway metadata (attached via
+   * `withGatewayMetadata()`) get that metadata merged with controller-level
+   * `gatewayDefaults` and the `defaults` passed here. Routes without any
+   * metadata still appear in the manifest with empty metadata.
+   *
+   * The returned object is JSON-serializable; pass it to a generator package
+   * like `@opinionated-machine/gateway-envoy` or
+   * `@opinionated-machine/gateway-krakend` to produce a config.
+   *
+   * SSE and dual-mode controllers are not included in v1.
+   *
+   * @example
+   * ```ts
+   * const manifest = context.buildGatewayManifest({
+   *   service: 'users-api',
+   *   defaults: { cors: { origins: ['https://app.example.com'] } },
+   * })
+   * const envoy = renderEnvoyConfig(manifest, { listenPort: 8080, clusters: { 'users-service': { hosts: ['users:8081'] } } })
+   * writeFileSync('envoy.yaml', envoy.yaml)
+   * ```
+   */
+  buildGatewayManifest(options: BuildGatewayManifestOptions): GatewayManifest {
+    const collected: CollectedController[] = []
+
+    for (const { name, resolver } of this.controllerResolvers) {
+      // biome-ignore lint/suspicious/noExplicitAny: any controller works here
+      const controller: AbstractController<any> = resolver.resolve(this.diContainer)
+      collected.push({ name, kind: 'rest', controller })
+    }
+
+    for (const name of this.apiControllerNames) {
+      const controller: AbstractApiController = this.diContainer.resolve(name)
+      collected.push({ name, kind: 'api', controller })
+    }
+
+    return buildGatewayManifestFrom(collected, options)
   }
 
   /**

--- a/lib/api-contracts/AbstractApiController.ts
+++ b/lib/api-contracts/AbstractApiController.ts
@@ -1,4 +1,5 @@
 import type { RouteOptions } from 'fastify'
+import type { GatewayMetadataValue } from '../gateway/gatewayMetadata.ts'
 
 /**
  * Abstract base class for controllers that use the `ApiContract` API.
@@ -17,4 +18,13 @@ import type { RouteOptions } from 'fastify'
  */
 export abstract class AbstractApiController {
   abstract readonly routes: RouteOptions[]
+
+  /**
+   * Optional controller-level defaults for gateway metadata.
+   *
+   * Merged underneath per-route metadata (attached via `withGatewayMetadata`)
+   * when `DIContext.buildGatewayManifest()` assembles a manifest. See
+   * `AbstractController.gatewayDefaults` for full semantics.
+   */
+  public readonly gatewayDefaults?: GatewayMetadataValue
 }

--- a/lib/gateway/fastifyGatewayPlugin.spec.ts
+++ b/lib/gateway/fastifyGatewayPlugin.spec.ts
@@ -1,0 +1,79 @@
+import { createContainer } from 'awilix'
+import { fastify } from 'fastify'
+import { describe, expect, it } from 'vitest'
+import { TestModule, type TestModuleDependencies } from '../../test/TestModule.ts'
+import { DIContext } from '../DIContext.ts'
+import { fastifyGatewayPlugin } from './fastifyGatewayPlugin.ts'
+
+// biome-ignore lint/complexity/noBannedTypes: shape mirrors test/DIContext.spec.ts
+type Config = {}
+
+function createContext() {
+  const container = createContainer<TestModuleDependencies>({ injectionMode: 'PROXY' })
+  const context = new DIContext<TestModuleDependencies, Config>(container, {}, {})
+  context.registerDependencies({ modules: [new TestModule()] }, undefined)
+  return context
+}
+
+describe('fastifyGatewayPlugin', () => {
+  it('decorates app.gateway with getManifest()', async () => {
+    const app = fastify()
+    await app.register(fastifyGatewayPlugin, {
+      context: createContext(),
+      defaults: { service: 'users-api' },
+    })
+    const manifest = app.gateway.getManifest()
+    expect(manifest.service).toBe('users-api')
+    expect(manifest.routes.length).toBeGreaterThan(0)
+    await app.close()
+  })
+
+  it('exposes the manifest over HTTP on the default route', async () => {
+    const app = fastify()
+    await app.register(fastifyGatewayPlugin, {
+      context: createContext(),
+      defaults: { service: 'users-api' },
+    })
+    const res = await app.inject({ method: 'GET', url: '/_gateway/manifest' })
+    expect(res.statusCode).toBe(200)
+    const body = res.json() as { service: string; manifestVersion: string }
+    expect(body.service).toBe('users-api')
+    expect(body.manifestVersion).toBe('1')
+    await app.close()
+  })
+
+  it('honours a custom route path', async () => {
+    const app = fastify()
+    await app.register(fastifyGatewayPlugin, {
+      context: createContext(),
+      defaults: { service: 'users-api' },
+      exposeRoute: '/__gateway',
+    })
+    const res = await app.inject({ method: 'GET', url: '/__gateway' })
+    expect(res.statusCode).toBe(200)
+    await app.close()
+  })
+
+  it('skips the HTTP route when exposeRoute is false', async () => {
+    const app = fastify()
+    await app.register(fastifyGatewayPlugin, {
+      context: createContext(),
+      defaults: { service: 'users-api' },
+      exposeRoute: false,
+    })
+    const res = await app.inject({ method: 'GET', url: '/_gateway/manifest' })
+    expect(res.statusCode).toBe(404)
+    await app.close()
+  })
+
+  it('overrides merge into defaults at call time', async () => {
+    const app = fastify()
+    await app.register(fastifyGatewayPlugin, {
+      context: createContext(),
+      defaults: { service: 'default-name' },
+    })
+    const manifest = app.gateway.getManifest({ service: 'override' })
+    expect(manifest.service).toBe('override')
+    await app.close()
+  })
+})

--- a/lib/gateway/fastifyGatewayPlugin.spec.ts
+++ b/lib/gateway/fastifyGatewayPlugin.spec.ts
@@ -28,41 +28,29 @@ describe('fastifyGatewayPlugin', () => {
     await app.close()
   })
 
-  it('exposes the manifest over HTTP on the default route', async () => {
+  it('does NOT register an HTTP route by default (manifest exposure is opt-in)', async () => {
     const app = fastify()
     await app.register(fastifyGatewayPlugin, {
       context: createContext(),
       defaults: { service: 'users-api' },
     })
     const res = await app.inject({ method: 'GET', url: '/_gateway/manifest' })
+    expect(res.statusCode).toBe(404)
+    await app.close()
+  })
+
+  it('exposes the manifest over HTTP when exposeRoute is set', async () => {
+    const app = fastify()
+    await app.register(fastifyGatewayPlugin, {
+      context: createContext(),
+      defaults: { service: 'users-api' },
+      exposeRoute: '/__gateway/manifest',
+    })
+    const res = await app.inject({ method: 'GET', url: '/__gateway/manifest' })
     expect(res.statusCode).toBe(200)
     const body = res.json() as { service: string; manifestVersion: string }
     expect(body.service).toBe('users-api')
     expect(body.manifestVersion).toBe('1')
-    await app.close()
-  })
-
-  it('honours a custom route path', async () => {
-    const app = fastify()
-    await app.register(fastifyGatewayPlugin, {
-      context: createContext(),
-      defaults: { service: 'users-api' },
-      exposeRoute: '/__gateway',
-    })
-    const res = await app.inject({ method: 'GET', url: '/__gateway' })
-    expect(res.statusCode).toBe(200)
-    await app.close()
-  })
-
-  it('skips the HTTP route when exposeRoute is false', async () => {
-    const app = fastify()
-    await app.register(fastifyGatewayPlugin, {
-      context: createContext(),
-      defaults: { service: 'users-api' },
-      exposeRoute: false,
-    })
-    const res = await app.inject({ method: 'GET', url: '/_gateway/manifest' })
-    expect(res.statusCode).toBe(404)
     await app.close()
   })
 

--- a/lib/gateway/fastifyGatewayPlugin.spec.ts
+++ b/lib/gateway/fastifyGatewayPlugin.spec.ts
@@ -16,13 +16,13 @@ function createContext() {
 }
 
 describe('fastifyGatewayPlugin', () => {
-  it('decorates app.gateway with getManifest()', async () => {
+  it('decorates app.buildGatewayManifest()', async () => {
     const app = fastify()
     await app.register(fastifyGatewayPlugin, {
       context: createContext(),
       defaults: { service: 'users-api' },
     })
-    const manifest = app.gateway.getManifest()
+    const manifest = app.buildGatewayManifest()
     expect(manifest.service).toBe('users-api')
     expect(manifest.routes.length).toBeGreaterThan(0)
     await app.close()
@@ -72,7 +72,7 @@ describe('fastifyGatewayPlugin', () => {
       context: createContext(),
       defaults: { service: 'default-name' },
     })
-    const manifest = app.gateway.getManifest({ service: 'override' })
+    const manifest = app.buildGatewayManifest({ service: 'override' })
     expect(manifest.service).toBe('override')
     await app.close()
   })

--- a/lib/gateway/fastifyGatewayPlugin.ts
+++ b/lib/gateway/fastifyGatewayPlugin.ts
@@ -1,0 +1,87 @@
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
+import fp from 'fastify-plugin'
+import type { DIContext } from '../DIContext.ts'
+import type { BuildGatewayManifestOptions } from './manifest/buildManifest.ts'
+import type { GatewayManifest } from './manifest/manifestSchema.ts'
+
+/**
+ * Decoration shape installed on the Fastify instance by `fastifyGatewayPlugin`.
+ *
+ * Mirrors the spirit of `@fastify/swagger`'s `app.swagger()` — call `getManifest()`
+ * to build the manifest on demand, or hit `GET <route>` (default `/_gateway/manifest`)
+ * to expose it over HTTP, handy for CLIs and config-generation pipelines.
+ */
+export interface GatewayDecorator {
+  /** Build the manifest. Recomputed on every call so it always reflects the current registered routes. */
+  getManifest: (overrides?: Partial<BuildGatewayManifestOptions>) => GatewayManifest
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    gateway: GatewayDecorator
+  }
+}
+
+export type FastifyGatewayPluginOptions = {
+  /**
+   * The DI context that owns the controllers whose manifest we expose.
+   * The plugin calls `context.buildGatewayManifest()` lazily, so route
+   * registration order (plugin first vs. routes first) doesn't matter.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: DIContext generics are erased at the plugin boundary
+  context: DIContext<any, any, any>
+  /** Default options applied to every `getManifest()` call. */
+  defaults: BuildGatewayManifestOptions
+  /**
+   * If set, also exposes `GET <route>` returning the manifest as JSON.
+   * Use case: CLIs that don't want to load TypeScript code can `curl` the
+   * running app to fetch its manifest. Set to `false` to skip.
+   * @default '/_gateway/manifest'
+   */
+  exposeRoute?: string | false
+}
+
+/**
+ * Optional Fastify plugin that decorates `app.gateway` with a `getManifest()`
+ * accessor and (optionally) exposes the manifest over HTTP.
+ *
+ * @example
+ * ```ts
+ * await app.register(fastifyGatewayPlugin, {
+ *   context,
+ *   defaults: { service: 'users-api' },
+ * })
+ *
+ * // From anywhere in the app:
+ * const manifest = app.gateway.getManifest()
+ *
+ * // Or fetched over HTTP (default route):
+ * //   GET /_gateway/manifest
+ * ```
+ */
+const fastifyGatewayPluginInner: FastifyPluginCallback<FastifyGatewayPluginOptions> = (
+  app: FastifyInstance,
+  opts,
+  done,
+) => {
+  const decorator: GatewayDecorator = {
+    getManifest: (overrides) =>
+      opts.context.buildGatewayManifest({ ...opts.defaults, ...(overrides ?? {}) }),
+  }
+  app.decorate('gateway', decorator)
+
+  const route = opts.exposeRoute === undefined ? '/_gateway/manifest' : opts.exposeRoute
+  if (route !== false) {
+    app.route({
+      method: 'GET',
+      url: route,
+      handler: async () => decorator.getManifest(),
+    })
+  }
+  done()
+}
+
+export const fastifyGatewayPlugin = fp(fastifyGatewayPluginInner, {
+  name: '@opinionated-machine/gateway',
+  fastify: '5.x',
+})

--- a/lib/gateway/fastifyGatewayPlugin.ts
+++ b/lib/gateway/fastifyGatewayPlugin.ts
@@ -5,20 +5,19 @@ import type { BuildGatewayManifestOptions } from './manifest/buildManifest.ts'
 import type { GatewayManifest } from './manifest/manifestSchema.ts'
 
 /**
- * Decoration shape installed on the Fastify instance by `fastifyGatewayPlugin`.
+ * Function decoration installed on the Fastify instance by
+ * `fastifyGatewayPlugin`. Returns the gateway manifest, recomputed on every
+ * call so it always reflects the current set of registered controllers.
  *
- * Mirrors the spirit of `@fastify/swagger`'s `app.swagger()` — call `getManifest()`
- * to build the manifest on demand, or hit `GET <route>` (default `/_gateway/manifest`)
- * to expose it over HTTP, handy for CLIs and config-generation pipelines.
+ * Mirrors the spirit of `@fastify/swagger`'s `app.swagger()`.
  */
-export interface GatewayDecorator {
-  /** Build the manifest. Recomputed on every call so it always reflects the current registered routes. */
-  getManifest: (overrides?: Partial<BuildGatewayManifestOptions>) => GatewayManifest
-}
+export type BuildGatewayManifestFn = (
+  overrides?: Partial<BuildGatewayManifestOptions>,
+) => GatewayManifest
 
 declare module 'fastify' {
   interface FastifyInstance {
-    gateway: GatewayDecorator
+    buildGatewayManifest: BuildGatewayManifestFn
   }
 }
 
@@ -30,7 +29,7 @@ export type FastifyGatewayPluginOptions = {
    */
   // biome-ignore lint/suspicious/noExplicitAny: DIContext generics are erased at the plugin boundary
   context: DIContext<any, any, any>
-  /** Default options applied to every `getManifest()` call. */
+  /** Default options applied to every `app.buildGatewayManifest()` call. */
   defaults: BuildGatewayManifestOptions
   /**
    * If set, also exposes `GET <route>` returning the manifest as JSON.
@@ -42,8 +41,8 @@ export type FastifyGatewayPluginOptions = {
 }
 
 /**
- * Optional Fastify plugin that decorates `app.gateway` with a `getManifest()`
- * accessor and (optionally) exposes the manifest over HTTP.
+ * Optional Fastify plugin that decorates `app.buildGatewayManifest()` and
+ * (optionally) exposes the manifest over HTTP.
  *
  * @example
  * ```ts
@@ -53,7 +52,7 @@ export type FastifyGatewayPluginOptions = {
  * })
  *
  * // From anywhere in the app:
- * const manifest = app.gateway.getManifest()
+ * const manifest = app.buildGatewayManifest()
  *
  * // Or fetched over HTTP (default route):
  * //   GET /_gateway/manifest
@@ -64,18 +63,16 @@ const fastifyGatewayPluginInner: FastifyPluginCallback<FastifyGatewayPluginOptio
   opts,
   done,
 ) => {
-  const decorator: GatewayDecorator = {
-    getManifest: (overrides) =>
-      opts.context.buildGatewayManifest({ ...opts.defaults, ...(overrides ?? {}) }),
-  }
-  app.decorate('gateway', decorator)
+  const buildManifest: BuildGatewayManifestFn = (overrides) =>
+    opts.context.buildGatewayManifest({ ...opts.defaults, ...(overrides ?? {}) })
+  app.decorate('buildGatewayManifest', buildManifest)
 
   const route = opts.exposeRoute === undefined ? '/_gateway/manifest' : opts.exposeRoute
   if (route !== false) {
     app.route({
       method: 'GET',
       url: route,
-      handler: async () => decorator.getManifest(),
+      handler: async () => buildManifest(),
     })
   }
   done()

--- a/lib/gateway/fastifyGatewayPlugin.ts
+++ b/lib/gateway/fastifyGatewayPlugin.ts
@@ -32,12 +32,15 @@ export type FastifyGatewayPluginOptions = {
   /** Default options applied to every `app.buildGatewayManifest()` call. */
   defaults: BuildGatewayManifestOptions
   /**
-   * If set, also exposes `GET <route>` returning the manifest as JSON.
-   * Use case: CLIs that don't want to load TypeScript code can `curl` the
-   * running app to fetch its manifest. Set to `false` to skip.
-   * @default '/_gateway/manifest'
+   * If set to a path string, exposes `GET <route>` returning the manifest as
+   * JSON. Useful when a CLI / sibling process wants to fetch the manifest
+   * over HTTP instead of loading the service code.
+   *
+   * **Opt-in.** No HTTP route is registered when this is omitted, so adding
+   * the plugin can never accidentally expose internal routing topology to
+   * unauthenticated callers.
    */
-  exposeRoute?: string | false
+  exposeRoute?: string
 }
 
 /**
@@ -67,11 +70,10 @@ const fastifyGatewayPluginInner: FastifyPluginCallback<FastifyGatewayPluginOptio
     opts.context.buildGatewayManifest({ ...opts.defaults, ...(overrides ?? {}) })
   app.decorate('buildGatewayManifest', buildManifest)
 
-  const route = opts.exposeRoute === undefined ? '/_gateway/manifest' : opts.exposeRoute
-  if (route !== false) {
+  if (typeof opts.exposeRoute === 'string' && opts.exposeRoute.length > 0) {
     app.route({
       method: 'GET',
-      url: route,
+      url: opts.exposeRoute,
       handler: async () => buildManifest(),
     })
   }

--- a/lib/gateway/gatewayMetadata.ts
+++ b/lib/gateway/gatewayMetadata.ts
@@ -1,0 +1,202 @@
+import { z } from 'zod/v4'
+
+/**
+ * Duration string in the format "<number><unit>", e.g. "5s", "300ms", "1m", "2h".
+ * Parsed at generation time by individual gateway generators.
+ */
+export const durationSchema = z.string().regex(/^\d+(ms|s|m|h)$/, {
+  message: 'Duration must be a number followed by ms, s, m, or h (e.g. "5s", "300ms").',
+})
+export type Duration = z.infer<typeof durationSchema>
+
+/**
+ * Match rule for a single header or query value.
+ * Bare strings are treated as exact matches; objects are explicit.
+ */
+export const matchRuleSchema = z.union([
+  z.string(),
+  z.object({ exact: z.string() }),
+  z.object({ prefix: z.string() }),
+  z.object({ regex: z.string() }),
+])
+export type MatchRule = z.infer<typeof matchRuleSchema>
+
+const httpMethodSchema = z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+
+const matchSchema = z
+  .object({
+    headers: z.record(z.string(), matchRuleSchema).optional(),
+    customHeaders: z.record(z.string(), matchRuleSchema).optional(),
+    query: z.record(z.string(), matchRuleSchema).optional(),
+    customQuery: z.record(z.string(), matchRuleSchema).optional(),
+    host: z.union([z.string(), z.array(z.string())]).optional(),
+  })
+  .strict()
+
+const rewriteSchema = z
+  .object({
+    stripPrefix: z.string().optional(),
+    replacePrefix: z.object({ from: z.string(), to: z.string() }).strict().optional(),
+  })
+  .strict()
+
+const timeoutsSchema = z
+  .object({
+    request: durationSchema.optional(),
+    idle: durationSchema.optional(),
+    connect: durationSchema.optional(),
+  })
+  .strict()
+
+const retrySchema = z
+  .object({
+    attempts: z.number().int().min(0).optional(),
+    on: z
+      .array(z.enum(['5xx', 'gateway-error', 'connect-failure', 'reset', 'retriable-4xx']))
+      .optional(),
+    perTryTimeout: durationSchema.optional(),
+    backoff: z
+      .object({ base: durationSchema.optional(), max: durationSchema.optional() })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const circuitBreakerSchema = z
+  .object({
+    maxConnections: z.number().int().positive().optional(),
+    maxPendingRequests: z.number().int().positive().optional(),
+    maxRequests: z.number().int().positive().optional(),
+    maxRetries: z.number().int().nonnegative().optional(),
+  })
+  .strict()
+
+const rateLimitKeySchema = z.union([
+  z.literal('ip'),
+  z.object({ header: z.string() }).strict(),
+  z.object({ customHeader: z.string() }).strict(),
+  z.object({ query: z.string() }).strict(),
+  z.object({ customQuery: z.string() }).strict(),
+])
+
+const rateLimitSchema = z
+  .object({
+    requests: z.number().int().positive(),
+    per: durationSchema,
+    key: rateLimitKeySchema.optional(),
+  })
+  .strict()
+
+const trafficSchema = z
+  .object({
+    weights: z
+      .array(z.object({ upstream: z.string(), weight: z.number().int().min(0).max(100) }).strict())
+      .optional(),
+    shadow: z
+      .object({
+        upstream: z.string(),
+        percent: z.number().min(0).max(100),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const corsSchema = z
+  .object({
+    origins: z.array(z.string()),
+    methods: z.array(httpMethodSchema).optional(),
+    headers: z.array(z.string()).optional(),
+    exposeHeaders: z.array(z.string()).optional(),
+    credentials: z.boolean().optional(),
+    maxAge: durationSchema.optional(),
+  })
+  .strict()
+
+const authSchema = z
+  .object({
+    required: z.boolean().optional(),
+    jwt: z
+      .object({
+        issuer: z.string(),
+        audiences: z.array(z.string()).optional(),
+        jwksUri: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    mTLS: z.boolean().optional(),
+  })
+  .strict()
+
+const cacheSchema = z
+  .object({
+    ttl: durationSchema,
+    methods: z.array(z.enum(['GET', 'HEAD'])).optional(),
+    vary: z.array(z.string()).optional(),
+  })
+  .strict()
+
+const headersSchema = z
+  .object({
+    request: z
+      .object({
+        add: z.record(z.string(), z.string()).optional(),
+        remove: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    response: z
+      .object({
+        add: z.record(z.string(), z.string()).optional(),
+        remove: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+
+const extensionsSchema = z.record(z.string(), z.record(z.string(), z.unknown()).optional())
+
+/**
+ * Universal gateway metadata schema.
+ *
+ * Vendor-neutral. Generators map every field they support and put unmapped
+ * data into `warnings`. Use `extensions.<vendor>` for gateway-specific knobs
+ * the universal model doesn't cover.
+ */
+export const gatewayMetadataSchema = z
+  .object({
+    id: z.string().optional(),
+    upstream: z.string().optional(),
+    visibility: z.enum(['public', 'internal', 'admin']).optional(),
+    tags: z.array(z.string()).optional(),
+
+    match: matchSchema.optional(),
+    rewrite: rewriteSchema.optional(),
+
+    timeouts: timeoutsSchema.optional(),
+    retry: retrySchema.optional(),
+    circuitBreaker: circuitBreakerSchema.optional(),
+
+    rateLimit: rateLimitSchema.optional(),
+    traffic: trafficSchema.optional(),
+
+    cors: corsSchema.optional(),
+    auth: authSchema.optional(),
+    cache: cacheSchema.optional(),
+
+    headers: headersSchema.optional(),
+
+    extensions: extensionsSchema.optional(),
+  })
+  .strict()
+
+/**
+ * Runtime-validated gateway metadata.
+ *
+ * For per-route declarations use the contract-generic alias `GatewayMetadata<Contract>`
+ * exported from `./gatewayTypes.ts` — the runtime schema is intentionally lenient
+ * about header/query keys (case-insensitive HTTP, dynamic keys); the type-level
+ * narrowing is what guides authoring.
+ */
+export type GatewayMetadataValue = z.infer<typeof gatewayMetadataSchema>

--- a/lib/gateway/gatewaySymbol.ts
+++ b/lib/gateway/gatewaySymbol.ts
@@ -1,0 +1,9 @@
+/**
+ * Symbol used to attach gateway metadata to a Fastify route object.
+ *
+ * Stamped as a non-enumerable property by `withGatewayMetadata()` and read by
+ * `DIContext.buildGatewayManifest()`. Using `Symbol.for` ensures every module
+ * resolving the same key gets the same symbol, even across realms or duplicate
+ * package copies.
+ */
+export const GATEWAY_METADATA_SYMBOL = Symbol.for('opinionated-machine.gateway.metadata')

--- a/lib/gateway/gatewayTypes.ts
+++ b/lib/gateway/gatewayTypes.ts
@@ -1,0 +1,67 @@
+import type { z } from 'zod/v4'
+import type { GatewayMetadataValue, MatchRule } from './gatewayMetadata.ts'
+
+/**
+ * Lowercase-keyed header names inferred from `contract.requestHeaderSchema`.
+ * Falls back to `never` when no header schema is declared, forcing developers
+ * to use the explicit `customHeaders` escape hatch.
+ *
+ * HTTP headers are case-insensitive; we lowercase here because gateway configs
+ * (Envoy, KrakenD) match against lowercase header names.
+ */
+export type ContractHeaderKey<C> = C extends {
+  requestHeaderSchema: z.ZodObject<infer Shape>
+}
+  ? Lowercase<Extract<keyof Shape, string>>
+  : never
+
+/**
+ * Query parameter names inferred from `contract.requestQuerySchema`.
+ * Falls back to `never` when no query schema is declared.
+ */
+export type ContractQueryKey<C> = C extends {
+  requestQuerySchema: z.ZodObject<infer Shape>
+}
+  ? Extract<keyof Shape, string>
+  : never
+
+type ContractMatch<Contract> = {
+  /** Keys narrowed to `requestHeaderSchema`. Use `customHeaders` for headers not in the contract. */
+  headers?: Partial<Record<ContractHeaderKey<Contract>, MatchRule>>
+  /** Escape hatch for headers not declared on the contract (CDN, infra, auth tokens). */
+  customHeaders?: Record<string, MatchRule>
+  /** Keys narrowed to `requestQuerySchema`. Use `customQuery` for params not in the contract. */
+  query?: Partial<Record<ContractQueryKey<Contract>, MatchRule>>
+  /** Escape hatch for query params not declared on the contract. */
+  customQuery?: Record<string, MatchRule>
+  host?: string | string[]
+}
+
+type ContractRateLimitKey<Contract> =
+  | 'ip'
+  | { header: ContractHeaderKey<Contract> }
+  | { customHeader: string }
+  | { query: ContractQueryKey<Contract> }
+  | { customQuery: string }
+
+/**
+ * Per-route gateway metadata, generic in the route's contract.
+ *
+ * `match.headers` and `match.query` keys are narrowed to the contract's request
+ * schemas, catching typos and stale references at compile time. For headers /
+ * query params not in the contract, use the explicit `customHeaders` /
+ * `customQuery` escape hatches.
+ *
+ * Defaults at the controller / service level are unbound by a contract — use
+ * `GatewayMetadata` (no generic) which expands to the same shape with `string`
+ * keys for matching.
+ */
+export type GatewayMetadata<Contract = unknown> = Omit<
+  GatewayMetadataValue,
+  'match' | 'rateLimit'
+> & {
+  match?: ContractMatch<Contract>
+  rateLimit?: Omit<NonNullable<GatewayMetadataValue['rateLimit']>, 'key'> & {
+    key?: ContractRateLimitKey<Contract>
+  }
+}

--- a/lib/gateway/index.ts
+++ b/lib/gateway/index.ts
@@ -1,7 +1,7 @@
 export {
+  type BuildGatewayManifestFn,
   type FastifyGatewayPluginOptions,
   fastifyGatewayPlugin,
-  type GatewayDecorator,
 } from './fastifyGatewayPlugin.ts'
 export {
   type Duration,

--- a/lib/gateway/index.ts
+++ b/lib/gateway/index.ts
@@ -1,0 +1,32 @@
+export {
+  type FastifyGatewayPluginOptions,
+  fastifyGatewayPlugin,
+  type GatewayDecorator,
+} from './fastifyGatewayPlugin.ts'
+export {
+  type Duration,
+  durationSchema,
+  type GatewayMetadataValue,
+  gatewayMetadataSchema,
+  type MatchRule,
+  matchRuleSchema,
+} from './gatewayMetadata.ts'
+export { GATEWAY_METADATA_SYMBOL } from './gatewaySymbol.ts'
+export type {
+  ContractHeaderKey,
+  ContractQueryKey,
+  GatewayMetadata,
+} from './gatewayTypes.ts'
+export {
+  type BuildGatewayManifestOptions,
+  buildGatewayManifestFrom,
+  type CollectedController,
+} from './manifest/buildManifest.ts'
+export {
+  type GatewayManifest,
+  type GatewayManifestRoute,
+  gatewayManifestRouteSchema,
+  gatewayManifestSchema,
+} from './manifest/manifestSchema.ts'
+export { normalizePath } from './manifest/pathNormalize.ts'
+export { readGatewayMetadata, withGatewayMetadata } from './withGatewayMetadata.ts'

--- a/lib/gateway/manifest/buildManifest.spec.ts
+++ b/lib/gateway/manifest/buildManifest.spec.ts
@@ -1,0 +1,140 @@
+import { buildRestContract } from '@lokalise/api-contracts'
+import { buildFastifyRoute } from '@lokalise/fastify-api-contracts'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import { AbstractController, type BuildRoutesReturnType } from '../../AbstractController.ts'
+import type { GatewayMetadataValue } from '../gatewayMetadata.ts'
+import { withGatewayMetadata } from '../withGatewayMetadata.ts'
+import { buildGatewayManifestFrom, type CollectedController } from './buildManifest.ts'
+
+const getContract = buildRestContract({
+  method: 'get',
+  successResponseBodySchema: z.object({ ok: z.boolean() }),
+  requestPathParamsSchema: z.object({ userId: z.string() }),
+  requestHeaderSchema: z.object({ 'x-trace-id': z.string() }),
+  pathResolver: (p) => `/users/${p.userId}`,
+})
+
+const createContract = buildRestContract({
+  method: 'post',
+  successResponseBodySchema: z.object({ ok: z.boolean() }),
+  requestBodySchema: z.object({ name: z.string() }),
+  pathResolver: () => '/users',
+})
+
+class TestUsersController extends AbstractController<typeof TestUsersController.contracts> {
+  public static contracts = { getItem: getContract, createItem: createContract } as const
+
+  public override readonly gatewayDefaults: GatewayMetadataValue = {
+    upstream: 'users-service',
+    timeouts: { request: '5s' },
+    tags: ['users'],
+  }
+
+  private getItem = buildFastifyRoute(TestUsersController.contracts.getItem, async (_, reply) => {
+    await reply.status(200).send({ ok: true })
+  })
+
+  private createItem = buildFastifyRoute(
+    TestUsersController.contracts.createItem,
+    async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    },
+  )
+
+  public buildRoutes(): BuildRoutesReturnType<typeof TestUsersController.contracts> {
+    return {
+      getItem: withGatewayMetadata(TestUsersController.contracts.getItem, this.getItem, {
+        cache: { ttl: '60s' },
+        match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } },
+        tags: ['users', 'cacheable'],
+      }),
+      createItem: this.createItem,
+    }
+  }
+}
+
+function collected(): CollectedController[] {
+  return [{ name: 'usersController', kind: 'rest', controller: new TestUsersController() }]
+}
+
+describe('buildGatewayManifestFrom', () => {
+  it('emits one entry per route, sorted by path then method', () => {
+    const manifest = buildGatewayManifestFrom(collected(), { service: 'users-api' })
+    expect(manifest.service).toBe('users-api')
+    expect(manifest.manifestVersion).toBe('1')
+    expect(manifest.routes.map((r) => `${r.method} ${r.path}`)).toEqual([
+      'POST /users',
+      'GET /users/{userId}',
+    ])
+  })
+
+  it('attributes routes to the controller dependency name and route key', () => {
+    const manifest = buildGatewayManifestFrom(collected(), { service: 'users-api' })
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    expect(getItem).toMatchObject({
+      controller: 'usersController',
+      routeKey: 'getItem',
+      id: 'usersController.getItem',
+    })
+  })
+
+  it('merges service → controller → route metadata in order', () => {
+    const manifest = buildGatewayManifestFrom(collected(), {
+      service: 'users-api',
+      defaults: {
+        timeouts: { idle: '60s' },
+        cors: { origins: ['https://app.example.com'] },
+      },
+    })
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    expect(getItem?.metadata).toMatchObject({
+      // From service defaults
+      cors: { origins: ['https://app.example.com'] },
+      // From controller defaults
+      upstream: 'users-service',
+      // From route metadata
+      cache: { ttl: '60s' },
+      match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } },
+      // Deep-merged: service idle + controller request
+      timeouts: { idle: '60s', request: '5s' },
+    })
+  })
+
+  it('replaces (does not append) arrays when later layers redeclare them', () => {
+    const manifest = buildGatewayManifestFrom(collected(), { service: 'users-api' })
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    // Route-level tags ['users','cacheable'] replace controller-level ['users']
+    expect(getItem?.metadata.tags).toEqual(['users', 'cacheable'])
+  })
+
+  it('un-annotated routes still appear and inherit defaults', () => {
+    const manifest = buildGatewayManifestFrom(collected(), { service: 'users-api' })
+    const createItem = manifest.routes.find((r) => r.routeKey === 'createItem')
+    expect(createItem?.metadata).toMatchObject({
+      upstream: 'users-service',
+      timeouts: { request: '5s' },
+    })
+    expect(createItem?.metadata.cache).toBeUndefined()
+  })
+
+  it('rejects invalid metadata at the manifest boundary', () => {
+    class BadController extends AbstractController<{ x: typeof getContract }> {
+      private getItem = buildFastifyRoute(getContract, async (_, reply) => {
+        await reply.status(200).send({ ok: true })
+      })
+      public buildRoutes(): BuildRoutesReturnType<{ x: typeof getContract }> {
+        // Invalid duration "5seconds" should fail validation.
+        return {
+          x: withGatewayMetadata(getContract, this.getItem, {
+            timeouts: { request: '5seconds' as never },
+          }),
+        }
+      }
+    }
+    const list: CollectedController[] = [
+      { name: 'bad', kind: 'rest', controller: new BadController() },
+    ]
+    expect(() => buildGatewayManifestFrom(list, { service: 'svc' })).toThrow()
+  })
+})

--- a/lib/gateway/manifest/buildManifest.ts
+++ b/lib/gateway/manifest/buildManifest.ts
@@ -1,0 +1,137 @@
+import type { RouteOptions } from 'fastify'
+import { merge } from 'ts-deepmerge'
+import type { AbstractController } from '../../AbstractController.ts'
+import type { AbstractApiController } from '../../api-contracts/AbstractApiController.ts'
+import type { GatewayMetadataValue } from '../gatewayMetadata.ts'
+import { readGatewayMetadata } from '../withGatewayMetadata.ts'
+import {
+  type GatewayManifest,
+  type GatewayManifestRoute,
+  gatewayManifestSchema,
+} from './manifestSchema.ts'
+import { normalizePath } from './pathNormalize.ts'
+
+export type BuildGatewayManifestOptions = {
+  /** Logical service name written into the manifest. */
+  service: string
+  /** Optional service/release version (e.g. git SHA, semver) for traceability. */
+  version?: string
+  /** Service-wide metadata defaults; merged underneath controller- and route-level metadata. */
+  defaults?: GatewayMetadataValue
+}
+
+/**
+ * Anything resolved from the DI container that may carry routes + gateway defaults.
+ * Either `AbstractController` (REST) or `AbstractApiController` (api-contracts).
+ *
+ * The contract generic on `AbstractController` is erased here on purpose — the
+ * manifest builder treats every route as a `RouteOptions` and reads the
+ * gateway-metadata symbol regardless of contract shape.
+ */
+type CollectedController =
+  | {
+      name: string
+      kind: 'rest'
+      // biome-ignore lint/suspicious/noExplicitAny: contract generic erased at the manifest boundary
+      controller: AbstractController<any>
+    }
+  | { name: string; kind: 'api'; controller: AbstractApiController }
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
+type CanonicalMethod = (typeof HTTP_METHODS)[number]
+
+function normalizeMethod(method: RouteOptions['method']): CanonicalMethod {
+  if (Array.isArray(method)) {
+    throw new Error(
+      `Gateway manifest does not support multi-method routes (got [${method.join(', ')}]). Declare one route per method.`,
+    )
+  }
+  const upper = String(method).toUpperCase()
+  if (!HTTP_METHODS.includes(upper as CanonicalMethod)) {
+    throw new Error(`Unsupported HTTP method "${method}" in gateway manifest`)
+  }
+  return upper as CanonicalMethod
+}
+
+function mergeMetadata(layers: Array<GatewayMetadataValue | undefined>): GatewayMetadataValue {
+  const present = layers.filter((m): m is GatewayMetadataValue => m !== undefined)
+  if (present.length === 0) return {}
+  if (present.length === 1) return present[0] as GatewayMetadataValue
+  // ts-deepmerge replaces arrays in later layers (documented merge semantics).
+  // biome-ignore lint/suspicious/noExplicitAny: ts-deepmerge generic doesn't cleanly express this
+  return merge.withOptions({ mergeArrays: false }, ...(present as any[])) as GatewayMetadataValue
+}
+
+function collectRouteEntries(
+  collected: CollectedController,
+): Array<{ routeKey: string; route: RouteOptions }> {
+  if (collected.kind === 'rest') {
+    const built = collected.controller.buildRoutes() as Record<string, RouteOptions>
+    return Object.entries(built).map(([routeKey, route]) => ({ routeKey, route }))
+  }
+  // AbstractApiController: routes is an array — index becomes the routeKey.
+  return collected.controller.routes.map((route, index) => ({
+    routeKey: String(index),
+    route,
+  }))
+}
+
+/**
+ * Pure manifest builder. Takes already-resolved controllers; performs no DI.
+ *
+ * Used by `DIContext.buildGatewayManifest()` after it resolves controllers from
+ * the container. Exposed separately for unit testing without spinning up a DI
+ * context.
+ */
+export function buildGatewayManifestFrom(
+  controllers: ReadonlyArray<CollectedController>,
+  options: BuildGatewayManifestOptions,
+): GatewayManifest {
+  const routes: GatewayManifestRoute[] = []
+
+  for (const collected of controllers) {
+    const controllerDefaults = collected.controller.gatewayDefaults
+    for (const { routeKey, route } of collectRouteEntries(collected)) {
+      const routeMetadata = readGatewayMetadata(route)
+      const merged = mergeMetadata([options.defaults, controllerDefaults, routeMetadata])
+
+      if (route.url === undefined) {
+        throw new Error(
+          `Route "${collected.name}.${routeKey}" is missing a URL — gateway manifest cannot be generated.`,
+        )
+      }
+      const path = normalizePath(route.url)
+      const method = normalizeMethod(route.method)
+      const id = merged.id ?? `${collected.name}.${routeKey}`
+
+      routes.push({
+        id,
+        method,
+        path,
+        controller: collected.name,
+        routeKey,
+        metadata: merged,
+      })
+    }
+  }
+
+  // Sort for stable output across runs (gateways like deterministic configs).
+  routes.sort((a, b) =>
+    a.path === b.path ? a.method.localeCompare(b.method) : a.path.localeCompare(b.path),
+  )
+
+  const manifest = {
+    manifestVersion: '1' as const,
+    service: options.service,
+    ...(options.version !== undefined ? { version: options.version } : {}),
+    generatedAt: new Date().toISOString(),
+    routes,
+  }
+
+  // Validate the per-route merged metadata too. The route-level types narrow
+  // header/query keys, but service- and controller-level defaults are
+  // contract-unbound, so a runtime check at the boundary protects generators.
+  return gatewayManifestSchema.parse(manifest)
+}
+
+export type { CollectedController }

--- a/lib/gateway/manifest/buildManifest.ts
+++ b/lib/gateway/manifest/buildManifest.ts
@@ -88,6 +88,9 @@ export function buildGatewayManifestFrom(
   options: BuildGatewayManifestOptions,
 ): GatewayManifest {
   const routes: GatewayManifestRoute[] = []
+  // Track route ids back to their origin so we can produce a useful error
+  // message if two declarations end up with the same explicit metadata.id.
+  const idOrigin = new Map<string, string>()
 
   for (const collected of controllers) {
     const controllerDefaults = collected.controller.gatewayDefaults
@@ -102,7 +105,16 @@ export function buildGatewayManifestFrom(
       }
       const path = normalizePath(route.url)
       const method = normalizeMethod(route.method)
-      const id = merged.id ?? `${collected.name}.${routeKey}`
+      const origin = `${collected.name}.${routeKey}`
+      const id = merged.id ?? origin
+
+      const previousOrigin = idOrigin.get(id)
+      if (previousOrigin) {
+        throw new Error(
+          `Duplicate gateway route id "${id}": declared by both ${previousOrigin} and ${origin}. Set a distinct metadata.id on one of them.`,
+        )
+      }
+      idOrigin.set(id, origin)
 
       routes.push({
         id,

--- a/lib/gateway/manifest/manifestSchema.ts
+++ b/lib/gateway/manifest/manifestSchema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod/v4'
+import { gatewayMetadataSchema } from '../gatewayMetadata.ts'
+
+const httpMethodSchema = z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'])
+
+export const gatewayManifestRouteSchema = z
+  .object({
+    /** Stable id; defaults to "<controller>.<routeKey>" when not declared in metadata. */
+    id: z.string(),
+    method: httpMethodSchema,
+    /** OpenAPI-style path: `/users/{userId}`. */
+    path: z.string().startsWith('/'),
+    /** Dependency-container name of the controller. */
+    controller: z.string(),
+    /** Key of the route inside the controller (`buildRoutes` map key, or array index for `AbstractApiController`). */
+    routeKey: z.string(),
+    /** Already-merged metadata: service defaults → controller defaults → route. */
+    metadata: gatewayMetadataSchema,
+  })
+  .strict()
+
+export const gatewayManifestSchema = z
+  .object({
+    manifestVersion: z.literal('1'),
+    service: z.string(),
+    version: z.string().optional(),
+    /** ISO-8601 timestamp. */
+    generatedAt: z.string(),
+    routes: z.array(gatewayManifestRouteSchema),
+  })
+  .strict()
+
+export type GatewayManifestRoute = z.infer<typeof gatewayManifestRouteSchema>
+export type GatewayManifest = z.infer<typeof gatewayManifestSchema>

--- a/lib/gateway/manifest/pathNormalize.spec.ts
+++ b/lib/gateway/manifest/pathNormalize.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePath } from './pathNormalize.ts'
+
+describe('normalizePath', () => {
+  it('passes through static paths unchanged', () => {
+    expect(normalizePath('/users')).toBe('/users')
+    expect(normalizePath('/')).toBe('/')
+  })
+
+  it('converts a single Fastify-style param', () => {
+    expect(normalizePath('/users/:userId')).toBe('/users/{userId}')
+  })
+
+  it('converts multiple Fastify-style params', () => {
+    expect(normalizePath('/users/:userId/posts/:postId')).toBe('/users/{userId}/posts/{postId}')
+  })
+
+  it('strips the optional marker from path text (optionality is metadata-level)', () => {
+    expect(normalizePath('/users/:userId?')).toBe('/users/{userId}')
+  })
+
+  it('rewrites bare wildcards to {wildcard}', () => {
+    expect(normalizePath('/files/*')).toBe('/files/{wildcard}')
+  })
+
+  it('preserves trailing slash exactly as authored', () => {
+    expect(normalizePath('/users/:userId/')).toBe('/users/{userId}/')
+  })
+
+  it('rejects paths that do not start with /', () => {
+    expect(() => normalizePath('users/:id')).toThrow(/start with/)
+  })
+
+  it('rejects invalid parameter names', () => {
+    expect(() => normalizePath('/users/:1bad')).toThrow(/Invalid path parameter/)
+  })
+})

--- a/lib/gateway/manifest/pathNormalize.spec.ts
+++ b/lib/gateway/manifest/pathNormalize.spec.ts
@@ -34,4 +34,13 @@ describe('normalizePath', () => {
   it('rejects invalid parameter names', () => {
     expect(() => normalizePath('/users/:1bad')).toThrow(/Invalid path parameter/)
   })
+
+  it('strips Fastify inline-constraint suffix (`:id(regex)`)', () => {
+    expect(normalizePath('/users/:id(\\d+)')).toBe('/users/{id}')
+    expect(normalizePath('/items/:slug(\\w+)')).toBe('/items/{slug}')
+  })
+
+  it('handles optional + inline constraint together', () => {
+    expect(normalizePath('/maybe/:id(\\d+)?')).toBe('/maybe/{id}')
+  })
 })

--- a/lib/gateway/manifest/pathNormalize.ts
+++ b/lib/gateway/manifest/pathNormalize.ts
@@ -1,0 +1,33 @@
+/**
+ * Convert a Fastify-style path (`:userId`, `:userId?`, `*`) to the canonical
+ * OpenAPI/RFC 6570 form used by the manifest (`{userId}`, `{userId}` with the
+ * caller marking it optional separately, `{wildcard}`).
+ *
+ * The manifest emits OpenAPI-style paths so each generator can translate to
+ * its own dialect (Envoy regex matchers, KrakenD `{var}`, AWS `{proxy+}`).
+ *
+ * Examples:
+ *   /users/:userId            → /users/{userId}
+ *   /users/:userId/posts/:id  → /users/{userId}/posts/{id}
+ *   /files/*                  → /files/{wildcard}
+ *   /a/:id?                   → /a/{id}      (optional flag is dropped from path text)
+ */
+export function normalizePath(fastifyPath: string): string {
+  if (!fastifyPath.startsWith('/')) {
+    throw new Error(`Path must start with "/": ${fastifyPath}`)
+  }
+
+  const segments = fastifyPath.split('/').map((segment) => {
+    if (segment === '*') return '{wildcard}'
+    if (segment.startsWith(':')) {
+      const name = segment.slice(1).replace(/\?$/, '')
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+        throw new Error(`Invalid path parameter name "${name}" in "${fastifyPath}"`)
+      }
+      return `{${name}}`
+    }
+    return segment
+  })
+
+  return segments.join('/')
+}

--- a/lib/gateway/manifest/pathNormalize.ts
+++ b/lib/gateway/manifest/pathNormalize.ts
@@ -1,16 +1,23 @@
 /**
- * Convert a Fastify-style path (`:userId`, `:userId?`, `*`) to the canonical
- * OpenAPI/RFC 6570 form used by the manifest (`{userId}`, `{userId}` with the
- * caller marking it optional separately, `{wildcard}`).
+ * Convert a Fastify-style path to the canonical OpenAPI/RFC 6570 form used
+ * by the manifest. The manifest emits OpenAPI-style paths so each generator
+ * can translate to its own dialect (Envoy regex matchers, KrakenD `{var}`,
+ * AWS `{proxy+}`).
  *
- * The manifest emits OpenAPI-style paths so each generator can translate to
- * its own dialect (Envoy regex matchers, KrakenD `{var}`, AWS `{proxy+}`).
+ * Supported Fastify shapes (find-my-way):
+ *   - `:userId`            ordinary parameter
+ *   - `:userId?`           optional parameter   (the `?` is for matching only;
+ *                                                we drop it from the path text)
+ *   - `:userId(regex)`     inline-constraint    (the `(regex)` is for matching
+ *                                                only; we drop it)
+ *   - `*`                  wildcard             → `{wildcard}`
  *
  * Examples:
  *   /users/:userId            → /users/{userId}
  *   /users/:userId/posts/:id  → /users/{userId}/posts/{id}
  *   /files/*                  → /files/{wildcard}
- *   /a/:id?                   → /a/{id}      (optional flag is dropped from path text)
+ *   /a/:id?                   → /a/{id}
+ *   /items/:slug(\\w+)        → /items/{slug}
  */
 export function normalizePath(fastifyPath: string): string {
   if (!fastifyPath.startsWith('/')) {
@@ -19,14 +26,17 @@ export function normalizePath(fastifyPath: string): string {
 
   const segments = fastifyPath.split('/').map((segment) => {
     if (segment === '*') return '{wildcard}'
-    if (segment.startsWith(':')) {
-      const name = segment.slice(1).replace(/\?$/, '')
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-        throw new Error(`Invalid path parameter name "${name}" in "${fastifyPath}"`)
-      }
-      return `{${name}}`
+    if (!segment.startsWith(':')) return segment
+
+    // Strip optional-marker (?) and inline-constraint suffix ((regex)) — both
+    // are matching directives, not part of the parameter's identity. Only the
+    // bare name lands in the manifest path.
+    const rest = segment.slice(1)
+    const name = rest.replace(/\?$/, '').replace(/\(.*\)$/s, '')
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(`Invalid path parameter name "${name}" in "${fastifyPath}"`)
     }
-    return segment
+    return `{${name}}`
   })
 
   return segments.join('/')

--- a/lib/gateway/withGatewayMetadata.spec.ts
+++ b/lib/gateway/withGatewayMetadata.spec.ts
@@ -1,0 +1,84 @@
+import { buildRestContract } from '@lokalise/api-contracts'
+import { buildFastifyRoute } from '@lokalise/fastify-api-contracts'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import { GATEWAY_METADATA_SYMBOL } from './gatewaySymbol.ts'
+import { readGatewayMetadata, withGatewayMetadata } from './withGatewayMetadata.ts'
+
+const headerAwareContract = buildRestContract({
+  method: 'post',
+  successResponseBodySchema: z.object({ ok: z.boolean() }),
+  requestBodySchema: z.object({ name: z.string() }),
+  requestPathParamsSchema: z.object({ tenantId: z.string() }),
+  requestHeaderSchema: z.object({ 'x-trace-id': z.string() }),
+  pathResolver: (p) => `/tenants/${p.tenantId}/items`,
+})
+
+describe('withGatewayMetadata', () => {
+  it('returns the same route reference (no copy)', () => {
+    const route = buildFastifyRoute(headerAwareContract, async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    })
+    const annotated = withGatewayMetadata(headerAwareContract, route, {
+      cache: { ttl: '60s' },
+    })
+    expect(annotated).toBe(route)
+  })
+
+  it('attaches metadata via a non-enumerable symbol (invisible to Fastify and JSON)', () => {
+    const route = buildFastifyRoute(headerAwareContract, async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    })
+    withGatewayMetadata(headerAwareContract, route, { upstream: 'svc' })
+
+    expect(Object.keys(route)).not.toContain(GATEWAY_METADATA_SYMBOL.toString())
+    expect(JSON.stringify(route)).not.toContain('upstream')
+    expect(Object.getOwnPropertyDescriptor(route, GATEWAY_METADATA_SYMBOL)?.enumerable).toBe(false)
+  })
+
+  it('readGatewayMetadata returns the stamped metadata', () => {
+    const route = buildFastifyRoute(headerAwareContract, async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    })
+    withGatewayMetadata(headerAwareContract, route, {
+      upstream: 'tenants-service',
+      cache: { ttl: '30s' },
+    })
+    expect(readGatewayMetadata(route)).toEqual({
+      upstream: 'tenants-service',
+      cache: { ttl: '30s' },
+    })
+  })
+
+  it('readGatewayMetadata returns undefined for un-annotated routes', () => {
+    const route = buildFastifyRoute(headerAwareContract, async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    })
+    expect(readGatewayMetadata(route)).toBeUndefined()
+  })
+
+  it('accepts contract-typed match.headers keys (typecheck-driven)', () => {
+    const route = buildFastifyRoute(headerAwareContract, async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    })
+    // The 'x-trace-id' key is type-checked against requestHeaderSchema.
+    const annotated = withGatewayMetadata(headerAwareContract, route, {
+      match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } },
+    })
+    expect(readGatewayMetadata(annotated)?.match?.headers?.['x-trace-id']).toEqual({
+      regex: '^[a-f0-9]+$',
+    })
+  })
+
+  it('customHeaders accepts free-form keys for headers not in the contract', () => {
+    const route = buildFastifyRoute(headerAwareContract, async (_, reply) => {
+      await reply.status(200).send({ ok: true })
+    })
+    const annotated = withGatewayMetadata(headerAwareContract, route, {
+      match: { customHeaders: { 'x-cf-tenant': 'enterprise' } },
+    })
+    expect(readGatewayMetadata(annotated)?.match?.customHeaders).toEqual({
+      'x-cf-tenant': 'enterprise',
+    })
+  })
+})

--- a/lib/gateway/withGatewayMetadata.ts
+++ b/lib/gateway/withGatewayMetadata.ts
@@ -1,5 +1,5 @@
 import type { CommonRouteDefinition } from '@lokalise/api-contracts'
-import type { GatewayMetadataValue } from './gatewayMetadata.ts'
+import { type GatewayMetadataValue, gatewayMetadataSchema } from './gatewayMetadata.ts'
 import { GATEWAY_METADATA_SYMBOL } from './gatewaySymbol.ts'
 import type { GatewayMetadata } from './gatewayTypes.ts'
 
@@ -43,8 +43,12 @@ export function withGatewayMetadata<Contract extends AnyContract, Route extends 
   route: Route,
   metadata: GatewayMetadata<Contract>,
 ): Route {
+  // Validate eagerly so a bad shape fails at the call site (with a clean
+  // Zod issue path) rather than later when DIContext.buildGatewayManifest
+  // walks every route at once.
+  const validated = gatewayMetadataSchema.parse(metadata) as GatewayMetadataValue
   Object.defineProperty(route, GATEWAY_METADATA_SYMBOL, {
-    value: metadata as GatewayMetadataValue,
+    value: validated,
     enumerable: false,
     configurable: true,
     writable: true,

--- a/lib/gateway/withGatewayMetadata.ts
+++ b/lib/gateway/withGatewayMetadata.ts
@@ -1,0 +1,61 @@
+import type { CommonRouteDefinition } from '@lokalise/api-contracts'
+import type { GatewayMetadataValue } from './gatewayMetadata.ts'
+import { GATEWAY_METADATA_SYMBOL } from './gatewaySymbol.ts'
+import type { GatewayMetadata } from './gatewayTypes.ts'
+
+// biome-ignore lint/suspicious/noExplicitAny: shape-agnostic — we don't constrain contract generics here
+type AnyContract = CommonRouteDefinition<any, any, any, any, any, any, any, any>
+
+/**
+ * Attach gateway metadata to a route built by `buildFastifyRoute` / `buildApiRoute`.
+ *
+ * The metadata is stamped on the route via a non-enumerable `Symbol` property,
+ * so Fastify never sees it (it walks own enumerable keys when registering
+ * routes). The same route reference is returned — no copy, no spread.
+ *
+ * Apply at the `buildRoutes()` return site (or in the `routes` array for
+ * `AbstractApiController`) so all gateway annotations for a controller live in
+ * a single, scannable block:
+ *
+ * @example
+ * ```ts
+ * public buildRoutes(): BuildRoutesReturnType<typeof MyController.contracts> {
+ *   return {
+ *     getItem: withGatewayMetadata(MyController.contracts.getItem, this.getItem, {
+ *       cache: { ttl: '60s' },
+ *       match: { customHeaders: { 'x-tenant-id': { regex: '^t_' } } },
+ *     }),
+ *     // un-annotated routes pass through directly — they still inherit
+ *     // controller- and service-wide gateway defaults.
+ *     deleteItem: this.deleteItem,
+ *   }
+ * }
+ * ```
+ *
+ * @param _contract - The contract is taken purely to drive type inference for
+ *   `match.headers`, `match.query`, and `rateLimit.key`. It is not stored.
+ * @param route - The route returned by `buildFastifyRoute` or `buildApiRoute`.
+ * @param metadata - Per-route gateway metadata.
+ * @returns The same `route` reference, with metadata attached via Symbol.
+ */
+export function withGatewayMetadata<Contract extends AnyContract, Route extends object>(
+  _contract: Contract,
+  route: Route,
+  metadata: GatewayMetadata<Contract>,
+): Route {
+  Object.defineProperty(route, GATEWAY_METADATA_SYMBOL, {
+    value: metadata as GatewayMetadataValue,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  })
+  return route
+}
+
+/**
+ * Read gateway metadata previously stamped on a route by `withGatewayMetadata`.
+ * Returns `undefined` if no metadata was attached.
+ */
+export function readGatewayMetadata(route: object): GatewayMetadataValue | undefined {
+  return (route as Record<symbol, GatewayMetadataValue | undefined>)[GATEWAY_METADATA_SYMBOL]
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dependencies": {
         "@fastify/sse": "^0.4.0",
         "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.0",
         "ts-deepmerge": "^7.0.3"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opinionated-machine",
-    "version": "6.16.1",
+    "version": "6.17.0",
     "description": "Very opinionated DI framework for fastify, built on top of awilix ",
     "type": "module",
     "license": "MIT",

--- a/packages/gateway-envoy/README.md
+++ b/packages/gateway-envoy/README.md
@@ -1,25 +1,28 @@
 # @opinionated-machine/gateway-envoy
 
-Envoy v3 static-config generator for [opinionated-machine](https://github.com/kibertoad/opinionated-machine)
-gateway manifests.
-
-## Install
+Generate an Envoy v3 static config from your
+[opinionated-machine](https://github.com/kibertoad/opinionated-machine) routes.
+Annotate routes once with timeouts / retries / header rules / etc., then run
+this generator at build time and deploy the resulting `envoy.yaml`.
 
 ```sh
-npm install @opinionated-machine/gateway-envoy
+npm install --save-dev @opinionated-machine/gateway-envoy
 ```
 
 `opinionated-machine` is a peer dependency.
 
-## Usage
+## Use it
 
 ```ts
+// bin/render-envoy.ts
 import { writeFileSync } from 'node:fs'
 import { renderEnvoyConfig } from '@opinionated-machine/gateway-envoy'
+import { buildContext } from '../src/diContext.ts'   // your DIContext factory
 
-const manifest = context.buildGatewayManifest({ service: 'users-api' })
+const ctx = await buildContext()
+const manifest = ctx.buildGatewayManifest({ service: 'users-api' })
 
-const { yaml, json, warnings } = renderEnvoyConfig(manifest, {
+const { yaml, warnings } = renderEnvoyConfig(manifest, {
   listenPort: 8080,
   clusters: {
     'users-service': { hosts: ['users:8081'], connectTimeout: '1s' },
@@ -27,53 +30,57 @@ const { yaml, json, warnings } = renderEnvoyConfig(manifest, {
 })
 
 writeFileSync('envoy.yaml', yaml)
-console.warn(warnings)            // metadata fields Envoy v1 doesn't natively support
+if (warnings.length) console.warn('[envoy]', warnings)
 ```
 
-The generator is a pure function — same manifest in, same config out — with
-zero coupling to Fastify, your DI container, or contract definitions.
+```sh
+$ tsx bin/render-envoy.ts && envoy --mode validate -c envoy.yaml
+configuration 'envoy.yaml' OK
+```
 
-## Field mappings
+`renderEnvoyConfig(...)` also returns `json` (the same config as a JS object,
+handy for tests and inspection).
 
-| `GatewayMetadata` field | Envoy mapping |
-| ----------------------- | ------------- |
-| `upstream`              | `cluster` reference; deduped clusters in `static_resources.clusters` |
-| `match.headers` / `customHeaders` | `match.headers[]` with `string_match` (exact/prefix/regex) |
-| `match.query` / `customQuery`     | `match.query_parameters[]` |
-| `timeouts.request`      | `route.timeout` |
-| `timeouts.connect`      | `cluster.connect_timeout` (via `EnvoyClusterOptions.connectTimeout`) |
-| `retry.attempts`        | `route.retry_policy.num_retries` |
-| `retry.on`              | `route.retry_policy.retry_on` (CSV) |
-| `retry.perTryTimeout`   | `route.retry_policy.per_try_timeout` |
-| `rewrite.stripPrefix`   | `route.prefix_rewrite: '/'` |
-| `headers.request.add`   | `route.request_headers_to_add` |
-| `headers.request.remove`| `route.request_headers_to_remove` |
-| `headers.response.add`  | `route.response_headers_to_add` |
-| `headers.response.remove` | `route.response_headers_to_remove` |
-| `extensions.envoy`      | shallow-merged onto the route last (escape hatch) |
+## How metadata maps to Envoy
 
-## Limitations (v1)
+| Route metadata | Envoy output |
+| -------------- | ------------ |
+| `upstream` | route's `cluster`; deduped clusters under `static_resources.clusters` |
+| `match.headers` / `customHeaders` | `route.match.headers[]` (`exact` / `prefix` / `safe_regex`) |
+| `match.query` / `customQuery`     | `route.match.query_parameters[]` |
+| `timeouts.request`     | `route.timeout` |
+| `timeouts.connect`     | `cluster.connect_timeout` (set via `EnvoyClusterOptions.connectTimeout`) |
+| `retry.attempts`       | `route.retry_policy.num_retries` |
+| `retry.on`             | `route.retry_policy.retry_on` (CSV) |
+| `retry.perTryTimeout`  | `route.retry_policy.per_try_timeout` |
+| `rewrite.stripPrefix`  | `route.prefix_rewrite: '/'` |
+| `headers.request.{add,remove}`   | `route.request_headers_to_{add,remove}` |
+| `headers.response.{add,remove}`  | `route.response_headers_to_{add,remove}` |
+| `extensions.envoy`     | shallow-merged onto the route last (escape hatch) |
 
-The following universal fields are **not** mapped to Envoy in v1 — they appear
-as `warnings[]` entries on the result so they aren't silently dropped:
+## What it doesn't do
 
-- `cache.ttl` — needs `envoy.filters.http.cache` wired separately
-- `circuitBreaker` — applies at the cluster level; v1 emits routes only
-- `auth.jwt` — needs `envoy.filters.http.jwt_authn` filter + provider on the listener
-- `cors` — needs `envoy.filters.http.cors` filter
-- `rateLimit` — needs `envoy.filters.http.local_ratelimit` typed_per_filter_config
+These metadata fields produce a `warnings[]` entry instead of being silently
+dropped — they need an Envoy filter that this generator doesn't wire for you:
 
-Use `extensions.envoy` on a route for any of these.
+- `cache.ttl` — needs `envoy.filters.http.cache`
+- `auth.jwt` — needs `envoy.filters.http.jwt_authn`
+- `cors` — needs `envoy.filters.http.cors`
+- `rateLimit` — needs `envoy.filters.http.local_ratelimit`
+- `circuitBreaker` — applies at the cluster level
 
-## Acceptance tests
+For any of these, configure the filter once in your Envoy listener and use
+`extensions.envoy` on the route to attach the per-route typed-config block.
 
-This package includes a Docker-based acceptance suite that boots a real Envoy
-container plus a stub upstream and drives traffic through the generated config:
+## Verifying generated configs
+
+This package's CI runs an acceptance suite that boots a real Envoy container
+plus a stub upstream and drives traffic through the generated config:
 
 ```sh
 npm run test:acceptance
 ```
 
-Triggered automatically in CI by the
+Requires Docker. Triggered automatically by the
 [`gateway-acceptance`](../../.github/workflows/gateway-acceptance.yml) workflow
-when this package or `lib/gateway/` changes. Requires Docker locally.
+when this package or `lib/gateway/` changes.

--- a/packages/gateway-envoy/README.md
+++ b/packages/gateway-envoy/README.md
@@ -1,0 +1,79 @@
+# @opinionated-machine/gateway-envoy
+
+Envoy v3 static-config generator for [opinionated-machine](https://github.com/kibertoad/opinionated-machine)
+gateway manifests.
+
+## Install
+
+```sh
+npm install @opinionated-machine/gateway-envoy
+```
+
+`opinionated-machine` is a peer dependency.
+
+## Usage
+
+```ts
+import { writeFileSync } from 'node:fs'
+import { renderEnvoyConfig } from '@opinionated-machine/gateway-envoy'
+
+const manifest = context.buildGatewayManifest({ service: 'users-api' })
+
+const { yaml, json, warnings } = renderEnvoyConfig(manifest, {
+  listenPort: 8080,
+  clusters: {
+    'users-service': { hosts: ['users:8081'], connectTimeout: '1s' },
+  },
+})
+
+writeFileSync('envoy.yaml', yaml)
+console.warn(warnings)            // metadata fields Envoy v1 doesn't natively support
+```
+
+The generator is a pure function — same manifest in, same config out — with
+zero coupling to Fastify, your DI container, or contract definitions.
+
+## Field mappings
+
+| `GatewayMetadata` field | Envoy mapping |
+| ----------------------- | ------------- |
+| `upstream`              | `cluster` reference; deduped clusters in `static_resources.clusters` |
+| `match.headers` / `customHeaders` | `match.headers[]` with `string_match` (exact/prefix/regex) |
+| `match.query` / `customQuery`     | `match.query_parameters[]` |
+| `timeouts.request`      | `route.timeout` |
+| `timeouts.connect`      | `cluster.connect_timeout` (via `EnvoyClusterOptions.connectTimeout`) |
+| `retry.attempts`        | `route.retry_policy.num_retries` |
+| `retry.on`              | `route.retry_policy.retry_on` (CSV) |
+| `retry.perTryTimeout`   | `route.retry_policy.per_try_timeout` |
+| `rewrite.stripPrefix`   | `route.prefix_rewrite: '/'` |
+| `headers.request.add`   | `route.request_headers_to_add` |
+| `headers.request.remove`| `route.request_headers_to_remove` |
+| `headers.response.add`  | `route.response_headers_to_add` |
+| `headers.response.remove` | `route.response_headers_to_remove` |
+| `extensions.envoy`      | shallow-merged onto the route last (escape hatch) |
+
+## Limitations (v1)
+
+The following universal fields are **not** mapped to Envoy in v1 — they appear
+as `warnings[]` entries on the result so they aren't silently dropped:
+
+- `cache.ttl` — needs `envoy.filters.http.cache` wired separately
+- `circuitBreaker` — applies at the cluster level; v1 emits routes only
+- `auth.jwt` — needs `envoy.filters.http.jwt_authn` filter + provider on the listener
+- `cors` — needs `envoy.filters.http.cors` filter
+- `rateLimit` — needs `envoy.filters.http.local_ratelimit` typed_per_filter_config
+
+Use `extensions.envoy` on a route for any of these.
+
+## Acceptance tests
+
+This package includes a Docker-based acceptance suite that boots a real Envoy
+container plus a stub upstream and drives traffic through the generated config:
+
+```sh
+npm run test:acceptance
+```
+
+Triggered automatically in CI by the
+[`gateway-acceptance`](../../.github/workflows/gateway-acceptance.yml) workflow
+when this package or `lib/gateway/` changes. Requires Docker locally.

--- a/packages/gateway-envoy/acceptance/envoy.acceptance.spec.ts
+++ b/packages/gateway-envoy/acceptance/envoy.acceptance.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Acceptance tests for the Envoy generator. Driven by the
+ * `vitest.acceptance.config.ts` config — they only run via
+ * `npm run test:acceptance`, which:
+ *
+ *   1. builds the package (so `dist/` is up-to-date),
+ *   2. renders the acceptance manifest to YAML,
+ *   3. boots `docker compose` (Envoy + a Node stub upstream),
+ *   4. runs this file under the acceptance vitest config,
+ *   5. tears compose down.
+ *
+ * The CI workflow `gateway-acceptance.yml` runs the script only when this
+ * package or `lib/gateway` changes.
+ */
+const GATEWAY_URL = process.env.GATEWAY_URL ?? 'http://localhost:10000'
+
+describe('envoy acceptance', () => {
+  it('routes GET /echo to the upstream', async () => {
+    const res = await fetch(`${GATEWAY_URL}/echo`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { method: string; path: string }
+    expect(body.method).toBe('GET')
+    expect(body.path).toBe('/echo')
+  })
+
+  it('forwards arbitrary headers to the upstream', async () => {
+    const res = await fetch(`${GATEWAY_URL}/echo`, {
+      headers: { 'x-trace-id': 'abc123' },
+    })
+    const body = (await res.json()) as { headers: Record<string, string | null> }
+    expect(body.headers['x-trace-id']).toBe('abc123')
+  })
+
+  it('enforces the per-route request timeout', async () => {
+    // /slow has a 200ms timeout in the manifest; ms=2000 exceeds it.
+    const res = await fetch(`${GATEWAY_URL}/slow?ms=2000`)
+    // Envoy returns 504 (Gateway Timeout) when the upstream exceeds route.timeout.
+    expect(res.status).toBe(504)
+  })
+
+  it('rejects unknown paths with 404 from the gateway', async () => {
+    const res = await fetch(`${GATEWAY_URL}/nope`)
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/gateway-envoy/acceptance/envoy.acceptance.spec.ts
+++ b/packages/gateway-envoy/acceptance/envoy.acceptance.spec.ts
@@ -15,10 +15,17 @@ import { describe, expect, it } from 'vitest'
  * package or `lib/gateway` changes.
  */
 const GATEWAY_URL = process.env.GATEWAY_URL ?? 'http://localhost:10000'
+const FETCH_TIMEOUT_MS = 10_000
+
+const fetchGateway = (path: string, init?: RequestInit) =>
+  fetch(`${GATEWAY_URL}${path}`, {
+    ...init,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  })
 
 describe('envoy acceptance', () => {
   it('routes GET /echo to the upstream', async () => {
-    const res = await fetch(`${GATEWAY_URL}/echo`)
+    const res = await fetchGateway('/echo')
     expect(res.status).toBe(200)
     const body = (await res.json()) as { method: string; path: string }
     expect(body.method).toBe('GET')
@@ -26,22 +33,21 @@ describe('envoy acceptance', () => {
   })
 
   it('forwards arbitrary headers to the upstream', async () => {
-    const res = await fetch(`${GATEWAY_URL}/echo`, {
-      headers: { 'x-trace-id': 'abc123' },
-    })
+    const res = await fetchGateway('/echo', { headers: { 'x-trace-id': 'abc123' } })
+    expect(res.status).toBe(200)
     const body = (await res.json()) as { headers: Record<string, string | null> }
     expect(body.headers['x-trace-id']).toBe('abc123')
   })
 
   it('enforces the per-route request timeout', async () => {
     // /slow has a 200ms timeout in the manifest; ms=2000 exceeds it.
-    const res = await fetch(`${GATEWAY_URL}/slow?ms=2000`)
+    const res = await fetchGateway('/slow?ms=2000')
     // Envoy returns 504 (Gateway Timeout) when the upstream exceeds route.timeout.
     expect(res.status).toBe(504)
   })
 
   it('rejects unknown paths with 404 from the gateway', async () => {
-    const res = await fetch(`${GATEWAY_URL}/nope`)
+    const res = await fetchGateway('/nope')
     expect(res.status).toBe(404)
   })
 })

--- a/packages/gateway-envoy/acceptance/manifest.acceptance.mjs
+++ b/packages/gateway-envoy/acceptance/manifest.acceptance.mjs
@@ -1,11 +1,11 @@
-import type { GatewayManifest } from 'opinionated-machine'
-
 /**
- * Acceptance-test manifest. Hand-written rather than generated through
- * `DIContext.buildGatewayManifest` to keep this self-contained — we want to
- * verify the generator under conditions we control, not the full pipeline.
+ * Acceptance manifest. Hand-written rather than collected from a real
+ * DIContext to keep this self-contained — we want to verify the generator
+ * under conditions we control, not the full pipeline.
+ *
+ * @type {import('opinionated-machine').GatewayManifest}
  */
-export const acceptanceManifest: GatewayManifest = {
+export const acceptanceManifest = {
   manifestVersion: '1',
   service: 'gateway-envoy-acceptance',
   generatedAt: '2026-05-06T00:00:00.000Z',

--- a/packages/gateway-envoy/acceptance/manifest.acceptance.ts
+++ b/packages/gateway-envoy/acceptance/manifest.acceptance.ts
@@ -1,0 +1,34 @@
+import type { GatewayManifest } from 'opinionated-machine'
+
+/**
+ * Acceptance-test manifest. Hand-written rather than generated through
+ * `DIContext.buildGatewayManifest` to keep this self-contained — we want to
+ * verify the generator under conditions we control, not the full pipeline.
+ */
+export const acceptanceManifest: GatewayManifest = {
+  manifestVersion: '1',
+  service: 'gateway-envoy-acceptance',
+  generatedAt: '2026-05-06T00:00:00.000Z',
+  routes: [
+    {
+      id: 'echo.get',
+      method: 'GET',
+      path: '/echo',
+      controller: 'echo',
+      routeKey: 'get',
+      metadata: {
+        upstream: 'upstream',
+        timeouts: { request: '2s' },
+      },
+    },
+    {
+      id: 'echo.slow',
+      method: 'GET',
+      path: '/slow',
+      controller: 'echo',
+      routeKey: 'slow',
+      // Tight timeout so we can verify Envoy enforces it.
+      metadata: { upstream: 'upstream', timeouts: { request: '200ms' } },
+    },
+  ],
+}

--- a/packages/gateway-envoy/acceptance/render-config.mjs
+++ b/packages/gateway-envoy/acceptance/render-config.mjs
@@ -14,6 +14,10 @@ const { yaml, warnings } = renderEnvoyConfig(acceptanceManifest, {
   listenPort: 10000,
   // The "upstream" name maps to the docker-compose service name.
   clusters: { upstream: { hosts: ['upstream:8081'], connectTimeout: '1s' } },
+  // Expose the admin interface so /ready, /stats, /clusters etc. are
+  // available — useful for debugging acceptance failures and for ops in
+  // general. The docker-compose file forwards 9901.
+  admin: { port: 9901 },
 })
 writeFileSync(join(outDir, 'envoy.yaml'), yaml)
 if (warnings.length) {

--- a/packages/gateway-envoy/acceptance/render-config.mjs
+++ b/packages/gateway-envoy/acceptance/render-config.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { renderEnvoyConfig } from '../dist/render.js'
-import { acceptanceManifest } from './manifest.acceptance.js'
+import { acceptanceManifest } from './manifest.acceptance.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const outDir = join(__dirname, 'generated')

--- a/packages/gateway-envoy/acceptance/render-config.mjs
+++ b/packages/gateway-envoy/acceptance/render-config.mjs
@@ -1,0 +1,22 @@
+// Renders the acceptance manifest to a YAML file that docker-compose mounts
+// into the Envoy container. Run before `docker compose up`.
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderEnvoyConfig } from '../dist/render.js'
+import { acceptanceManifest } from './manifest.acceptance.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const outDir = join(__dirname, 'generated')
+mkdirSync(outDir, { recursive: true })
+
+const { yaml, warnings } = renderEnvoyConfig(acceptanceManifest, {
+  listenPort: 10000,
+  // The "upstream" name maps to the docker-compose service name.
+  clusters: { upstream: { hosts: ['upstream:8081'], connectTimeout: '1s' } },
+})
+writeFileSync(join(outDir, 'envoy.yaml'), yaml)
+if (warnings.length) {
+  console.warn('[render-config] warnings:', warnings)
+}
+console.log('[render-config] wrote', join(outDir, 'envoy.yaml'))

--- a/packages/gateway-envoy/acceptance/upstream.mjs
+++ b/packages/gateway-envoy/acceptance/upstream.mjs
@@ -1,0 +1,36 @@
+// Minimal upstream stub for acceptance tests.
+//
+// Echoes back the path, method, and a few headers the gateway forwards.
+// Path "/slow" delays for the requested ms (driven by ?ms=X) so we can verify
+// gateway timeouts.
+import { createServer } from 'node:http'
+
+const PORT = Number(process.env.PORT ?? 8081)
+
+createServer((req, res) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
+
+  if (url.pathname === '/slow') {
+    const delay = Number(url.searchParams.get('ms') ?? '500')
+    setTimeout(() => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ path: url.pathname, delayedMs: delay }))
+    }, delay)
+    return
+  }
+
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(
+    JSON.stringify({
+      method: req.method,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      headers: {
+        'x-trace-id': req.headers['x-trace-id'] ?? null,
+        'x-internal': req.headers['x-internal'] ?? null,
+      },
+    }),
+  )
+}).listen(PORT, () => {
+  console.log(`[upstream] listening on :${PORT}`)
+})

--- a/packages/gateway-envoy/docker-compose.yml
+++ b/packages/gateway-envoy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   upstream:
     image: node:20-alpine

--- a/packages/gateway-envoy/docker-compose.yml
+++ b/packages/gateway-envoy/docker-compose.yml
@@ -24,11 +24,11 @@ services:
       - '10000:10000'
       - '9901:9901'
     healthcheck:
-      # Hit Envoy's admin /ready endpoint via bash-only TCP — works without
-      # wget/curl. Admin port comes up after Envoy loads the listener config,
-      # which is the right "ready" signal (the route's /echo path depends on
-      # upstream DNS propagation, which would race the healthcheck).
-      test: ['CMD', 'bash', '-c', 'exec 3<>/dev/tcp/127.0.0.1/9901']
+      # Probe the data-plane port — bash (in the ubuntu base image) opens a
+      # TCP connection via /dev/tcp, no wget/curl required. The HCM listener
+      # binds 10000 only after Envoy successfully loads its config, which is
+      # the right "ready" signal for the acceptance suite.
+      test: ['CMD', 'bash', '-c', 'exec 3<>/dev/tcp/127.0.0.1/10000']
       interval: 2s
       timeout: 5s
       retries: 30

--- a/packages/gateway-envoy/docker-compose.yml
+++ b/packages/gateway-envoy/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  upstream:
+    image: node:20-alpine
+    volumes:
+      - ./acceptance/upstream.mjs:/app/upstream.mjs:ro
+    command: node /app/upstream.mjs
+    environment:
+      PORT: '8081'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8081/']
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    depends_on:
+      upstream:
+        condition: service_healthy
+    volumes:
+      - ./acceptance/generated/envoy.yaml:/etc/envoy/envoy.yaml:ro
+    command: ['envoy', '-c', '/etc/envoy/envoy.yaml', '--log-level', 'warn']
+    ports:
+      - '10000:10000'
+      - '9901:9901'
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'wget -qO- http://localhost:10000/echo > /dev/null 2>&1 || exit 1']
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/packages/gateway-envoy/docker-compose.yml
+++ b/packages/gateway-envoy/docker-compose.yml
@@ -24,8 +24,12 @@ services:
       - '10000:10000'
       - '9901:9901'
     healthcheck:
-      test:
-        ['CMD-SHELL', 'wget -qO- http://localhost:10000/echo > /dev/null 2>&1 || exit 1']
+      # Hit Envoy's admin /ready endpoint via bash-only TCP — works without
+      # wget/curl. Admin port comes up after Envoy loads the listener config,
+      # which is the right "ready" signal (the route's /echo path depends on
+      # upstream DNS propagation, which would race the healthcheck).
+      test: ['CMD', 'bash', '-c', 'exec 3<>/dev/tcp/127.0.0.1/9901']
       interval: 2s
       timeout: 5s
       retries: 30
+      start_period: 5s

--- a/packages/gateway-envoy/package.json
+++ b/packages/gateway-envoy/package.json
@@ -1,0 +1,68 @@
+{
+    "name": "@opinionated-machine/gateway-envoy",
+    "version": "0.1.0",
+    "description": "Envoy config generator for opinionated-machine gateway manifests",
+    "type": "module",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": "./dist/index.js",
+        "./package.json": "./package.json"
+    },
+    "maintainers": [
+        {
+            "name": "Igor Savin",
+            "email": "kibertoad@gmail.com"
+        }
+    ],
+    "scripts": {
+        "build": "rimraf dist && tsc -p tsconfig.build.json",
+        "lint": "biome check . && tsc",
+        "lint:fix": "biome check --write .",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "acceptance:render": "node acceptance/render-config.mjs",
+        "acceptance:up": "docker compose up -d --wait",
+        "acceptance:down": "docker compose down -v",
+        "test:acceptance": "npm run build && npm run acceptance:render && npm run acceptance:up && vitest run -c vitest.acceptance.config.ts; ec=$?; npm run acceptance:down; exit $ec",
+        "prepublishOnly": "npm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kibertoad/opinionated-machine.git",
+        "directory": "packages/gateway-envoy"
+    },
+    "peerDependencies": {
+        "opinionated-machine": ">=6.17.0"
+    },
+    "dependencies": {
+        "yaml": "^2.5.1"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.4.4",
+        "@lokalise/biome-config": "^3.1.1",
+        "@lokalise/tsconfig": "^3.1.0",
+        "@types/node": "^22.19.7",
+        "opinionated-machine": "^6.16.1",
+        "rimraf": "^6.1.2",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+    },
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "keywords": [
+        "envoy",
+        "gateway",
+        "generator",
+        "opinionated-machine"
+    ],
+    "homepage": "https://github.com/kibertoad/opinionated-machine/tree/main/packages/gateway-envoy",
+    "files": [
+        "README.md",
+        "LICENSE",
+        "dist/*"
+    ]
+}

--- a/packages/gateway-envoy/package.json
+++ b/packages/gateway-envoy/package.json
@@ -44,7 +44,7 @@
         "@lokalise/biome-config": "^3.1.1",
         "@lokalise/tsconfig": "^3.1.0",
         "@types/node": "^22.19.7",
-        "opinionated-machine": "^6.16.1",
+        "opinionated-machine": "^6.17.0",
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/packages/gateway-envoy/src/__fixtures__/manifest.fixture.ts
+++ b/packages/gateway-envoy/src/__fixtures__/manifest.fixture.ts
@@ -1,0 +1,68 @@
+import type { GatewayManifest } from 'opinionated-machine'
+
+/**
+ * A representative manifest covering the universal metadata fields exercised
+ * by the snapshot tests. Frozen `generatedAt` so snapshots stay stable.
+ */
+export const fixtureManifest: GatewayManifest = {
+  manifestVersion: '1',
+  service: 'users-api',
+  generatedAt: '2026-05-06T00:00:00.000Z',
+  routes: [
+    {
+      id: 'usersController.createItem',
+      method: 'POST',
+      path: '/users',
+      controller: 'usersController',
+      routeKey: 'createItem',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { request: '5s' },
+        headers: {
+          request: { add: { 'x-internal': 'true' }, remove: ['cookie'] },
+          response: { remove: ['server'] },
+        },
+      },
+    },
+    {
+      id: 'usersController.getItem',
+      method: 'GET',
+      path: '/users/{userId}',
+      controller: 'usersController',
+      routeKey: 'getItem',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { request: '5s' },
+        retry: {
+          attempts: 2,
+          on: ['5xx', 'connect-failure'],
+          perTryTimeout: '2s',
+        },
+        match: {
+          headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } },
+          customHeaders: { 'x-tenant-id': { prefix: 't_' } },
+          query: { include: 'profile' },
+        },
+        cache: { ttl: '60s' },
+      },
+    },
+    {
+      id: 'usersController.deleteItem',
+      method: 'DELETE',
+      path: '/users/{userId}',
+      controller: 'usersController',
+      routeKey: 'deleteItem',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { request: '3s' },
+        rewrite: { stripPrefix: '/users' },
+        extensions: {
+          envoy: {
+            // This block is merged onto the route last — escape hatch.
+            decorator: { operation: 'usersController.deleteItem' },
+          },
+        },
+      },
+    },
+  ],
+}

--- a/packages/gateway-envoy/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-envoy/src/__snapshots__/render.spec.ts.snap
@@ -1,0 +1,284 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderEnvoyConfig > matches the JSON snapshot for the fixture manifest 1`] = `
+{
+  "static_resources": {
+    "clusters": [
+      {
+        "connect_timeout": "1s",
+        "load_assignment": {
+          "cluster_name": "users-service",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "users",
+                        "port_value": 8081,
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        "name": "users-service",
+        "type": "STRICT_DNS",
+      },
+    ],
+    "listeners": [
+      {
+        "address": {
+          "socket_address": {
+            "address": "0.0.0.0",
+            "port_value": 8080,
+          },
+        },
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typed_config": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "http_filters": [
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                      },
+                    },
+                  ],
+                  "route_config": {
+                    "name": "users-api_routes",
+                    "virtual_hosts": [
+                      {
+                        "domains": [
+                          "*",
+                        ],
+                        "name": "users-api",
+                        "routes": [
+                          {
+                            "match": {
+                              "headers": [
+                                {
+                                  "name": ":method",
+                                  "string_match": {
+                                    "exact": "POST",
+                                  },
+                                },
+                              ],
+                              "safe_regex": {
+                                "regex": "/users",
+                              },
+                            },
+                            "name": "usersController.createItem",
+                            "request_headers_to_add": [
+                              {
+                                "header": {
+                                  "key": "x-internal",
+                                  "value": "true",
+                                },
+                              },
+                            ],
+                            "request_headers_to_remove": [
+                              "cookie",
+                            ],
+                            "response_headers_to_remove": [
+                              "server",
+                            ],
+                            "route": {
+                              "cluster": "users-service",
+                              "timeout": "5s",
+                            },
+                          },
+                          {
+                            "match": {
+                              "headers": [
+                                {
+                                  "name": ":method",
+                                  "string_match": {
+                                    "exact": "GET",
+                                  },
+                                },
+                                {
+                                  "name": "x-trace-id",
+                                  "string_match": {
+                                    "safe_regex": {
+                                      "regex": "^[a-f0-9]+$",
+                                    },
+                                  },
+                                },
+                                {
+                                  "name": "x-tenant-id",
+                                  "string_match": {
+                                    "prefix": "t_",
+                                  },
+                                },
+                              ],
+                              "query_parameters": [
+                                {
+                                  "name": "include",
+                                  "string_match": {
+                                    "exact": "profile",
+                                  },
+                                },
+                              ],
+                              "safe_regex": {
+                                "regex": "/users/[^/]+",
+                              },
+                            },
+                            "name": "usersController.getItem",
+                            "route": {
+                              "cluster": "users-service",
+                              "retry_policy": {
+                                "num_retries": 2,
+                                "per_try_timeout": "2s",
+                                "retry_on": "5xx,connect-failure",
+                              },
+                              "timeout": "5s",
+                            },
+                          },
+                          {
+                            "decorator": {
+                              "operation": "usersController.deleteItem",
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "name": ":method",
+                                  "string_match": {
+                                    "exact": "DELETE",
+                                  },
+                                },
+                              ],
+                              "safe_regex": {
+                                "regex": "/users/[^/]+",
+                              },
+                            },
+                            "name": "usersController.deleteItem",
+                            "route": {
+                              "cluster": "users-service",
+                              "prefix_rewrite": "/",
+                              "timeout": "3s",
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  "stat_prefix": "users-api",
+                },
+              },
+            ],
+          },
+        ],
+        "name": "listener_0",
+      },
+    ],
+  },
+}
+`;
+
+exports[`renderEnvoyConfig > matches the YAML snapshot for the fixture manifest 1`] = `
+"static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: users-api
+                route_config:
+                  name: users-api_routes
+                  virtual_hosts:
+                    - name: users-api
+                      domains:
+                        - "*"
+                      routes:
+                        - name: usersController.createItem
+                          match:
+                            safe_regex:
+                              regex: /users
+                            headers:
+                              - name: :method
+                                string_match:
+                                  exact: POST
+                          route:
+                            cluster: users-service
+                            timeout: 5s
+                          request_headers_to_add:
+                            - header:
+                                key: x-internal
+                                value: "true"
+                          request_headers_to_remove:
+                            - cookie
+                          response_headers_to_remove:
+                            - server
+                        - name: usersController.getItem
+                          match:
+                            safe_regex:
+                              regex: /users/[^/]+
+                            headers:
+                              - name: :method
+                                string_match:
+                                  exact: GET
+                              - name: x-trace-id
+                                string_match:
+                                  safe_regex:
+                                    regex: ^[a-f0-9]+$
+                              - name: x-tenant-id
+                                string_match:
+                                  prefix: t_
+                            query_parameters:
+                              - name: include
+                                string_match:
+                                  exact: profile
+                          route:
+                            cluster: users-service
+                            timeout: 5s
+                            retry_policy:
+                              num_retries: 2
+                              retry_on: 5xx,connect-failure
+                              per_try_timeout: 2s
+                        - name: usersController.deleteItem
+                          match:
+                            safe_regex:
+                              regex: /users/[^/]+
+                            headers:
+                              - name: :method
+                                string_match:
+                                  exact: DELETE
+                          route:
+                            cluster: users-service
+                            timeout: 3s
+                            prefix_rewrite: /
+                          decorator:
+                            operation: usersController.deleteItem
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: users-service
+      type: STRICT_DNS
+      connect_timeout: 1s
+      load_assignment:
+        cluster_name: users-service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: users
+                      port_value: 8081
+"
+`;

--- a/packages/gateway-envoy/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-envoy/src/__snapshots__/render.spec.ts.snap
@@ -162,7 +162,6 @@ exports[`renderEnvoyConfig > matches the JSON snapshot for the fixture manifest 
                             "name": "usersController.deleteItem",
                             "route": {
                               "cluster": "users-service",
-                              "prefix_rewrite": "/",
                               "timeout": "3s",
                             },
                           },
@@ -260,7 +259,6 @@ exports[`renderEnvoyConfig > matches the YAML snapshot for the fixture manifest 
                           route:
                             cluster: users-service
                             timeout: 3s
-                            prefix_rewrite: /
                           decorator:
                             operation: usersController.deleteItem
                 http_filters:

--- a/packages/gateway-envoy/src/durations.ts
+++ b/packages/gateway-envoy/src/durations.ts
@@ -1,0 +1,21 @@
+/**
+ * Convert a universal duration string ("5s", "300ms", "1m", "2h") to the
+ * Envoy `Duration` format: `"<seconds>s"` or `"0.<fraction>s"`.
+ *
+ * Envoy accepts decimal seconds with `s` suffix in YAML/JSON config — this is
+ * the simplest portable representation that works for both `route.timeout` and
+ * `retry_policy.per_try_timeout` etc.
+ */
+export function toEnvoyDuration(input: string): string {
+  const match = /^(\d+)(ms|s|m|h)$/.exec(input)
+  if (!match) {
+    throw new Error(`Unsupported duration "${input}" — expected formats like "5s", "300ms".`)
+  }
+  const value = Number(match[1])
+  const unit = match[2]
+  const seconds =
+    unit === 'ms' ? value / 1000 : unit === 's' ? value : unit === 'm' ? value * 60 : value * 3600
+  // Envoy accepts decimal seconds; trim trailing zeros to keep snapshots tidy.
+  const formatted = Number.isInteger(seconds) ? String(seconds) : seconds.toString()
+  return `${formatted}s`
+}

--- a/packages/gateway-envoy/src/index.ts
+++ b/packages/gateway-envoy/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  type EnvoyAdminOptions,
   type EnvoyClusterOptions,
   type EnvoyConfigShape,
   type EnvoyOptions,

--- a/packages/gateway-envoy/src/index.ts
+++ b/packages/gateway-envoy/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  type EnvoyClusterOptions,
+  type EnvoyConfigShape,
+  type EnvoyOptions,
+  type RenderEnvoyResult,
+  renderEnvoyConfig,
+} from './render.ts'

--- a/packages/gateway-envoy/src/pathMatch.ts
+++ b/packages/gateway-envoy/src/pathMatch.ts
@@ -1,0 +1,26 @@
+/**
+ * Convert an OpenAPI-style path (`/users/{userId}`) to an Envoy
+ * `safe_regex` pattern. Envoy doesn't natively support `{param}` segments —
+ * each one becomes a non-slash regex capture so the route matches exactly the
+ * same set of paths the contract intended.
+ *
+ * `{wildcard}` (the marker we emit for Fastify `*`) is rendered as `.*`.
+ */
+export function openApiPathToEnvoyRegex(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error(`Path must start with "/": ${path}`)
+  }
+  return path
+    .split('/')
+    .map((segment) => {
+      if (segment === '{wildcard}') return '.*'
+      const param = /^\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(segment)
+      if (param) return '[^/]+'
+      return escapeRegex(segment)
+    })
+    .join('/')
+}
+
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/gateway-envoy/src/render.spec.ts
+++ b/packages/gateway-envoy/src/render.spec.ts
@@ -47,4 +47,20 @@ describe('renderEnvoyConfig', () => {
     const { json } = renderEnvoyConfig(fixtureManifest, options)
     expect(json.static_resources.clusters.map((c) => c.name)).toEqual(['users-service'])
   })
+
+  it('emits no admin block by default (opt-in)', () => {
+    const { json } = renderEnvoyConfig(fixtureManifest, options)
+    expect(json.admin).toBeUndefined()
+  })
+
+  it('emits an admin block when options.admin is provided', () => {
+    const { json } = renderEnvoyConfig(fixtureManifest, {
+      ...options,
+      admin: { port: 9901, accessLogPath: '/tmp/envoy-admin.log' },
+    })
+    expect(json.admin).toEqual({
+      access_log_path: '/tmp/envoy-admin.log',
+      address: { socket_address: { address: '0.0.0.0', port_value: 9901 } },
+    })
+  })
 })

--- a/packages/gateway-envoy/src/render.spec.ts
+++ b/packages/gateway-envoy/src/render.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { fixtureManifest } from './__fixtures__/manifest.fixture.ts'
+import { renderEnvoyConfig } from './render.ts'
+
+describe('renderEnvoyConfig', () => {
+  const options = {
+    listenPort: 8080,
+    clusters: { 'users-service': { hosts: ['users:8081'] } },
+  }
+
+  it('matches the YAML snapshot for the fixture manifest', () => {
+    const { yaml } = renderEnvoyConfig(fixtureManifest, options)
+    expect(yaml).toMatchSnapshot()
+  })
+
+  it('matches the JSON snapshot for the fixture manifest', () => {
+    const { json } = renderEnvoyConfig(fixtureManifest, options)
+    expect(json).toMatchSnapshot()
+  })
+
+  it('reports unsupported metadata fields as warnings rather than dropping silently', () => {
+    const { warnings } = renderEnvoyConfig(fixtureManifest, options)
+    // The fixture exercises cache (unsupported in v1) — should appear in warnings.
+    expect(warnings.some((w) => w.includes('cache'))).toBe(true)
+  })
+
+  it('throws when an upstream is referenced but no hosts are configured', () => {
+    expect(() => renderEnvoyConfig(fixtureManifest, { listenPort: 8080, clusters: {} })).toThrow(
+      /upstream "users-service"/,
+    )
+  })
+
+  it('throws when a route has no upstream', () => {
+    const noUpstream = {
+      ...fixtureManifest,
+      routes: [
+        {
+          ...(fixtureManifest.routes[0] as (typeof fixtureManifest.routes)[number]),
+          metadata: {},
+        },
+      ],
+    }
+    expect(() => renderEnvoyConfig(noUpstream, options)).toThrow(/has no upstream/)
+  })
+
+  it('clusters are deduplicated and sorted by name', () => {
+    const { json } = renderEnvoyConfig(fixtureManifest, options)
+    expect(json.static_resources.clusters.map((c) => c.name)).toEqual(['users-service'])
+  })
+})

--- a/packages/gateway-envoy/src/render.ts
+++ b/packages/gateway-envoy/src/render.ts
@@ -1,0 +1,371 @@
+import type {
+  GatewayManifest,
+  GatewayManifestRoute,
+  GatewayMetadataValue,
+} from 'opinionated-machine'
+import { stringify as stringifyYaml } from 'yaml'
+import { toEnvoyDuration } from './durations.ts'
+import { openApiPathToEnvoyRegex } from './pathMatch.ts'
+
+export type EnvoyClusterOptions = {
+  /** Resolved hostnames (or `host:port`) that the cluster proxies to. */
+  hosts: string[]
+  /** Optional connect timeout for the cluster. Defaults to 1s. */
+  connectTimeout?: string
+}
+
+export type EnvoyOptions = {
+  /** Listener port (Envoy's HCM listens on 0.0.0.0:<listenPort>). */
+  listenPort: number
+  /** Map from `metadata.upstream` to actual cluster hosts. */
+  clusters: Record<string, EnvoyClusterOptions>
+  /** Optional name for the listener; defaults to "listener_0". */
+  listenerName?: string
+  /** Optional name for the route_config; defaults to "<service>_routes". */
+  routeConfigName?: string
+}
+
+export type RenderEnvoyResult = {
+  yaml: string
+  json: EnvoyConfigShape
+  warnings: string[]
+}
+
+/**
+ * Render an Envoy v3 static bootstrap config from a gateway manifest.
+ *
+ * Maps a curated subset of universal metadata fields. Anything we can't
+ * express (e.g. `cache.ttl` — Envoy needs an external HTTP cache filter) is
+ * reported as a warning rather than silently dropped.
+ */
+export function renderEnvoyConfig(
+  manifest: GatewayManifest,
+  options: EnvoyOptions,
+): RenderEnvoyResult {
+  const warnings: string[] = []
+  const usedClusters = new Set<string>()
+  const envoyRoutes = manifest.routes.map((route) => buildRoute(route, warnings, usedClusters))
+
+  // Validate that every referenced cluster has hosts configured.
+  for (const cluster of usedClusters) {
+    if (!options.clusters[cluster]) {
+      throw new Error(
+        `Manifest references upstream "${cluster}" but no hosts were configured in EnvoyOptions.clusters.`,
+      )
+    }
+  }
+
+  const config: EnvoyConfigShape = {
+    static_resources: {
+      listeners: [
+        {
+          name: options.listenerName ?? 'listener_0',
+          address: {
+            socket_address: { address: '0.0.0.0', port_value: options.listenPort },
+          },
+          filter_chains: [
+            {
+              filters: [
+                {
+                  name: 'envoy.filters.network.http_connection_manager',
+                  typed_config: {
+                    '@type':
+                      'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
+                    stat_prefix: manifest.service,
+                    route_config: {
+                      name: options.routeConfigName ?? `${manifest.service}_routes`,
+                      virtual_hosts: [
+                        {
+                          name: manifest.service,
+                          domains: ['*'],
+                          routes: envoyRoutes,
+                        },
+                      ],
+                    },
+                    http_filters: [
+                      { name: 'envoy.filters.http.router', typed_config: ROUTER_CONFIG },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      clusters: Array.from(usedClusters)
+        .sort()
+        .map((name) => buildCluster(name, options.clusters[name] as EnvoyClusterOptions)),
+    },
+  }
+
+  return {
+    yaml: stringifyYaml(config, { indent: 2 }),
+    json: config,
+    warnings,
+  }
+}
+
+const ROUTER_CONFIG = {
+  '@type': 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router',
+}
+
+const UNSUPPORTED_FIELDS: Array<{
+  field: keyof GatewayMetadataValue
+  detail: string
+  predicate?: (meta: GatewayMetadataValue) => boolean
+}> = [
+  {
+    field: 'cache',
+    detail: 'Envoy needs the http_cache filter (out of scope for v1)',
+  },
+  {
+    field: 'circuitBreaker',
+    detail: 'applied at the cluster level; v1 emits the route only',
+  },
+  {
+    field: 'auth',
+    detail: 'wire envoy.filters.http.jwt_authn manually if needed',
+    predicate: (meta) => meta.auth?.jwt !== undefined,
+  },
+  {
+    field: 'cors',
+    detail: 'wire envoy.filters.http.cors manually if needed',
+  },
+  {
+    field: 'rateLimit',
+    detail: 'wire envoy.filters.http.local_ratelimit if needed',
+  },
+]
+
+function collectUnsupportedWarnings(
+  routeId: string,
+  meta: GatewayMetadataValue,
+  warnings: string[],
+): void {
+  for (const { field, detail, predicate } of UNSUPPORTED_FIELDS) {
+    const present = predicate ? predicate(meta) : meta[field] !== undefined
+    if (present) {
+      warnings.push(`Route "${routeId}": metadata.${field} is not mapped in v1 — ${detail}.`)
+    }
+  }
+}
+
+function buildRouteAction(meta: GatewayMetadataValue, upstream: string): EnvoyRouteAction {
+  return {
+    cluster: upstream,
+    ...(meta.timeouts?.request !== undefined
+      ? { timeout: toEnvoyDuration(meta.timeouts.request) }
+      : {}),
+    ...(meta.rewrite?.stripPrefix !== undefined ? { prefix_rewrite: '/' } : {}),
+    ...(meta.retry ? { retry_policy: buildRetryPolicy(meta.retry) } : {}),
+  }
+}
+
+function buildRouteHeaderRules(meta: GatewayMetadataValue): {
+  request_headers_to_add?: EnvoyHeaderAddition[]
+  request_headers_to_remove?: string[]
+  response_headers_to_add?: EnvoyHeaderAddition[]
+  response_headers_to_remove?: string[]
+} {
+  const requestHeadersToAdd = collectHeaderAdditions(meta.headers?.request?.add)
+  const responseHeadersToAdd = collectHeaderAdditions(meta.headers?.response?.add)
+  return {
+    ...(requestHeadersToAdd.length > 0 ? { request_headers_to_add: requestHeadersToAdd } : {}),
+    ...(meta.headers?.request?.remove?.length
+      ? { request_headers_to_remove: meta.headers.request.remove }
+      : {}),
+    ...(responseHeadersToAdd.length > 0 ? { response_headers_to_add: responseHeadersToAdd } : {}),
+    ...(meta.headers?.response?.remove?.length
+      ? { response_headers_to_remove: meta.headers.response.remove }
+      : {}),
+  }
+}
+
+function buildRoute(
+  route: GatewayManifestRoute,
+  warnings: string[],
+  usedClusters: Set<string>,
+): EnvoyRoute {
+  const meta = route.metadata
+  if (!meta.upstream) {
+    throw new Error(
+      `Route "${route.id}" has no upstream — set metadata.upstream on the route or controller defaults.`,
+    )
+  }
+  usedClusters.add(meta.upstream)
+
+  collectUnsupportedWarnings(route.id, meta, warnings)
+
+  const headerMatchers = collectHeaderMatchers(route.method, meta)
+  const queryMatchers = collectQueryMatchers(meta)
+
+  const r: EnvoyRoute = {
+    name: route.id,
+    match: {
+      safe_regex: { regex: openApiPathToEnvoyRegex(route.path) },
+      ...(headerMatchers.length > 0 ? { headers: headerMatchers } : {}),
+      ...(queryMatchers.length > 0 ? { query_parameters: queryMatchers } : {}),
+    },
+    route: buildRouteAction(meta, meta.upstream),
+    ...buildRouteHeaderRules(meta),
+  }
+
+  // Vendor-specific extension: deep-merge envoy escape hatch into the route at the end.
+  const envoyExt = meta.extensions?.envoy as Record<string, unknown> | undefined
+  if (envoyExt) {
+    Object.assign(r, envoyExt)
+  }
+
+  return r
+}
+
+function buildCluster(name: string, opts: EnvoyClusterOptions): EnvoyCluster {
+  return {
+    name,
+    type: 'STRICT_DNS',
+    connect_timeout: toEnvoyDuration(opts.connectTimeout ?? '1s'),
+    load_assignment: {
+      cluster_name: name,
+      endpoints: [
+        {
+          lb_endpoints: opts.hosts.map((host) => {
+            const [address, portStr] = host.split(':')
+            return {
+              endpoint: {
+                address: {
+                  socket_address: {
+                    address: address as string,
+                    port_value: portStr ? Number(portStr) : 80,
+                  },
+                },
+              },
+            }
+          }),
+        },
+      ],
+    },
+  }
+}
+
+function buildRetryPolicy(retry: NonNullable<GatewayMetadataValue['retry']>): EnvoyRetryPolicy {
+  const onMap: Record<string, string> = {
+    '5xx': '5xx',
+    'gateway-error': 'gateway-error',
+    'connect-failure': 'connect-failure',
+    reset: 'reset',
+    'retriable-4xx': 'retriable-4xx',
+  }
+  return {
+    ...(retry.attempts !== undefined ? { num_retries: retry.attempts } : {}),
+    ...(retry.on?.length ? { retry_on: retry.on.map((c) => onMap[c] ?? c).join(',') } : {}),
+    ...(retry.perTryTimeout ? { per_try_timeout: toEnvoyDuration(retry.perTryTimeout) } : {}),
+  }
+}
+
+function collectHeaderMatchers(method: string, meta: GatewayMetadataValue): EnvoyHeaderMatcher[] {
+  const matchers: EnvoyHeaderMatcher[] = [{ name: ':method', string_match: { exact: method } }]
+  const headers = { ...(meta.match?.headers ?? {}), ...(meta.match?.customHeaders ?? {}) }
+  for (const [name, rule] of Object.entries(headers)) {
+    matchers.push({ name, string_match: matchRuleToEnvoy(rule) })
+  }
+  return matchers
+}
+
+function collectQueryMatchers(meta: GatewayMetadataValue): EnvoyQueryMatcher[] {
+  const merged = { ...(meta.match?.query ?? {}), ...(meta.match?.customQuery ?? {}) }
+  return Object.entries(merged).map(([name, rule]) => ({
+    name,
+    string_match: matchRuleToEnvoy(rule),
+  }))
+}
+
+function matchRuleToEnvoy(
+  rule: NonNullable<GatewayMetadataValue['match']>['headers'] extends infer T
+    ? T extends Record<string, infer V>
+      ? V
+      : never
+    : never,
+): EnvoyStringMatch {
+  if (typeof rule === 'string') return { exact: rule }
+  if ('exact' in rule) return { exact: rule.exact }
+  if ('prefix' in rule) return { prefix: rule.prefix }
+  return { safe_regex: { regex: rule.regex } }
+}
+
+function collectHeaderAdditions(add: Record<string, string> | undefined): EnvoyHeaderAddition[] {
+  if (!add) return []
+  return Object.entries(add).map(([key, value]) => ({
+    header: { key, value },
+  }))
+}
+
+// ============================================================================
+// Type definitions for the Envoy bootstrap subset we emit. Kept narrow on
+// purpose — we don't try to model all of envoy.config.v3, only what we render.
+// ============================================================================
+
+type EnvoyStringMatch = { exact: string } | { prefix: string } | { safe_regex: { regex: string } }
+
+type EnvoyHeaderMatcher = { name: string; string_match: EnvoyStringMatch }
+type EnvoyQueryMatcher = { name: string; string_match: EnvoyStringMatch }
+
+type EnvoyHeaderAddition = { header: { key: string; value: string } }
+
+type EnvoyRetryPolicy = {
+  num_retries?: number
+  retry_on?: string
+  per_try_timeout?: string
+}
+
+type EnvoyRouteAction = {
+  cluster: string
+  timeout?: string
+  prefix_rewrite?: string
+  retry_policy?: EnvoyRetryPolicy
+}
+
+type EnvoyRoute = {
+  name: string
+  match: {
+    safe_regex: { regex: string }
+    headers?: EnvoyHeaderMatcher[]
+    query_parameters?: EnvoyQueryMatcher[]
+  }
+  route: EnvoyRouteAction
+  request_headers_to_add?: EnvoyHeaderAddition[]
+  request_headers_to_remove?: string[]
+  response_headers_to_add?: EnvoyHeaderAddition[]
+  response_headers_to_remove?: string[]
+}
+
+type EnvoyCluster = {
+  name: string
+  type: 'STRICT_DNS'
+  connect_timeout: string
+  load_assignment: {
+    cluster_name: string
+    endpoints: Array<{
+      lb_endpoints: Array<{
+        endpoint: {
+          address: { socket_address: { address: string; port_value: number } }
+        }
+      }>
+    }>
+  }
+}
+
+export type EnvoyConfigShape = {
+  static_resources: {
+    listeners: Array<{
+      name: string
+      address: { socket_address: { address: string; port_value: number } }
+      filter_chains: Array<{
+        filters: Array<{
+          name: string
+          typed_config: Record<string, unknown>
+        }>
+      }>
+    }>
+    clusters: EnvoyCluster[]
+  }
+}

--- a/packages/gateway-envoy/src/render.ts
+++ b/packages/gateway-envoy/src/render.ts
@@ -62,11 +62,19 @@ export function renderEnvoyConfig(
   const usedClusters = new Set<string>()
   const envoyRoutes = manifest.routes.map((route) => buildRoute(route, warnings, usedClusters))
 
-  // Validate that every referenced cluster has hosts configured.
+  // Validate that every referenced cluster has hosts configured. An empty
+  // hosts array would render a cluster with no endpoints, making every
+  // matching route unroutable at runtime; treat that as a hard error.
   for (const cluster of usedClusters) {
-    if (!options.clusters[cluster]) {
+    const clusterOptions = options.clusters[cluster]
+    if (!clusterOptions) {
       throw new Error(
         `Manifest references upstream "${cluster}" but no hosts were configured in EnvoyOptions.clusters.`,
+      )
+    }
+    if (clusterOptions.hosts.length === 0) {
+      throw new Error(
+        `Cluster "${cluster}" was configured with an empty hosts array — every route mapped to this upstream would have no endpoints.`,
       )
     }
   }
@@ -281,13 +289,35 @@ function buildRoute(
     ...buildRouteHeaderRules(meta),
   }
 
-  // Vendor-specific extension: deep-merge envoy escape hatch into the route at the end.
+  // Vendor-specific extension: deep-merge the envoy escape hatch onto the
+  // generated route. Shallow assignment would let common patterns like
+  // `extensions.envoy.route = { regex_rewrite: {...} }` clobber the entire
+  // generated `route` object (including cluster, timeout, retry_policy);
+  // we merge nested objects recursively instead.
   const envoyExt = meta.extensions?.envoy as Record<string, unknown> | undefined
   if (envoyExt) {
-    Object.assign(r, envoyExt)
+    deepMergeInto(r as Record<string, unknown>, envoyExt)
   }
 
   return r
+}
+
+function deepMergeInto(target: Record<string, unknown>, source: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(source)) {
+    const existing = target[key]
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      existing &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+    ) {
+      deepMergeInto(existing as Record<string, unknown>, value as Record<string, unknown>)
+    } else {
+      target[key] = value
+    }
+  }
 }
 
 function buildCluster(name: string, opts: EnvoyClusterOptions): EnvoyCluster {

--- a/packages/gateway-envoy/src/render.ts
+++ b/packages/gateway-envoy/src/render.ts
@@ -2,6 +2,7 @@ import type {
   GatewayManifest,
   GatewayManifestRoute,
   GatewayMetadataValue,
+  MatchRule,
 } from 'opinionated-machine'
 import { stringify as stringifyYaml } from 'yaml'
 import { toEnvoyDuration } from './durations.ts'
@@ -109,31 +110,78 @@ const ROUTER_CONFIG = {
   '@type': 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router',
 }
 
-const UNSUPPORTED_FIELDS: Array<{
-  field: keyof GatewayMetadataValue
+type UnsupportedFieldWarning = {
   detail: string
-  predicate?: (meta: GatewayMetadataValue) => boolean
-}> = [
+  /** Returns true if the metadata triggers this warning. */
+  triggers: (meta: GatewayMetadataValue) => boolean
+}
+
+const UNSUPPORTED_FIELDS: Array<{ name: string } & UnsupportedFieldWarning> = [
   {
-    field: 'cache',
-    detail: 'Envoy needs the http_cache filter (out of scope for v1)',
+    name: 'cache',
+    triggers: (m) => m.cache !== undefined,
+    detail:
+      'Envoy needs the http_cache filter wired into the listener — set extensions.envoy on the route to attach typed_per_filter_config.',
   },
   {
-    field: 'circuitBreaker',
-    detail: 'applied at the cluster level; v1 emits the route only',
+    name: 'circuitBreaker',
+    triggers: (m) => m.circuitBreaker !== undefined,
+    detail:
+      'applies at the cluster level (cluster.circuit_breakers.thresholds[]) — set it via extensions.envoy on a representative route or configure the cluster manually.',
   },
   {
-    field: 'auth',
-    detail: 'wire envoy.filters.http.jwt_authn manually if needed',
-    predicate: (meta) => meta.auth?.jwt !== undefined,
+    name: 'auth.jwt',
+    triggers: (m) => m.auth?.jwt !== undefined,
+    detail:
+      'wire envoy.filters.http.jwt_authn into the listener and reference the provider via extensions.envoy.typed_per_filter_config.',
   },
   {
-    field: 'cors',
-    detail: 'wire envoy.filters.http.cors manually if needed',
+    name: 'auth.required (without auth.jwt)',
+    triggers: (m) => Boolean(m.auth?.required) && !m.auth?.jwt,
+    detail:
+      'has no automatic Envoy mapping — wire an authn filter (jwt_authn, ext_authz) on the listener.',
   },
   {
-    field: 'rateLimit',
-    detail: 'wire envoy.filters.http.local_ratelimit if needed',
+    name: 'auth.mTLS',
+    triggers: (m) => Boolean(m.auth?.mTLS),
+    detail:
+      'mTLS is configured at the listener / transport socket — set it on the listener, not per route.',
+  },
+  {
+    name: 'cors',
+    triggers: (m) => m.cors !== undefined,
+    detail:
+      'wire envoy.filters.http.cors into the listener and attach typed_per_filter_config via extensions.envoy.',
+  },
+  {
+    name: 'rateLimit',
+    triggers: (m) => m.rateLimit !== undefined,
+    detail:
+      'wire envoy.filters.http.local_ratelimit and attach the per-route policy via extensions.envoy.typed_per_filter_config.',
+  },
+  {
+    name: 'traffic.weights',
+    triggers: (m) => Array.isArray(m.traffic?.weights) && m.traffic.weights.length > 0,
+    detail:
+      'use envoy weighted_clusters — set it explicitly via extensions.envoy.route.weighted_clusters.',
+  },
+  {
+    name: 'traffic.shadow',
+    triggers: (m) => m.traffic?.shadow !== undefined,
+    detail:
+      'use envoy request_mirror_policies — set it via extensions.envoy.route.request_mirror_policies.',
+  },
+  {
+    name: 'match.host',
+    triggers: (m) => m.match?.host !== undefined,
+    detail:
+      'host routing belongs at the virtual_host level (domains) rather than per route — configure it on the listener.',
+  },
+  {
+    name: 'rewrite',
+    triggers: (m) => m.rewrite?.stripPrefix !== undefined || m.rewrite?.replacePrefix !== undefined,
+    detail:
+      'envoy needs regex_rewrite for our parameterised paths (prefix_rewrite only works with prefix matchers) — set it explicitly via extensions.envoy.route.regex_rewrite.',
   },
 ]
 
@@ -142,10 +190,9 @@ function collectUnsupportedWarnings(
   meta: GatewayMetadataValue,
   warnings: string[],
 ): void {
-  for (const { field, detail, predicate } of UNSUPPORTED_FIELDS) {
-    const present = predicate ? predicate(meta) : meta[field] !== undefined
-    if (present) {
-      warnings.push(`Route "${routeId}": metadata.${field} is not mapped in v1 — ${detail}.`)
+  for (const { name, triggers, detail } of UNSUPPORTED_FIELDS) {
+    if (triggers(meta)) {
+      warnings.push(`Route "${routeId}": metadata.${name} is not mapped — ${detail}`)
     }
   }
 }
@@ -156,7 +203,6 @@ function buildRouteAction(meta: GatewayMetadataValue, upstream: string): EnvoyRo
     ...(meta.timeouts?.request !== undefined
       ? { timeout: toEnvoyDuration(meta.timeouts.request) }
       : {}),
-    ...(meta.rewrite?.stripPrefix !== undefined ? { prefix_rewrite: '/' } : {}),
     ...(meta.retry ? { retry_policy: buildRetryPolicy(meta.retry) } : {}),
   }
 }
@@ -248,16 +294,12 @@ function buildCluster(name: string, opts: EnvoyClusterOptions): EnvoyCluster {
 }
 
 function buildRetryPolicy(retry: NonNullable<GatewayMetadataValue['retry']>): EnvoyRetryPolicy {
-  const onMap: Record<string, string> = {
-    '5xx': '5xx',
-    'gateway-error': 'gateway-error',
-    'connect-failure': 'connect-failure',
-    reset: 'reset',
-    'retriable-4xx': 'retriable-4xx',
-  }
+  // The retry-condition vocabulary already matches Envoy's retry_on values
+  // (5xx, gateway-error, connect-failure, reset, retriable-4xx) so they
+  // pass through as a CSV.
   return {
     ...(retry.attempts !== undefined ? { num_retries: retry.attempts } : {}),
-    ...(retry.on?.length ? { retry_on: retry.on.map((c) => onMap[c] ?? c).join(',') } : {}),
+    ...(retry.on?.length ? { retry_on: retry.on.join(',') } : {}),
     ...(retry.perTryTimeout ? { per_try_timeout: toEnvoyDuration(retry.perTryTimeout) } : {}),
   }
 }
@@ -279,13 +321,7 @@ function collectQueryMatchers(meta: GatewayMetadataValue): EnvoyQueryMatcher[] {
   }))
 }
 
-function matchRuleToEnvoy(
-  rule: NonNullable<GatewayMetadataValue['match']>['headers'] extends infer T
-    ? T extends Record<string, infer V>
-      ? V
-      : never
-    : never,
-): EnvoyStringMatch {
+function matchRuleToEnvoy(rule: MatchRule): EnvoyStringMatch {
   if (typeof rule === 'string') return { exact: rule }
   if ('exact' in rule) return { exact: rule.exact }
   if ('prefix' in rule) return { prefix: rule.prefix }

--- a/packages/gateway-envoy/src/render.ts
+++ b/packages/gateway-envoy/src/render.ts
@@ -15,6 +15,15 @@ export type EnvoyClusterOptions = {
   connectTimeout?: string
 }
 
+export type EnvoyAdminOptions = {
+  /** Bind address; defaults to '0.0.0.0'. */
+  address?: string
+  /** Bind port (e.g. 9901). */
+  port: number
+  /** Optional access-log path; omit to skip. */
+  accessLogPath?: string
+}
+
 export type EnvoyOptions = {
   /** Listener port (Envoy's HCM listens on 0.0.0.0:<listenPort>). */
   listenPort: number
@@ -24,6 +33,12 @@ export type EnvoyOptions = {
   listenerName?: string
   /** Optional name for the route_config; defaults to "<service>_routes". */
   routeConfigName?: string
+  /**
+   * Optional admin listener config. Off by default. When set, Envoy exposes
+   * its admin interface (/ready, /stats, /clusters, /config_dump) on the
+   * given port — usually 9901 in production deployments.
+   */
+  admin?: EnvoyAdminOptions
 }
 
 export type RenderEnvoyResult = {
@@ -57,6 +72,7 @@ export function renderEnvoyConfig(
   }
 
   const config: EnvoyConfigShape = {
+    ...(options.admin ? { admin: buildAdmin(options.admin) } : {}),
     static_resources: {
       listeners: [
         {
@@ -108,6 +124,15 @@ export function renderEnvoyConfig(
 
 const ROUTER_CONFIG = {
   '@type': 'type.googleapis.com/envoy.extensions.filters.http.router.v3.Router',
+}
+
+function buildAdmin(opts: EnvoyAdminOptions): EnvoyAdminConfig {
+  return {
+    ...(opts.accessLogPath ? { access_log_path: opts.accessLogPath } : {}),
+    address: {
+      socket_address: { address: opts.address ?? '0.0.0.0', port_value: opts.port },
+    },
+  }
 }
 
 type UnsupportedFieldWarning = {
@@ -390,7 +415,13 @@ type EnvoyCluster = {
   }
 }
 
+type EnvoyAdminConfig = {
+  access_log_path?: string
+  address: { socket_address: { address: string; port_value: number } }
+}
+
 export type EnvoyConfigShape = {
+  admin?: EnvoyAdminConfig
   static_resources: {
     listeners: Array<{
       name: string

--- a/packages/gateway-envoy/tsconfig.build.json
+++ b/packages/gateway-envoy/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"],
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/__fixtures__/**", "**/__snapshots__/**"]
+}

--- a/packages/gateway-envoy/tsconfig.json
+++ b/packages/gateway-envoy/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "declaration": true,
+        "declarationMap": true,
+        "noEmit": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/gateway-envoy/vitest.acceptance.config.ts
+++ b/packages/gateway-envoy/vitest.acceptance.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Acceptance suite — runs only via `npm run test:acceptance`, which boots
+ * docker compose with a real Envoy and stub upstream. Kept in a separate
+ * config so the default `vitest run` (used by `npm test`) never picks them up.
+ */
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['acceptance/**/*.acceptance.spec.ts'],
+    // Acceptance traffic includes 2s timeout assertions and container startup; allow generous time.
+    testTimeout: 30000,
+  },
+})

--- a/packages/gateway-envoy/vitest.config.ts
+++ b/packages/gateway-envoy/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    testTimeout: 10000,
+  },
+})

--- a/packages/gateway-kong/README.md
+++ b/packages/gateway-kong/README.md
@@ -1,79 +1,85 @@
 # @opinionated-machine/gateway-kong
 
-Kong (DB-less / declarative) config generator for
-[opinionated-machine](https://github.com/kibertoad/opinionated-machine) gateway
-manifests.
-
-## Install
+Generate a Kong (DB-less / declarative) config from your
+[opinionated-machine](https://github.com/kibertoad/opinionated-machine) routes.
+Annotate routes once with rate-limits / cache / JWT / etc., then run this
+generator at build time and deploy the resulting `kong.yaml`.
 
 ```sh
-npm install @opinionated-machine/gateway-kong
+npm install --save-dev @opinionated-machine/gateway-kong
 ```
 
 `opinionated-machine` is a peer dependency.
 
-## Usage
+## Use it
 
 ```ts
+// bin/render-kong.ts
 import { writeFileSync } from 'node:fs'
 import { renderKongConfig } from '@opinionated-machine/gateway-kong'
+import { buildContext } from '../src/diContext.ts'   // your DIContext factory
 
-const manifest = context.buildGatewayManifest({ service: 'users-api' })
+const ctx = await buildContext()
+const manifest = ctx.buildGatewayManifest({ service: 'users-api' })
 
-const { yaml, json, warnings } = renderKongConfig(manifest, {
+const { yaml, warnings } = renderKongConfig(manifest, {
   upstreams: {
     'users-service': { url: 'http://users:8081', retries: 2 },
   },
 })
 
 writeFileSync('kong.yaml', yaml)
-console.warn(warnings)
+if (warnings.length) console.warn('[kong]', warnings)
 ```
 
-The output is suitable for Kong's DB-less mode (`KONG_DATABASE=off`,
+The output goes straight into Kong's DB-less mode (`KONG_DATABASE=off`,
 `KONG_DECLARATIVE_CONFIG=/etc/kong/kong.yml`).
 
 Routes are grouped into one Kong **service** per `metadata.upstream`. Paths
-with `{param}` segments become regex paths with named captures (`~/users/(?<userId>[^/]+)$`).
+with `{param}` segments become regex paths with named captures —
+`/users/{userId}` becomes `~/users/(?<userId>[^/]+)$`.
 
-## Field mappings
+## How metadata maps to Kong
 
-| `GatewayMetadata` field    | Kong mapping |
-| -------------------------- | ------------ |
-| `upstream`                 | `services[].host`/`port` (resolved via `KongOptions.upstreams`) |
-| `timeouts.request`         | service `read_timeout` (tightest among all routes for that upstream) |
+| Route metadata | Kong output |
+| -------------- | ----------- |
+| `upstream` | `services[].host`/`port`, resolved via `KongOptions.upstreams` |
+| `timeouts.request` | service `read_timeout` (tightest among all routes for that upstream) |
 | `match.headers` / `customHeaders` | route `headers` (exact / `~prefix` / `~regex`) |
-| `rewrite.stripPrefix`      | route `strip_path: true` |
-| `rateLimit`                | `rate-limiting` plugin on the route (`second`/`minute`/`hour`/`day` bucket; `limit_by`) |
-| `cache.ttl`                | `proxy-cache` plugin on the route (`cache_ttl`, `request_method`, `vary_headers`) |
-| `auth.jwt`                 | `jwt` plugin on the route (marker — wire credentials separately) |
-| `cors`                     | promoted to a global `cors` plugin (Kong applies it at the global / service / route level) |
-| `headers.request.add/remove`  | `request-transformer` plugin on the route |
-| `headers.response.add/remove` | `response-transformer` plugin on the route |
-| `extensions.kong`          | shallow-merged onto the route last |
-| `extensions.kong_plugins`  | array of extra plugins appended to the route |
+| `rewrite.stripPrefix` | route `strip_path: true` |
+| `rateLimit` | `rate-limiting` plugin on the route (bucket: `second`/`minute`/`hour`/`day`; `limit_by`) |
+| `cache.ttl` | `proxy-cache` plugin on the route (`cache_ttl`, `request_method`, `vary_headers`) |
+| `auth.jwt` | `jwt` plugin on the route (marker — see "What it doesn't do" below) |
+| `cors` | promoted to a global `cors` plugin |
+| `headers.request.{add,remove}` | `request-transformer` plugin on the route |
+| `headers.response.{add,remove}` | `response-transformer` plugin on the route |
+| `extensions.kong` | shallow-merged onto the route last |
+| `extensions.kong_plugins` | array of extra plugins appended to the route |
 
-## Limitations (v1)
+Kong's plugin system is the natural fit for most of the universal metadata —
+this generator covers more of it natively than the Envoy or KrakenD ones do.
+
+## What it doesn't do
 
 Reported as `warnings[]` on the result:
 
 - `circuitBreaker` — no native equivalent in Kong CE; consider Kong Enterprise
   or a service-mesh layer.
-- `traffic.weights` / `traffic.shadow` — not modelled in v1; configure Kong
+- `traffic.weights` / `traffic.shadow` — not modelled here; configure Kong
   upstreams + targets manually if needed.
-- `auth.jwt` is a plugin **marker**: Kong's JWT plugin looks up keys from
-  consumer credentials, not from a JWKS URI in declarative config. Wire
-  consumers separately.
+- **`auth.jwt` is a marker only.** Kong's JWT plugin reads keys from consumer
+  credentials, not from a JWKS URI in declarative config. The generator emits
+  the plugin so you can wire credentials separately (consumers + jwt_secrets).
 
-## Acceptance tests
+## Verifying generated configs
 
-This package includes a Docker-based acceptance suite that boots Kong (DB-less)
-plus a stub upstream:
+CI boots Kong (DB-less) plus a stub upstream and drives traffic through the
+generated config:
 
 ```sh
 npm run test:acceptance
 ```
 
-Triggered automatically in CI by the
+Requires Docker. Triggered automatically by the
 [`gateway-acceptance`](../../.github/workflows/gateway-acceptance.yml) workflow
 when this package or `lib/gateway/` changes.

--- a/packages/gateway-kong/README.md
+++ b/packages/gateway-kong/README.md
@@ -1,0 +1,79 @@
+# @opinionated-machine/gateway-kong
+
+Kong (DB-less / declarative) config generator for
+[opinionated-machine](https://github.com/kibertoad/opinionated-machine) gateway
+manifests.
+
+## Install
+
+```sh
+npm install @opinionated-machine/gateway-kong
+```
+
+`opinionated-machine` is a peer dependency.
+
+## Usage
+
+```ts
+import { writeFileSync } from 'node:fs'
+import { renderKongConfig } from '@opinionated-machine/gateway-kong'
+
+const manifest = context.buildGatewayManifest({ service: 'users-api' })
+
+const { yaml, json, warnings } = renderKongConfig(manifest, {
+  upstreams: {
+    'users-service': { url: 'http://users:8081', retries: 2 },
+  },
+})
+
+writeFileSync('kong.yaml', yaml)
+console.warn(warnings)
+```
+
+The output is suitable for Kong's DB-less mode (`KONG_DATABASE=off`,
+`KONG_DECLARATIVE_CONFIG=/etc/kong/kong.yml`).
+
+Routes are grouped into one Kong **service** per `metadata.upstream`. Paths
+with `{param}` segments become regex paths with named captures (`~/users/(?<userId>[^/]+)$`).
+
+## Field mappings
+
+| `GatewayMetadata` field    | Kong mapping |
+| -------------------------- | ------------ |
+| `upstream`                 | `services[].host`/`port` (resolved via `KongOptions.upstreams`) |
+| `timeouts.request`         | service `read_timeout` (tightest among all routes for that upstream) |
+| `match.headers` / `customHeaders` | route `headers` (exact / `~prefix` / `~regex`) |
+| `rewrite.stripPrefix`      | route `strip_path: true` |
+| `rateLimit`                | `rate-limiting` plugin on the route (`second`/`minute`/`hour`/`day` bucket; `limit_by`) |
+| `cache.ttl`                | `proxy-cache` plugin on the route (`cache_ttl`, `request_method`, `vary_headers`) |
+| `auth.jwt`                 | `jwt` plugin on the route (marker — wire credentials separately) |
+| `cors`                     | promoted to a global `cors` plugin (Kong applies it at the global / service / route level) |
+| `headers.request.add/remove`  | `request-transformer` plugin on the route |
+| `headers.response.add/remove` | `response-transformer` plugin on the route |
+| `extensions.kong`          | shallow-merged onto the route last |
+| `extensions.kong_plugins`  | array of extra plugins appended to the route |
+
+## Limitations (v1)
+
+Reported as `warnings[]` on the result:
+
+- `circuitBreaker` — no native equivalent in Kong CE; consider Kong Enterprise
+  or a service-mesh layer.
+- `traffic.weights` / `traffic.shadow` — not modelled in v1; configure Kong
+  upstreams + targets manually if needed.
+- `auth.jwt` is a plugin **marker**: Kong's JWT plugin looks up keys from
+  consumer credentials, not from a JWKS URI in declarative config. Wire
+  consumers separately.
+
+## Acceptance tests
+
+This package includes a Docker-based acceptance suite that boots Kong (DB-less)
+plus a stub upstream:
+
+```sh
+npm run test:acceptance
+```
+
+Triggered automatically in CI by the
+[`gateway-acceptance`](../../.github/workflows/gateway-acceptance.yml) workflow
+when this package or `lib/gateway/` changes.

--- a/packages/gateway-kong/README.md
+++ b/packages/gateway-kong/README.md
@@ -59,12 +59,32 @@ with `{param}` segments become regex paths with named captures —
 Kong's plugin system is the natural fit for most of the universal metadata —
 this generator covers more of it natively than the Envoy or KrakenD ones do.
 
+## OSS vs Enterprise
+
+`KongOptions.profile` selects the target distribution. Default `'oss'`.
+
+```ts
+const { yaml } = renderKongConfig(manifest, {
+  upstreams: { 'users-service': { url: 'http://users:8081' } },
+  profile: 'enterprise',         // emit Enterprise-only plugins
+})
+```
+
+| Metadata | OSS profile | Enterprise profile |
+| -------- | ----------- | ------------------ |
+| `auth.mTLS: true` | warning — terminate at the listener | emits the `mtls-auth` plugin on the route |
+
+Other Enterprise plugins (e.g. `rate-limiting-advanced`, governance plugins)
+remain reachable via `extensions.kong_plugins` regardless of profile, so you
+can opt in piecewise.
+
 ## What it doesn't do
 
 Reported as `warnings[]` on the result:
 
-- `circuitBreaker` — no native equivalent in Kong CE; consider Kong Enterprise
-  or a service-mesh layer.
+- `circuitBreaker` — Kong CE has no first-class circuit breaker, and even
+  Kong Enterprise has no first-class plugin for connectivity governance;
+  reach for `extensions.kong_plugins` or a service-mesh layer.
 - `traffic.weights` / `traffic.shadow` — not modelled here; configure Kong
   upstreams + targets manually if needed.
 - **`auth.jwt` is a marker only.** Kong's JWT plugin reads keys from consumer

--- a/packages/gateway-kong/acceptance/kong.acceptance.spec.ts
+++ b/packages/gateway-kong/acceptance/kong.acceptance.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Acceptance tests for the Kong generator. Driven by
+ * `vitest.acceptance.config.ts` — run via `npm run test:acceptance`, which
+ * boots `docker compose` with Kong (DB-less) + a Node stub upstream and runs
+ * this file.
+ *
+ * The CI workflow `gateway-acceptance.yml` triggers it only when this package
+ * or `lib/gateway` changes.
+ */
+const GATEWAY_URL = process.env.GATEWAY_URL ?? 'http://localhost:8000'
+
+describe('kong acceptance', () => {
+  it('routes GET /echo to the upstream', async () => {
+    const res = await fetch(`${GATEWAY_URL}/echo`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { method: string; path: string }
+    expect(body.method).toBe('GET')
+    expect(body.path).toBe('/echo')
+  })
+
+  it('enforces the per-route request timeout', async () => {
+    const res = await fetch(`${GATEWAY_URL}/slow?ms=2000`)
+    // Kong returns 504 (Gateway Timeout) when read_timeout fires.
+    expect(res.status).toBe(504)
+  })
+
+  it('rejects unknown paths with 404', async () => {
+    const res = await fetch(`${GATEWAY_URL}/nope`)
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/gateway-kong/acceptance/kong.acceptance.spec.ts
+++ b/packages/gateway-kong/acceptance/kong.acceptance.spec.ts
@@ -10,10 +10,17 @@ import { describe, expect, it } from 'vitest'
  * or `lib/gateway` changes.
  */
 const GATEWAY_URL = process.env.GATEWAY_URL ?? 'http://localhost:8000'
+// Fail fast if Kong/upstream is unreachable so a hung request can't burn a CI
+// job. The actual HTTP round-trips through the gateway should complete in
+// well under a second.
+const FETCH_TIMEOUT_MS = 10_000
+
+const fetchGateway = (path: string) =>
+  fetch(`${GATEWAY_URL}${path}`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
 
 describe('kong acceptance', () => {
   it('routes GET /echo to the upstream', async () => {
-    const res = await fetch(`${GATEWAY_URL}/echo`)
+    const res = await fetchGateway('/echo')
     expect(res.status).toBe(200)
     const body = (await res.json()) as { method: string; path: string }
     expect(body.method).toBe('GET')
@@ -21,13 +28,13 @@ describe('kong acceptance', () => {
   })
 
   it('enforces the per-route request timeout', async () => {
-    const res = await fetch(`${GATEWAY_URL}/slow?ms=2000`)
+    const res = await fetchGateway('/slow?ms=2000')
     // Kong returns 504 (Gateway Timeout) when read_timeout fires.
     expect(res.status).toBe(504)
   })
 
   it('rejects unknown paths with 404', async () => {
-    const res = await fetch(`${GATEWAY_URL}/nope`)
+    const res = await fetchGateway('/nope')
     expect(res.status).toBe(404)
   })
 })

--- a/packages/gateway-kong/acceptance/manifest.acceptance.mjs
+++ b/packages/gateway-kong/acceptance/manifest.acceptance.mjs
@@ -10,7 +10,9 @@ export const acceptanceManifest = {
       path: '/echo',
       controller: 'echo',
       routeKey: 'get',
-      metadata: { upstream: 'upstream', timeouts: { request: '2s' } },
+      // No request timeout — Kong CE has no per-route timeout override, so
+      // we let /slow's tighter timeout drive the service-level read_timeout.
+      metadata: { upstream: 'upstream' },
     },
     {
       id: 'echo.slow',

--- a/packages/gateway-kong/acceptance/manifest.acceptance.mjs
+++ b/packages/gateway-kong/acceptance/manifest.acceptance.mjs
@@ -1,8 +1,7 @@
-import type { GatewayManifest } from 'opinionated-machine'
-
-export const acceptanceManifest: GatewayManifest = {
+/** @type {import('opinionated-machine').GatewayManifest} */
+export const acceptanceManifest = {
   manifestVersion: '1',
-  service: 'gateway-krakend-acceptance',
+  service: 'gateway-kong-acceptance',
   generatedAt: '2026-05-06T00:00:00.000Z',
   routes: [
     {
@@ -11,10 +10,7 @@ export const acceptanceManifest: GatewayManifest = {
       path: '/echo',
       controller: 'echo',
       routeKey: 'get',
-      metadata: {
-        upstream: 'upstream',
-        timeouts: { request: '2s' },
-      },
+      metadata: { upstream: 'upstream', timeouts: { request: '2s' } },
     },
     {
       id: 'echo.slow',
@@ -22,6 +18,7 @@ export const acceptanceManifest: GatewayManifest = {
       path: '/slow',
       controller: 'echo',
       routeKey: 'slow',
+      // 200ms timeout; the upstream takes 2000ms so Kong should return 504.
       metadata: { upstream: 'upstream', timeouts: { request: '200ms' } },
     },
   ],

--- a/packages/gateway-kong/acceptance/manifest.acceptance.ts
+++ b/packages/gateway-kong/acceptance/manifest.acceptance.ts
@@ -1,0 +1,26 @@
+import type { GatewayManifest } from 'opinionated-machine'
+
+export const acceptanceManifest: GatewayManifest = {
+  manifestVersion: '1',
+  service: 'gateway-kong-acceptance',
+  generatedAt: '2026-05-06T00:00:00.000Z',
+  routes: [
+    {
+      id: 'echo.get',
+      method: 'GET',
+      path: '/echo',
+      controller: 'echo',
+      routeKey: 'get',
+      metadata: { upstream: 'upstream', timeouts: { request: '2s' } },
+    },
+    {
+      id: 'echo.slow',
+      method: 'GET',
+      path: '/slow',
+      controller: 'echo',
+      routeKey: 'slow',
+      // 200ms timeout; the upstream takes 2000ms so Kong should return 504.
+      metadata: { upstream: 'upstream', timeouts: { request: '200ms' } },
+    },
+  ],
+}

--- a/packages/gateway-kong/acceptance/render-config.mjs
+++ b/packages/gateway-kong/acceptance/render-config.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { renderKongConfig } from '../dist/render.js'
-import { acceptanceManifest } from './manifest.acceptance.js'
+import { acceptanceManifest } from './manifest.acceptance.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const outDir = join(__dirname, 'generated')

--- a/packages/gateway-kong/acceptance/render-config.mjs
+++ b/packages/gateway-kong/acceptance/render-config.mjs
@@ -1,0 +1,21 @@
+// Renders the acceptance manifest to a YAML file that docker-compose mounts
+// into the Kong container. Run before `docker compose up`.
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderKongConfig } from '../dist/render.js'
+import { acceptanceManifest } from './manifest.acceptance.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const outDir = join(__dirname, 'generated')
+mkdirSync(outDir, { recursive: true })
+
+const { yaml, warnings } = renderKongConfig(acceptanceManifest, {
+  // The "upstream" name maps to the docker-compose service name.
+  upstreams: { upstream: { url: 'http://upstream:8081' } },
+})
+writeFileSync(join(outDir, 'kong.yaml'), yaml)
+if (warnings.length) {
+  console.warn('[render-config] warnings:', warnings)
+}
+console.log('[render-config] wrote', join(outDir, 'kong.yaml'))

--- a/packages/gateway-kong/acceptance/upstream.mjs
+++ b/packages/gateway-kong/acceptance/upstream.mjs
@@ -1,0 +1,31 @@
+// Minimal upstream stub for acceptance tests.
+//
+// Echoes back the path, method, and select headers; path "/slow" delays the
+// response (driven by ?ms=X) so we can verify gateway timeouts.
+import { createServer } from 'node:http'
+
+const PORT = Number(process.env.PORT ?? 8081)
+
+createServer((req, res) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
+
+  if (url.pathname === '/slow') {
+    const delay = Number(url.searchParams.get('ms') ?? '500')
+    setTimeout(() => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ path: url.pathname, delayedMs: delay }))
+    }, delay)
+    return
+  }
+
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(
+    JSON.stringify({
+      method: req.method,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+    }),
+  )
+}).listen(PORT, () => {
+  console.log(`[upstream] listening on :${PORT}`)
+})

--- a/packages/gateway-kong/docker-compose.yml
+++ b/packages/gateway-kong/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   upstream:
     image: node:20-alpine

--- a/packages/gateway-kong/docker-compose.yml
+++ b/packages/gateway-kong/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  upstream:
+    image: node:20-alpine
+    volumes:
+      - ./acceptance/upstream.mjs:/app/upstream.mjs:ro
+    command: node /app/upstream.mjs
+    environment:
+      PORT: '8081'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8081/']
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+  kong:
+    image: kong:3.7
+    depends_on:
+      upstream:
+        condition: service_healthy
+    volumes:
+      - ./acceptance/generated/kong.yaml:/etc/kong/kong.yml:ro
+    environment:
+      KONG_DATABASE: 'off'
+      KONG_DECLARATIVE_CONFIG: /etc/kong/kong.yml
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+      KONG_ADMIN_LISTEN: '0.0.0.0:8001'
+      KONG_PROXY_LISTEN: '0.0.0.0:8000'
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+    healthcheck:
+      test: ['CMD', 'kong', 'health']
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/packages/gateway-kong/docker-compose.yml
+++ b/packages/gateway-kong/docker-compose.yml
@@ -32,7 +32,10 @@ services:
       - '8000:8000'
       - '8001:8001'
     healthcheck:
+      # Kong ships the `kong health` command in its own image — the canonical
+      # readiness probe.
       test: ['CMD', 'kong', 'health']
       interval: 2s
       timeout: 5s
       retries: 30
+      start_period: 10s

--- a/packages/gateway-kong/package.json
+++ b/packages/gateway-kong/package.json
@@ -1,0 +1,68 @@
+{
+    "name": "@opinionated-machine/gateway-kong",
+    "version": "0.1.0",
+    "description": "Kong (DB-less / declarative) config generator for opinionated-machine gateway manifests",
+    "type": "module",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": "./dist/index.js",
+        "./package.json": "./package.json"
+    },
+    "maintainers": [
+        {
+            "name": "Igor Savin",
+            "email": "kibertoad@gmail.com"
+        }
+    ],
+    "scripts": {
+        "build": "rimraf dist && tsc -p tsconfig.build.json",
+        "lint": "biome check . && tsc",
+        "lint:fix": "biome check --write .",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "acceptance:render": "node acceptance/render-config.mjs",
+        "acceptance:up": "docker compose up -d --wait",
+        "acceptance:down": "docker compose down -v",
+        "test:acceptance": "npm run build && npm run acceptance:render && npm run acceptance:up && vitest run -c vitest.acceptance.config.ts; ec=$?; npm run acceptance:down; exit $ec",
+        "prepublishOnly": "npm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kibertoad/opinionated-machine.git",
+        "directory": "packages/gateway-kong"
+    },
+    "peerDependencies": {
+        "opinionated-machine": ">=6.17.0"
+    },
+    "dependencies": {
+        "yaml": "^2.5.1"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.4.4",
+        "@lokalise/biome-config": "^3.1.1",
+        "@lokalise/tsconfig": "^3.1.0",
+        "@types/node": "^22.19.7",
+        "opinionated-machine": "^6.16.1",
+        "rimraf": "^6.1.2",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+    },
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "keywords": [
+        "kong",
+        "gateway",
+        "generator",
+        "opinionated-machine"
+    ],
+    "homepage": "https://github.com/kibertoad/opinionated-machine/tree/main/packages/gateway-kong",
+    "files": [
+        "README.md",
+        "LICENSE",
+        "dist/*"
+    ]
+}

--- a/packages/gateway-kong/package.json
+++ b/packages/gateway-kong/package.json
@@ -44,7 +44,7 @@
         "@lokalise/biome-config": "^3.1.1",
         "@lokalise/tsconfig": "^3.1.0",
         "@types/node": "^22.19.7",
-        "opinionated-machine": "^6.16.1",
+        "opinionated-machine": "^6.17.0",
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/packages/gateway-kong/src/__fixtures__/manifest.fixture.ts
+++ b/packages/gateway-kong/src/__fixtures__/manifest.fixture.ts
@@ -1,0 +1,55 @@
+import type { GatewayManifest } from 'opinionated-machine'
+
+export const fixtureManifest: GatewayManifest = {
+  manifestVersion: '1',
+  service: 'users-api',
+  generatedAt: '2026-05-06T00:00:00.000Z',
+  routes: [
+    {
+      id: 'usersController.createItem',
+      method: 'POST',
+      path: '/users',
+      controller: 'usersController',
+      routeKey: 'createItem',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { request: '5s' },
+        rateLimit: { requests: 10, per: '1m', key: 'ip' },
+        headers: {
+          request: { add: { 'x-internal': 'true' }, remove: ['cookie'] },
+        },
+      },
+    },
+    {
+      id: 'usersController.getItem',
+      method: 'GET',
+      path: '/users/{userId}',
+      controller: 'usersController',
+      routeKey: 'getItem',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { request: '2s' },
+        cache: { ttl: '60s', methods: ['GET'] },
+        cors: { origins: ['https://app.example.com'], credentials: true },
+        match: {
+          customHeaders: { 'x-tenant-id': { prefix: 't_' } },
+        },
+      },
+    },
+    {
+      id: 'usersController.deleteItem',
+      method: 'DELETE',
+      path: '/users/{userId}',
+      controller: 'usersController',
+      routeKey: 'deleteItem',
+      metadata: {
+        upstream: 'users-service',
+        rewrite: { stripPrefix: '/users' },
+        auth: {
+          jwt: { issuer: 'https://auth.example.com', audiences: ['users-api'] },
+        },
+        circuitBreaker: { maxRequests: 100 },
+      },
+    },
+  ],
+}

--- a/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
@@ -4,17 +4,7 @@ exports[`renderKongConfig > matches the JSON snapshot for the fixture manifest 1
 {
   "_format_version": "3.0",
   "_transform": true,
-  "plugins": [
-    {
-      "config": {
-        "credentials": true,
-        "origins": [
-          "https://app.example.com",
-        ],
-      },
-      "name": "cors",
-    },
-  ],
+  "plugins": [],
   "services": [
     {
       "host": "users",
@@ -100,6 +90,15 @@ exports[`renderKongConfig > matches the JSON snapshot for the fixture manifest 1
               },
               "name": "proxy-cache",
             },
+            {
+              "config": {
+                "credentials": true,
+                "origins": [
+                  "https://app.example.com",
+                ],
+              },
+              "name": "cors",
+            },
           ],
           "preserve_host": false,
           "strip_path": false,
@@ -167,11 +166,11 @@ services:
               cache_ttl: 60
               request_method:
                 - GET
-plugins:
-  - name: cors
-    config:
-      origins:
-        - https://app.example.com
-      credentials: true
+          - name: cors
+            config:
+              origins:
+                - https://app.example.com
+              credentials: true
+plugins: []
 "
 `;

--- a/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`renderKongConfig > matches the JSON snapshot for the fixture manifest 1
       "path": undefined,
       "port": 8081,
       "protocol": "http",
-      "read_timeout": 2000,
+      "read_timeout": 5000,
       "routes": [
         {
           "methods": [
@@ -118,7 +118,7 @@ services:
     protocol: http
     host: users
     port: 8081
-    read_timeout: 2000
+    read_timeout: 5000
     routes:
       - name: usersController.createItem
         methods:

--- a/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderKongConfig > matches the JSON snapshot for the fixture manifest 1`] = `
+{
+  "_format_version": "3.0",
+  "_transform": true,
+  "plugins": [
+    {
+      "config": {
+        "credentials": true,
+        "origins": [
+          "https://app.example.com",
+        ],
+      },
+      "name": "cors",
+    },
+  ],
+  "services": [
+    {
+      "host": "users",
+      "name": "users-service",
+      "path": undefined,
+      "port": 8081,
+      "protocol": "http",
+      "read_timeout": 2000,
+      "routes": [
+        {
+          "methods": [
+            "POST",
+          ],
+          "name": "usersController.createItem",
+          "paths": [
+            "/users",
+          ],
+          "plugins": [
+            {
+              "config": {
+                "limit_by": "ip",
+                "minute": 10,
+              },
+              "name": "rate-limiting",
+            },
+            {
+              "config": {
+                "add": {
+                  "headers": [
+                    "x-internal:true",
+                  ],
+                },
+                "remove": {
+                  "headers": [
+                    "cookie",
+                  ],
+                },
+              },
+              "name": "request-transformer",
+            },
+          ],
+          "preserve_host": false,
+          "strip_path": false,
+        },
+        {
+          "methods": [
+            "DELETE",
+          ],
+          "name": "usersController.deleteItem",
+          "paths": [
+            "~/users/(?<userId>[^/]+)$",
+          ],
+          "plugins": [
+            {
+              "config": {},
+              "name": "jwt",
+            },
+          ],
+          "preserve_host": false,
+          "strip_path": true,
+        },
+        {
+          "headers": {
+            "x-tenant-id": [
+              "~^t_",
+            ],
+          },
+          "methods": [
+            "GET",
+          ],
+          "name": "usersController.getItem",
+          "paths": [
+            "~/users/(?<userId>[^/]+)$",
+          ],
+          "plugins": [
+            {
+              "config": {
+                "cache_ttl": 60,
+                "request_method": [
+                  "GET",
+                ],
+                "strategy": "memory",
+              },
+              "name": "proxy-cache",
+            },
+          ],
+          "preserve_host": false,
+          "strip_path": false,
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`renderKongConfig > matches the YAML snapshot for the fixture manifest 1`] = `
+"_format_version: "3.0"
+_transform: true
+services:
+  - name: users-service
+    protocol: http
+    host: users
+    port: 8081
+    read_timeout: 2000
+    routes:
+      - name: usersController.createItem
+        methods:
+          - POST
+        paths:
+          - /users
+        strip_path: false
+        preserve_host: false
+        plugins:
+          - name: rate-limiting
+            config:
+              minute: 10
+              limit_by: ip
+          - name: request-transformer
+            config:
+              add:
+                headers:
+                  - x-internal:true
+              remove:
+                headers:
+                  - cookie
+      - name: usersController.deleteItem
+        methods:
+          - DELETE
+        paths:
+          - ~/users/(?<userId>[^/]+)$
+        strip_path: true
+        preserve_host: false
+        plugins:
+          - name: jwt
+            config: {}
+      - name: usersController.getItem
+        methods:
+          - GET
+        paths:
+          - ~/users/(?<userId>[^/]+)$
+        strip_path: false
+        preserve_host: false
+        headers:
+          x-tenant-id:
+            - ~^t_
+        plugins:
+          - name: proxy-cache
+            config:
+              strategy: memory
+              cache_ttl: 60
+              request_method:
+                - GET
+plugins:
+  - name: cors
+    config:
+      origins:
+        - https://app.example.com
+      credentials: true
+"
+`;

--- a/packages/gateway-kong/src/durations.ts
+++ b/packages/gateway-kong/src/durations.ts
@@ -26,7 +26,18 @@ export function toMilliseconds(input: string): number {
   }
 }
 
-/** Kong's `proxy-cache` plugin and rate-limiting expect seconds. */
+/**
+ * Kong's `proxy-cache` plugin and rate-limiting take integer seconds — the
+ * universal `Duration` model allows millisecond precision (e.g. `300ms`),
+ * so we throw if the value isn't representable in whole seconds rather than
+ * silently rounding (which can zero out small values or inflate large ones).
+ */
 export function toSeconds(input: string): number {
-  return Math.round(toMilliseconds(input) / 1000)
+  const ms = toMilliseconds(input)
+  if (ms % 1000 !== 0) {
+    throw new Error(
+      `Duration "${input}" cannot be represented in whole seconds, which Kong's plugin config requires.`,
+    )
+  }
+  return ms / 1000
 }

--- a/packages/gateway-kong/src/durations.ts
+++ b/packages/gateway-kong/src/durations.ts
@@ -1,0 +1,32 @@
+/**
+ * Convert a universal duration string ("5s", "300ms", "1m", "2h") to milliseconds.
+ *
+ * Kong's timeout fields (`connect_timeout`, `read_timeout`, `write_timeout`)
+ * are integers in milliseconds, so this is the canonical conversion.
+ */
+export function toMilliseconds(input: string): number {
+  const match = /^(\d+)(ms|s|m|h)$/.exec(input)
+  if (!match) {
+    throw new Error(`Unsupported duration "${input}" — expected formats like "5s", "300ms".`)
+  }
+  const value = Number(match[1])
+  const unit = match[2]
+  switch (unit) {
+    case 'ms':
+      return value
+    case 's':
+      return value * 1000
+    case 'm':
+      return value * 60_000
+    case 'h':
+      return value * 3_600_000
+    default:
+      // Unreachable thanks to the regex.
+      return value
+  }
+}
+
+/** Kong's `proxy-cache` plugin and rate-limiting expect seconds. */
+export function toSeconds(input: string): number {
+  return Math.round(toMilliseconds(input) / 1000)
+}

--- a/packages/gateway-kong/src/index.ts
+++ b/packages/gateway-kong/src/index.ts
@@ -1,6 +1,7 @@
 export {
   type KongConfigShape,
   type KongOptions,
+  type KongProfile,
   type KongUpstreamOptions,
   type RenderKongResult,
   renderKongConfig,

--- a/packages/gateway-kong/src/index.ts
+++ b/packages/gateway-kong/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  type KongConfigShape,
+  type KongOptions,
+  type KongUpstreamOptions,
+  type RenderKongResult,
+  renderKongConfig,
+} from './render.ts'

--- a/packages/gateway-kong/src/pathMatch.ts
+++ b/packages/gateway-kong/src/pathMatch.ts
@@ -1,0 +1,37 @@
+/**
+ * Convert an OpenAPI-style path to a Kong regex path. Kong accepts plain
+ * prefix paths or regex paths prefixed with `~`. Since universal paths use
+ * `{param}` segments, every path with at least one `{...}` segment becomes a
+ * regex with named captures.
+ *
+ * Examples:
+ *   /users               → /users                                (plain prefix)
+ *   /users/{userId}      → ~/users/(?<userId>[^/]+)$
+ *   /files/{wildcard}    → ~/files/.*
+ */
+export function openApiPathToKong(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new Error(`Path must start with "/": ${path}`)
+  }
+
+  let hasParam = false
+  const segments = path.split('/').map((segment) => {
+    if (segment === '{wildcard}') {
+      hasParam = true
+      return '.*'
+    }
+    const param = /^\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(segment)
+    if (param) {
+      hasParam = true
+      return `(?<${param[1]}>[^/]+)`
+    }
+    return escapeRegex(segment)
+  })
+
+  if (!hasParam) return path
+  return `~${segments.join('/')}$`
+}
+
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/packages/gateway-kong/src/pathMatch.ts
+++ b/packages/gateway-kong/src/pathMatch.ts
@@ -25,6 +25,16 @@ export function openApiPathToKong(path: string): string {
       hasParam = true
       return `(?<${param[1]}>[^/]+)`
     }
+    // Anything that LOOKS like a brace param (e.g. `{user-id}`) but isn't a
+    // valid PCRE2 named-capture identifier must fail loudly. Returning the
+    // segment unchanged would produce a literal Kong prefix path that can
+    // never match the actual requests (`/users/{user-id}` ≠ `/users/123`).
+    if (/^\{[^}]+\}$/.test(segment)) {
+      throw new Error(
+        `Path parameter "${segment}" in "${path}" is not a valid PCRE2 named-capture identifier. ` +
+          `Use only ASCII letters, digits, and underscores in the parameter name (e.g. "{userId}").`,
+      )
+    }
     return escapeRegex(segment)
   })
 

--- a/packages/gateway-kong/src/render.spec.ts
+++ b/packages/gateway-kong/src/render.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { fixtureManifest } from './__fixtures__/manifest.fixture.ts'
+import { renderKongConfig } from './render.ts'
+
+describe('renderKongConfig', () => {
+  const options = {
+    upstreams: { 'users-service': { url: 'http://users:8081' } },
+  }
+
+  it('matches the YAML snapshot for the fixture manifest', () => {
+    const { yaml } = renderKongConfig(fixtureManifest, options)
+    expect(yaml).toMatchSnapshot()
+  })
+
+  it('matches the JSON snapshot for the fixture manifest', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    expect(json).toMatchSnapshot()
+  })
+
+  it('emits one Kong service per upstream, with all routes nested under it', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    expect(json.services).toHaveLength(1)
+    expect(json.services[0]?.name).toBe('users-service')
+    expect(json.services[0]?.routes.map((r) => r.name).sort()).toEqual([
+      'usersController.createItem',
+      'usersController.deleteItem',
+      'usersController.getItem',
+    ])
+  })
+
+  it('converts {param} segments to Kong regex paths with named captures', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    const getItem = json.services[0]?.routes.find((r) => r.name === 'usersController.getItem')
+    expect(getItem?.paths).toEqual(['~/users/(?<userId>[^/]+)$'])
+  })
+
+  it('attaches a rate-limiting plugin for routes that declare metadata.rateLimit', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    const createItem = json.services[0]?.routes.find((r) => r.name === 'usersController.createItem')
+    const rl = createItem?.plugins?.find((p) => p.name === 'rate-limiting')
+    expect(rl?.config).toMatchObject({ minute: 10, limit_by: 'ip' })
+  })
+
+  it('attaches a proxy-cache plugin for routes that declare metadata.cache', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    const getItem = json.services[0]?.routes.find((r) => r.name === 'usersController.getItem')
+    const cache = getItem?.plugins?.find((p) => p.name === 'proxy-cache')
+    expect(cache?.config).toMatchObject({ cache_ttl: 60, request_method: ['GET'] })
+  })
+
+  it('promotes the first route-level CORS block to a global Kong plugin', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    expect(json.plugins.find((p) => p.name === 'cors')?.config).toMatchObject({
+      origins: ['https://app.example.com'],
+      credentials: true,
+    })
+  })
+
+  it('propagates header transformations as request-/response-transformer plugins', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    const createItem = json.services[0]?.routes.find((r) => r.name === 'usersController.createItem')
+    const reqTransformer = createItem?.plugins?.find((p) => p.name === 'request-transformer')
+    expect(reqTransformer?.config).toMatchObject({
+      add: { headers: ['x-internal:true'] },
+      remove: { headers: ['cookie'] },
+    })
+  })
+
+  it('reports unsupported metadata fields as warnings', () => {
+    const { warnings } = renderKongConfig(fixtureManifest, options)
+    expect(warnings.some((w) => w.includes('circuitBreaker'))).toBe(true)
+  })
+
+  it('throws when an upstream is referenced but no URL is configured', () => {
+    expect(() => renderKongConfig(fixtureManifest, { upstreams: {} })).toThrow(
+      /upstream "users-service"/,
+    )
+  })
+
+  it('reads service-level read_timeout from the tightest route timeout in that upstream', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    // Tightest among 5s / 2s / (no timeout) is 2s = 2000ms.
+    expect(json.services[0]?.read_timeout).toBe(2000)
+  })
+})

--- a/packages/gateway-kong/src/render.spec.ts
+++ b/packages/gateway-kong/src/render.spec.ts
@@ -77,9 +77,57 @@ describe('renderKongConfig', () => {
     )
   })
 
-  it('reads service-level read_timeout from the tightest route timeout in that upstream', () => {
+  it('reads service-level read_timeout from the LOOSEST route timeout in that upstream', () => {
+    // Kong CE has no per-route timeout override; using the loosest avoids
+    // silently shortening timeouts on routes that asked for more.
     const { json } = renderKongConfig(fixtureManifest, options)
-    // Tightest among 5s / 2s / (no timeout) is 2s = 2000ms.
-    expect(json.services[0]?.read_timeout).toBe(2000)
+    // Loosest among 5s / 2s / (no timeout) is 5s = 5000ms.
+    expect(json.services[0]?.read_timeout).toBe(5000)
+  })
+
+  it('warns when a route asked for a tighter timeout than the service-level one allows', () => {
+    const { warnings } = renderKongConfig(fixtureManifest, options)
+    // The 2s route is tighter than the service-level 5s read_timeout.
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes('usersController.getItem') &&
+          w.includes('tighter') &&
+          w.includes('per-route timeout override'),
+      ),
+    ).toBe(true)
+  })
+
+  describe('profile: enterprise', () => {
+    const mtlsManifest: typeof fixtureManifest = {
+      ...fixtureManifest,
+      routes: [
+        {
+          id: 'secure.get',
+          method: 'GET',
+          path: '/secure',
+          controller: 'secure',
+          routeKey: 'get',
+          metadata: { upstream: 'users-service', auth: { mTLS: true, required: true } },
+        },
+      ],
+    }
+
+    it('emits the mtls-auth plugin for auth.mTLS routes (no warning)', () => {
+      const { json, warnings } = renderKongConfig(mtlsManifest, {
+        ...options,
+        profile: 'enterprise',
+      })
+      const route = json.services[0]?.routes[0]
+      expect(route?.plugins?.some((p) => p.name === 'mtls-auth')).toBe(true)
+      expect(warnings.some((w) => w.includes('auth.mTLS'))).toBe(false)
+    })
+
+    it('warns instead of emitting mtls-auth under the OSS profile', () => {
+      const { json, warnings } = renderKongConfig(mtlsManifest, options) // profile defaults to 'oss'
+      const route = json.services[0]?.routes[0]
+      expect(route?.plugins?.some((p) => p.name === 'mtls-auth') ?? false).toBe(false)
+      expect(warnings.some((w) => w.includes('auth.mTLS') && w.includes('Enterprise'))).toBe(true)
+    })
   })
 })

--- a/packages/gateway-kong/src/render.spec.ts
+++ b/packages/gateway-kong/src/render.spec.ts
@@ -48,12 +48,16 @@ describe('renderKongConfig', () => {
     expect(cache?.config).toMatchObject({ cache_ttl: 60, request_method: ['GET'] })
   })
 
-  it('promotes the first route-level CORS block to a global Kong plugin', () => {
+  it('emits cors as a per-route plugin (not promoted to global)', () => {
     const { json } = renderKongConfig(fixtureManifest, options)
-    expect(json.plugins.find((p) => p.name === 'cors')?.config).toMatchObject({
+    const getItem = json.services[0]?.routes.find((r) => r.name === 'usersController.getItem')
+    const cors = getItem?.plugins?.find((p) => p.name === 'cors')
+    expect(cors?.config).toMatchObject({
       origins: ['https://app.example.com'],
       credentials: true,
     })
+    // No global plugins emitted — each route's CORS intent is preserved.
+    expect(json.plugins).toEqual([])
   })
 
   it('propagates header transformations as request-/response-transformer plugins', () => {

--- a/packages/gateway-kong/src/render.ts
+++ b/packages/gateway-kong/src/render.ts
@@ -1,0 +1,317 @@
+import type { GatewayManifest, GatewayMetadataValue } from 'opinionated-machine'
+import { stringify as stringifyYaml } from 'yaml'
+import { toMilliseconds, toSeconds } from './durations.ts'
+import { openApiPathToKong } from './pathMatch.ts'
+
+export type KongUpstreamOptions = {
+  /** Base URL for the upstream service (e.g. `http://users:8081`). */
+  url: string
+  /** Optional Kong service-level retry count. */
+  retries?: number
+}
+
+export type KongOptions = {
+  /** Map from `metadata.upstream` to the upstream URL Kong should proxy to. */
+  upstreams: Record<string, KongUpstreamOptions>
+}
+
+export type RenderKongResult = {
+  yaml: string
+  json: KongConfigShape
+  warnings: string[]
+}
+
+/**
+ * Render a Kong **declarative** (DB-less) configuration from a gateway manifest.
+ *
+ * Kong's plugin model is the natural fit for most gateway-metadata fields:
+ * timeouts and retries map onto service attributes, while rate-limiting,
+ * CORS, JWT, caching, and header transformations map onto first-class
+ * plugins. Anything that doesn't have a clean Kong CE equivalent (traffic
+ * splitting, circuit breaker) is reported as a warning.
+ */
+export function renderKongConfig(
+  manifest: GatewayManifest,
+  options: KongOptions,
+): RenderKongResult {
+  const warnings: string[] = []
+
+  // Group routes by upstream so we emit one Kong service per upstream.
+  const byUpstream = new Map<string, GatewayManifest['routes']>()
+  for (const route of manifest.routes) {
+    if (!route.metadata.upstream) {
+      throw new Error(
+        `Route "${route.id}" has no upstream — set metadata.upstream on the route or controller defaults.`,
+      )
+    }
+    const list = byUpstream.get(route.metadata.upstream) ?? []
+    list.push(route)
+    byUpstream.set(route.metadata.upstream, list)
+  }
+
+  for (const upstream of byUpstream.keys()) {
+    if (!options.upstreams[upstream]) {
+      throw new Error(
+        `Manifest references upstream "${upstream}" but no URL was configured in KongOptions.upstreams.`,
+      )
+    }
+  }
+
+  const services: KongService[] = []
+  for (const [upstreamName, routes] of byUpstream) {
+    const upstreamOpts = options.upstreams[upstreamName] as KongUpstreamOptions
+    services.push(buildService(upstreamName, upstreamOpts, routes, warnings))
+  }
+  services.sort((a, b) => a.name.localeCompare(b.name))
+
+  const config: KongConfigShape = {
+    _format_version: '3.0',
+    _transform: true,
+    services,
+    plugins: collectGlobalPlugins(manifest, warnings),
+  }
+
+  return {
+    yaml: stringifyYaml(config, { indent: 2 }),
+    json: config,
+    warnings,
+  }
+}
+
+function buildService(
+  name: string,
+  upstreamOpts: KongUpstreamOptions,
+  routes: GatewayManifest['routes'],
+  warnings: string[],
+): KongService {
+  const url = new URL(upstreamOpts.url)
+  // Use the maximum of all route timeouts as the service-level read_timeout
+  // (Kong's read_timeout applies to upstream reads). Per-route overrides ride
+  // on the route via the `request-termination`-style plugin below if needed.
+  const readTimeout = pickTightestTimeout(routes)
+
+  return {
+    name,
+    protocol: url.protocol.replace(':', ''),
+    host: url.hostname,
+    port: url.port ? Number(url.port) : url.protocol === 'https:' ? 443 : 80,
+    path: url.pathname === '/' ? undefined : url.pathname,
+    ...(upstreamOpts.retries !== undefined ? { retries: upstreamOpts.retries } : {}),
+    ...(readTimeout !== undefined ? { read_timeout: readTimeout } : {}),
+    routes: routes
+      .map((route) => buildRoute(route, warnings))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  }
+}
+
+function pickTightestTimeout(routes: GatewayManifest['routes']): number | undefined {
+  let tightest: number | undefined
+  for (const route of routes) {
+    const timeout = route.metadata.timeouts?.request
+    if (!timeout) continue
+    const ms = toMilliseconds(timeout)
+    if (tightest === undefined || ms < tightest) tightest = ms
+  }
+  return tightest
+}
+
+function buildRoute(route: GatewayManifest['routes'][number], warnings: string[]): KongRoute {
+  const meta = route.metadata
+  const headers = collectHeaderMatchers(meta)
+
+  const r: KongRoute = {
+    name: route.id,
+    methods: [route.method],
+    paths: [openApiPathToKong(route.path)],
+    strip_path: meta.rewrite?.stripPrefix !== undefined,
+    preserve_host: false,
+    ...(headers ? { headers } : {}),
+    plugins: collectRoutePlugins(route.id, meta, warnings),
+  }
+  if (r.plugins?.length === 0) delete r.plugins
+
+  // Vendor escape hatch: extensions.kong is shallow-merged onto the route.
+  const kongExt = meta.extensions?.kong as Record<string, unknown> | undefined
+  if (kongExt) Object.assign(r, kongExt)
+
+  return r
+}
+
+function collectHeaderMatchers(meta: GatewayMetadataValue): Record<string, string[]> | undefined {
+  const out: Record<string, string[]> = {}
+  const merged = { ...(meta.match?.headers ?? {}), ...(meta.match?.customHeaders ?? {}) }
+  for (const [name, rule] of Object.entries(merged)) {
+    if (typeof rule === 'string') {
+      out[name] = [rule]
+      continue
+    }
+    if ('exact' in rule) out[name] = [rule.exact]
+    else if ('prefix' in rule) out[name] = [`~^${escapeRegex(rule.prefix)}`]
+    else if ('regex' in rule) out[name] = [`~${rule.regex}`]
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function collectRoutePlugins(
+  routeId: string,
+  meta: GatewayMetadataValue,
+  warnings: string[],
+): KongPlugin[] {
+  const plugins: KongPlugin[] = []
+
+  if (meta.rateLimit) plugins.push(buildRateLimitPlugin(meta.rateLimit))
+  if (meta.cache?.ttl) plugins.push(buildCachePlugin(meta.cache))
+  if (meta.auth?.jwt) plugins.push(buildJwtPlugin())
+  const transformer = buildTransformerPlugins(meta.headers)
+  plugins.push(...transformer)
+
+  if (meta.circuitBreaker) {
+    warnings.push(
+      `Route "${routeId}": metadata.circuitBreaker has no native equivalent in Kong CE — consider Kong Enterprise or a service-mesh layer.`,
+    )
+  }
+  if (meta.traffic?.weights || meta.traffic?.shadow) {
+    warnings.push(
+      `Route "${routeId}": metadata.traffic (weighted / shadow) is not modelled in v1; configure Kong upstreams + targets manually if needed.`,
+    )
+  }
+
+  // Vendor escape hatch: meta.extensions.kong_plugins (array) is appended.
+  const extPlugins = (meta.extensions?.kong_plugins as KongPlugin[] | undefined) ?? []
+  plugins.push(...extPlugins)
+
+  return plugins
+}
+
+function buildRateLimitPlugin(
+  rateLimit: NonNullable<GatewayMetadataValue['rateLimit']>,
+): KongPlugin {
+  const seconds = toSeconds(rateLimit.per)
+  // Map per-second / per-minute / per-hour buckets to Kong's discrete fields.
+  const config: Record<string, unknown> = {}
+  if (seconds <= 1) config.second = rateLimit.requests
+  else if (seconds <= 60) config.minute = rateLimit.requests
+  else if (seconds <= 3600) config.hour = rateLimit.requests
+  else config.day = rateLimit.requests
+
+  const key = rateLimit.key
+  config.limit_by =
+    key === 'ip'
+      ? 'ip'
+      : key && typeof key === 'object' && ('header' in key || 'customHeader' in key)
+        ? 'header'
+        : 'consumer'
+  if (key && typeof key === 'object' && 'header' in key) {
+    config.header_name = key.header
+  } else if (key && typeof key === 'object' && 'customHeader' in key) {
+    config.header_name = key.customHeader
+  }
+
+  return { name: 'rate-limiting', config }
+}
+
+function buildCachePlugin(cache: NonNullable<GatewayMetadataValue['cache']>): KongPlugin {
+  return {
+    name: 'proxy-cache',
+    config: {
+      strategy: 'memory',
+      cache_ttl: toSeconds(cache.ttl),
+      ...(cache.methods?.length ? { request_method: cache.methods } : {}),
+      ...(cache.vary?.length ? { vary_headers: cache.vary } : {}),
+    },
+  }
+}
+
+function buildJwtPlugin(): KongPlugin {
+  // Kong's JWT plugin draws its keys from consumers/credentials, not from a
+  // jwks URI in declarative config. We emit the plugin as a marker so
+  // operators can wire credentials separately.
+  return { name: 'jwt', config: {} }
+}
+
+function buildTransformerPlugins(headers: GatewayMetadataValue['headers']): KongPlugin[] {
+  const out: KongPlugin[] = []
+  if (headers?.request) {
+    const config: Record<string, unknown> = {}
+    if (headers.request.add) {
+      config.add = { headers: Object.entries(headers.request.add).map(([k, v]) => `${k}:${v}`) }
+    }
+    if (headers.request.remove?.length) {
+      config.remove = { headers: headers.request.remove }
+    }
+    if (Object.keys(config).length > 0) out.push({ name: 'request-transformer', config })
+  }
+  if (headers?.response) {
+    const config: Record<string, unknown> = {}
+    if (headers.response.add) {
+      config.add = { headers: Object.entries(headers.response.add).map(([k, v]) => `${k}:${v}`) }
+    }
+    if (headers.response.remove?.length) {
+      config.remove = { headers: headers.response.remove }
+    }
+    if (Object.keys(config).length > 0) out.push({ name: 'response-transformer', config })
+  }
+  return out
+}
+
+function collectGlobalPlugins(manifest: GatewayManifest, _warnings: string[]): KongPlugin[] {
+  // Promote the first route-level CORS block to a global Kong plugin —
+  // Kong applies CORS at the global / service / route level, and aggregating
+  // it once keeps the config tidy.
+  const firstCors = manifest.routes.find((r) => r.metadata.cors)?.metadata.cors
+  if (!firstCors) return []
+  return [
+    {
+      name: 'cors',
+      config: {
+        origins: firstCors.origins,
+        ...(firstCors.methods ? { methods: firstCors.methods } : {}),
+        ...(firstCors.headers ? { headers: firstCors.headers } : {}),
+        ...(firstCors.exposeHeaders ? { exposed_headers: firstCors.exposeHeaders } : {}),
+        ...(firstCors.credentials !== undefined ? { credentials: firstCors.credentials } : {}),
+        ...(firstCors.maxAge ? { max_age: toSeconds(firstCors.maxAge) } : {}),
+      },
+    },
+  ]
+}
+
+// ============================================================================
+// Type definitions for the Kong subset we emit.
+// ============================================================================
+
+type KongPlugin = {
+  name: string
+  config: Record<string, unknown>
+}
+
+type KongRoute = {
+  name: string
+  methods: string[]
+  paths: string[]
+  strip_path: boolean
+  preserve_host: boolean
+  headers?: Record<string, string[]>
+  plugins?: KongPlugin[]
+}
+
+type KongService = {
+  name: string
+  protocol: string
+  host: string
+  port: number
+  path?: string
+  retries?: number
+  read_timeout?: number
+  routes: KongRoute[]
+}
+
+export type KongConfigShape = {
+  _format_version: '3.0'
+  _transform: true
+  services: KongService[]
+  plugins: KongPlugin[]
+}

--- a/packages/gateway-kong/src/render.ts
+++ b/packages/gateway-kong/src/render.ts
@@ -81,7 +81,9 @@ export function renderKongConfig(
     _format_version: '3.0',
     _transform: true,
     services,
-    plugins: collectGlobalPlugins(manifest, warnings),
+    // No global plugins emitted — per-route concerns (CORS, etc.) live on
+    // their routes so distinct policies are preserved.
+    plugins: [],
   }
 
   return {
@@ -209,8 +211,9 @@ function collectRoutePlugins(
 ): KongPlugin[] {
   const plugins: KongPlugin[] = []
 
-  if (meta.rateLimit) plugins.push(buildRateLimitPlugin(meta.rateLimit))
+  if (meta.rateLimit) plugins.push(buildRateLimitPlugin(routeId, meta.rateLimit, warnings))
   if (meta.cache?.ttl) plugins.push(buildCachePlugin(meta.cache))
+  if (meta.cors) plugins.push(buildCorsPlugin(meta.cors))
   if (meta.auth?.jwt) plugins.push(buildJwtPlugin())
   plugins.push(...buildTransformerPlugins(meta.headers))
 
@@ -269,7 +272,9 @@ function collectRouteWarnings(
 }
 
 function buildRateLimitPlugin(
+  routeId: string,
   rateLimit: NonNullable<GatewayMetadataValue['rateLimit']>,
+  warnings: string[],
 ): KongPlugin {
   const seconds = toSeconds(rateLimit.per)
   // Bucket selection — Kong's rate-limiting plugin takes per-second / minute
@@ -280,17 +285,28 @@ function buildRateLimitPlugin(
   else if (seconds <= 3600) config.hour = rateLimit.requests
   else config.day = rateLimit.requests
 
+  // Kong's `rate-limiting` plugin supports limit_by: ip / header / consumer
+  // / consumer-group / credential / service / path. The universal model also
+  // allows query / customQuery as keys, which Kong cannot natively translate
+  // — surface a warning so the user can wire a Lua plugin or restructure
+  // the limiter rather than silently degrading to consumer-based limiting.
   const key = rateLimit.key
-  config.limit_by =
-    key === 'ip'
-      ? 'ip'
-      : key && typeof key === 'object' && ('header' in key || 'customHeader' in key)
-        ? 'header'
-        : 'consumer'
-  if (key && typeof key === 'object' && 'header' in key) {
+  if (key === undefined) {
+    config.limit_by = 'consumer'
+  } else if (key === 'ip') {
+    config.limit_by = 'ip'
+  } else if (typeof key === 'object' && 'header' in key) {
+    config.limit_by = 'header'
     config.header_name = key.header
-  } else if (key && typeof key === 'object' && 'customHeader' in key) {
+  } else if (typeof key === 'object' && 'customHeader' in key) {
+    config.limit_by = 'header'
     config.header_name = key.customHeader
+  } else {
+    // 'query' or 'customQuery' — unsupported by Kong's rate-limiting plugin.
+    warnings.push(
+      `Route "${routeId}": Kong's rate-limiting plugin doesn't support query-based identity (metadata.rateLimit.key) — falling back to limit_by: 'ip'. Wire a Lua / custom plugin via extensions.kong_plugins for true query-based limiting.`,
+    )
+    config.limit_by = 'ip'
   }
 
   return { name: 'rate-limiting', config }
@@ -340,25 +356,22 @@ function buildTransformerPlugins(headers: GatewayMetadataValue['headers']): Kong
   return out
 }
 
-function collectGlobalPlugins(manifest: GatewayManifest, _warnings: string[]): KongPlugin[] {
-  // Promote the first route-level CORS block to a global Kong plugin —
-  // Kong applies CORS at the global / service / route level, and aggregating
-  // it once keeps the config tidy.
-  const firstCors = manifest.routes.find((r) => r.metadata.cors)?.metadata.cors
-  if (!firstCors) return []
-  return [
-    {
-      name: 'cors',
-      config: {
-        origins: firstCors.origins,
-        ...(firstCors.methods ? { methods: firstCors.methods } : {}),
-        ...(firstCors.headers ? { headers: firstCors.headers } : {}),
-        ...(firstCors.exposeHeaders ? { exposed_headers: firstCors.exposeHeaders } : {}),
-        ...(firstCors.credentials !== undefined ? { credentials: firstCors.credentials } : {}),
-        ...(firstCors.maxAge ? { max_age: toSeconds(firstCors.maxAge) } : {}),
-      },
+function buildCorsPlugin(cors: NonNullable<GatewayMetadataValue['cors']>): KongPlugin {
+  // Kong's CORS plugin attaches at any of: global, service, or route level.
+  // We emit it per route so each route's CORS intent is preserved verbatim
+  // — the previous "promote first to global" approach silently dropped any
+  // policy after the first.
+  return {
+    name: 'cors',
+    config: {
+      origins: cors.origins,
+      ...(cors.methods ? { methods: cors.methods } : {}),
+      ...(cors.headers ? { headers: cors.headers } : {}),
+      ...(cors.exposeHeaders ? { exposed_headers: cors.exposeHeaders } : {}),
+      ...(cors.credentials !== undefined ? { credentials: cors.credentials } : {}),
+      ...(cors.maxAge ? { max_age: toSeconds(cors.maxAge) } : {}),
     },
-  ]
+  }
 }
 
 // ============================================================================

--- a/packages/gateway-kong/src/render.ts
+++ b/packages/gateway-kong/src/render.ts
@@ -10,9 +10,21 @@ export type KongUpstreamOptions = {
   retries?: number
 }
 
+/**
+ * Which Kong distribution the rendered config targets.
+ *
+ * - `'oss'` (default): Kong Gateway OSS / Community Edition. Enterprise-only
+ *   plugins are not emitted; metadata that needs them produces a warning.
+ * - `'enterprise'`: Kong Gateway Enterprise. Enables plugins that are not
+ *   available in OSS (e.g. `mtls-auth`).
+ */
+export type KongProfile = 'oss' | 'enterprise'
+
 export type KongOptions = {
   /** Map from `metadata.upstream` to the upstream URL Kong should proxy to. */
   upstreams: Record<string, KongUpstreamOptions>
+  /** Distribution to target. Default: `'oss'`. */
+  profile?: KongProfile
 }
 
 export type RenderKongResult = {
@@ -27,14 +39,15 @@ export type RenderKongResult = {
  * Kong's plugin model is the natural fit for most gateway-metadata fields:
  * timeouts and retries map onto service attributes, while rate-limiting,
  * CORS, JWT, caching, and header transformations map onto first-class
- * plugins. Anything that doesn't have a clean Kong CE equivalent (traffic
- * splitting, circuit breaker) is reported as a warning.
+ * plugins. Set `options.profile = 'enterprise'` to additionally emit plugins
+ * that only exist in Kong Gateway Enterprise (e.g. `mtls-auth`).
  */
 export function renderKongConfig(
   manifest: GatewayManifest,
   options: KongOptions,
 ): RenderKongResult {
   const warnings: string[] = []
+  const profile: KongProfile = options.profile ?? 'oss'
 
   // Group routes by upstream so we emit one Kong service per upstream.
   const byUpstream = new Map<string, GatewayManifest['routes']>()
@@ -60,7 +73,7 @@ export function renderKongConfig(
   const services: KongService[] = []
   for (const [upstreamName, routes] of byUpstream) {
     const upstreamOpts = options.upstreams[upstreamName] as KongUpstreamOptions
-    services.push(buildService(upstreamName, upstreamOpts, routes, warnings))
+    services.push(buildService(upstreamName, upstreamOpts, routes, profile, warnings))
   }
   services.sort((a, b) => a.name.localeCompare(b.name))
 
@@ -82,13 +95,25 @@ function buildService(
   name: string,
   upstreamOpts: KongUpstreamOptions,
   routes: GatewayManifest['routes'],
+  profile: KongProfile,
   warnings: string[],
 ): KongService {
   const url = new URL(upstreamOpts.url)
-  // Use the maximum of all route timeouts as the service-level read_timeout
-  // (Kong's read_timeout applies to upstream reads). Per-route overrides ride
-  // on the route via the `request-termination`-style plugin below if needed.
-  const readTimeout = pickTightestTimeout(routes)
+  // Kong CE's read_timeout is service-level — every route under this service
+  // inherits the same value, so we use the LOOSEST timeout among the routes.
+  // Routes that asked for a tighter timeout get a warning so the operator
+  // knows to enforce it elsewhere (a Lua plugin, a sidecar, the upstream).
+  const readTimeout = pickLoosestTimeout(routes)
+  for (const route of routes) {
+    const declared = route.metadata.timeouts?.request
+    if (!declared) continue
+    const declaredMs = toMilliseconds(declared)
+    if (readTimeout !== undefined && declaredMs < readTimeout) {
+      warnings.push(
+        `Route "${route.id}": metadata.timeouts.request (${declared}) is tighter than the service-level read_timeout (${readTimeout}ms) — Kong CE has no per-route timeout override; enforce this at the upstream or via a Lua plugin.`,
+      )
+    }
+  }
 
   return {
     name,
@@ -99,34 +124,54 @@ function buildService(
     ...(upstreamOpts.retries !== undefined ? { retries: upstreamOpts.retries } : {}),
     ...(readTimeout !== undefined ? { read_timeout: readTimeout } : {}),
     routes: routes
-      .map((route) => buildRoute(route, warnings))
+      .map((route) => buildRoute(route, profile, warnings))
       .sort((a, b) => a.name.localeCompare(b.name)),
   }
 }
 
-function pickTightestTimeout(routes: GatewayManifest['routes']): number | undefined {
-  let tightest: number | undefined
+function pickLoosestTimeout(routes: GatewayManifest['routes']): number | undefined {
+  let loosest: number | undefined
   for (const route of routes) {
     const timeout = route.metadata.timeouts?.request
     if (!timeout) continue
     const ms = toMilliseconds(timeout)
-    if (tightest === undefined || ms < tightest) tightest = ms
+    if (loosest === undefined || ms > loosest) loosest = ms
   }
-  return tightest
+  return loosest
 }
 
-function buildRoute(route: GatewayManifest['routes'][number], warnings: string[]): KongRoute {
+function buildRoute(
+  route: GatewayManifest['routes'][number],
+  profile: KongProfile,
+  warnings: string[],
+): KongRoute {
   const meta = route.metadata
   const headers = collectHeaderMatchers(meta)
+  const kongPath = openApiPathToKong(route.path)
+  const stripPath = meta.rewrite?.stripPrefix !== undefined
+
+  // Kong's strip_path strips the entire matched route path. For regex paths
+  // (anything we authored with {param}), that strips the captured params too —
+  // almost never what the user wrote rewrite.stripPrefix to do. Warn loudly.
+  if (stripPath && kongPath.startsWith('~')) {
+    warnings.push(
+      `Route "${route.id}": metadata.rewrite.stripPrefix on a parameterised path doesn't translate cleanly to Kong's strip_path — Kong will strip the entire matched path, including captured params. Consider request-transformer with a custom rewrite, or restructure the upstream URL.`,
+    )
+  }
+  if (meta.rewrite?.replacePrefix) {
+    warnings.push(
+      `Route "${route.id}": metadata.rewrite.replacePrefix is not modelled — use a request-transformer plugin via extensions.kong_plugins, or restructure the upstream URL.`,
+    )
+  }
 
   const r: KongRoute = {
     name: route.id,
     methods: [route.method],
-    paths: [openApiPathToKong(route.path)],
-    strip_path: meta.rewrite?.stripPrefix !== undefined,
+    paths: [kongPath],
+    strip_path: stripPath,
     preserve_host: false,
     ...(headers ? { headers } : {}),
-    plugins: collectRoutePlugins(route.id, meta, warnings),
+    plugins: collectRoutePlugins(route.id, meta, profile, warnings),
   }
   if (r.plugins?.length === 0) delete r.plugins
 
@@ -159,6 +204,7 @@ function escapeRegex(literal: string): string {
 function collectRoutePlugins(
   routeId: string,
   meta: GatewayMetadataValue,
+  profile: KongProfile,
   warnings: string[],
 ): KongPlugin[] {
   const plugins: KongPlugin[] = []
@@ -166,19 +212,14 @@ function collectRoutePlugins(
   if (meta.rateLimit) plugins.push(buildRateLimitPlugin(meta.rateLimit))
   if (meta.cache?.ttl) plugins.push(buildCachePlugin(meta.cache))
   if (meta.auth?.jwt) plugins.push(buildJwtPlugin())
-  const transformer = buildTransformerPlugins(meta.headers)
-  plugins.push(...transformer)
+  plugins.push(...buildTransformerPlugins(meta.headers))
 
-  if (meta.circuitBreaker) {
-    warnings.push(
-      `Route "${routeId}": metadata.circuitBreaker has no native equivalent in Kong CE — consider Kong Enterprise or a service-mesh layer.`,
-    )
+  // mTLS — first-class only in Enterprise via the mtls-auth plugin.
+  if (meta.auth?.mTLS && profile === 'enterprise') {
+    plugins.push({ name: 'mtls-auth', config: {} })
   }
-  if (meta.traffic?.weights || meta.traffic?.shadow) {
-    warnings.push(
-      `Route "${routeId}": metadata.traffic (weighted / shadow) is not modelled in v1; configure Kong upstreams + targets manually if needed.`,
-    )
-  }
+
+  collectRouteWarnings(routeId, meta, profile, warnings)
 
   // Vendor escape hatch: meta.extensions.kong_plugins (array) is appended.
   const extPlugins = (meta.extensions?.kong_plugins as KongPlugin[] | undefined) ?? []
@@ -187,11 +228,52 @@ function collectRoutePlugins(
   return plugins
 }
 
+function collectRouteWarnings(
+  routeId: string,
+  meta: GatewayMetadataValue,
+  profile: KongProfile,
+  warnings: string[],
+): void {
+  if (meta.auth?.mTLS && profile !== 'enterprise') {
+    warnings.push(
+      `Route "${routeId}": metadata.auth.mTLS requires Kong Enterprise's mtls-auth plugin — pass options.profile = 'enterprise', or terminate mTLS at the listener in front of Kong.`,
+    )
+  }
+  if (meta.circuitBreaker) {
+    warnings.push(
+      profile === 'enterprise'
+        ? `Route "${routeId}": metadata.circuitBreaker has no first-class Kong plugin even in Enterprise — wire connectivity governance via a service-mesh layer or extensions.kong_plugins.`
+        : `Route "${routeId}": metadata.circuitBreaker has no native equivalent in Kong OSS — consider Kong Enterprise or a service-mesh layer.`,
+    )
+  }
+  if (meta.traffic?.weights || meta.traffic?.shadow) {
+    warnings.push(
+      `Route "${routeId}": metadata.traffic (weighted / shadow) is not modelled — configure Kong upstreams + targets manually if needed.`,
+    )
+  }
+  if (meta.match?.host) {
+    warnings.push(
+      `Route "${routeId}": metadata.match.host is not modelled — use the Kong route's hosts attribute via extensions.kong.`,
+    )
+  }
+  if (meta.match?.query || meta.match?.customQuery) {
+    warnings.push(
+      `Route "${routeId}": metadata.match.query / customQuery has no native Kong route matcher — wire it via a request-validator plugin.`,
+    )
+  }
+  if (meta.auth?.required && !meta.auth.jwt && !meta.auth.mTLS) {
+    warnings.push(
+      `Route "${routeId}": metadata.auth.required without auth.jwt / auth.mTLS has no automatic mapping — attach a Kong auth plugin (key-auth, basic-auth, oauth2) via extensions.kong_plugins.`,
+    )
+  }
+}
+
 function buildRateLimitPlugin(
   rateLimit: NonNullable<GatewayMetadataValue['rateLimit']>,
 ): KongPlugin {
   const seconds = toSeconds(rateLimit.per)
-  // Map per-second / per-minute / per-hour buckets to Kong's discrete fields.
+  // Bucket selection — Kong's rate-limiting plugin takes per-second / minute
+  // / hour / day counts; pick the smallest bucket the window fits in.
   const config: Record<string, unknown> = {}
   if (seconds <= 1) config.second = rateLimit.requests
   else if (seconds <= 60) config.minute = rateLimit.requests

--- a/packages/gateway-kong/tsconfig.build.json
+++ b/packages/gateway-kong/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"],
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/__fixtures__/**", "**/__snapshots__/**"]
+}

--- a/packages/gateway-kong/tsconfig.json
+++ b/packages/gateway-kong/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "declaration": true,
+        "declarationMap": true,
+        "noEmit": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/gateway-kong/vitest.acceptance.config.ts
+++ b/packages/gateway-kong/vitest.acceptance.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Acceptance suite — runs only via `npm run test:acceptance`, which boots
+ * docker compose with a real Kong (DB-less mode) and stub upstream. Kept in a
+ * separate config so the default `vitest run` (used by `npm test`) never
+ * picks them up.
+ */
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['acceptance/**/*.acceptance.spec.ts'],
+    testTimeout: 30000,
+  },
+})

--- a/packages/gateway-kong/vitest.config.ts
+++ b/packages/gateway-kong/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    testTimeout: 10000,
+  },
+})

--- a/packages/gateway-krakend/README.md
+++ b/packages/gateway-krakend/README.md
@@ -1,0 +1,70 @@
+# @opinionated-machine/gateway-krakend
+
+KrakenD v3 declarative-config generator for
+[opinionated-machine](https://github.com/kibertoad/opinionated-machine) gateway
+manifests.
+
+## Install
+
+```sh
+npm install @opinionated-machine/gateway-krakend
+```
+
+`opinionated-machine` is a peer dependency.
+
+## Usage
+
+```ts
+import { writeFileSync } from 'node:fs'
+import { renderKrakendConfig } from '@opinionated-machine/gateway-krakend'
+
+const manifest = context.buildGatewayManifest({ service: 'users-api' })
+
+const { json, warnings } = renderKrakendConfig(manifest, {
+  port: 8080,
+  upstreams: { 'users-service': 'http://users:8081' },
+})
+
+writeFileSync('krakend.json', JSON.stringify(json, null, 2))
+console.warn(warnings)
+```
+
+KrakenD's `{var}` path syntax is native, so paths pass through unchanged.
+
+## Field mappings
+
+| `GatewayMetadata` field   | KrakenD mapping |
+| ------------------------- | --------------- |
+| `upstream`                | endpoint `backend[].host` (resolved via `KrakendOptions.upstreams`) |
+| `timeouts.request`        | endpoint `backend[].extra_config["backend/http/client"].timeout` |
+| `cache.ttl`               | endpoint `extra_config["qos/http-cache"].ttl` |
+| `cache.vary`              | endpoint `extra_config["qos/http-cache"].vary` |
+| `rateLimit`               | endpoint `extra_config["qos/ratelimit/router"]` (`max_rate`/`every`/`strategy`) |
+| `circuitBreaker`          | endpoint `extra_config["qos/circuit-breaker"]` |
+| `auth.jwt`                | endpoint `extra_config["auth/validator"]` (issuer / audience / jwk_url) |
+| `cors`                    | promoted to root-level `extra_config["security/cors"]` (KrakenD applies CORS globally) |
+| `rewrite.stripPrefix`     | endpoint `backend[].url_pattern` rewriting |
+| `extensions.krakend`      | shallow-merged into endpoint `extra_config` last (escape hatch) |
+
+## Limitations (v1)
+
+Reported as `warnings[]` on the result:
+
+- `headers.request.add` — KrakenD doesn't natively express request-header
+  injection per endpoint; use `extensions.krakend` or a Lua plugin.
+- `match.host` — host routing is typically handled at the listener level.
+- `retry` — KrakenD's retry knobs live under `backend/http/client`; v1 emits
+  attempts on a best-effort basis.
+
+## Acceptance tests
+
+This package includes a Docker-based acceptance suite that boots a real
+KrakenD container plus a stub upstream:
+
+```sh
+npm run test:acceptance
+```
+
+Triggered automatically in CI by the
+[`gateway-acceptance`](../../.github/workflows/gateway-acceptance.yml) workflow
+when this package or `lib/gateway/` changes.

--- a/packages/gateway-krakend/README.md
+++ b/packages/gateway-krakend/README.md
@@ -1,24 +1,26 @@
 # @opinionated-machine/gateway-krakend
 
-KrakenD v3 declarative-config generator for
-[opinionated-machine](https://github.com/kibertoad/opinionated-machine) gateway
-manifests.
-
-## Install
+Generate a KrakenD v3 declarative config from your
+[opinionated-machine](https://github.com/kibertoad/opinionated-machine) routes.
+Annotate routes once with timeouts / cache / rate-limits / etc., then run this
+generator at build time and deploy the resulting `krakend.json`.
 
 ```sh
-npm install @opinionated-machine/gateway-krakend
+npm install --save-dev @opinionated-machine/gateway-krakend
 ```
 
 `opinionated-machine` is a peer dependency.
 
-## Usage
+## Use it
 
 ```ts
+// bin/render-krakend.ts
 import { writeFileSync } from 'node:fs'
 import { renderKrakendConfig } from '@opinionated-machine/gateway-krakend'
+import { buildContext } from '../src/diContext.ts'   // your DIContext factory
 
-const manifest = context.buildGatewayManifest({ service: 'users-api' })
+const ctx = await buildContext()
+const manifest = ctx.buildGatewayManifest({ service: 'users-api' })
 
 const { json, warnings } = renderKrakendConfig(manifest, {
   port: 8080,
@@ -26,45 +28,55 @@ const { json, warnings } = renderKrakendConfig(manifest, {
 })
 
 writeFileSync('krakend.json', JSON.stringify(json, null, 2))
-console.warn(warnings)
+if (warnings.length) console.warn('[krakend]', warnings)
 ```
 
-KrakenD's `{var}` path syntax is native, so paths pass through unchanged.
+```sh
+$ tsx bin/render-krakend.ts && krakend check -c krakend.json
+Syntax OK!
+```
 
-## Field mappings
+KrakenD's native `{var}` path syntax matches the manifest's path format, so
+paths pass through unchanged.
 
-| `GatewayMetadata` field   | KrakenD mapping |
-| ------------------------- | --------------- |
-| `upstream`                | endpoint `backend[].host` (resolved via `KrakendOptions.upstreams`) |
-| `timeouts.request`        | endpoint `backend[].extra_config["backend/http/client"].timeout` |
-| `cache.ttl`               | endpoint `extra_config["qos/http-cache"].ttl` |
-| `cache.vary`              | endpoint `extra_config["qos/http-cache"].vary` |
-| `rateLimit`               | endpoint `extra_config["qos/ratelimit/router"]` (`max_rate`/`every`/`strategy`) |
-| `circuitBreaker`          | endpoint `extra_config["qos/circuit-breaker"]` |
-| `auth.jwt`                | endpoint `extra_config["auth/validator"]` (issuer / audience / jwk_url) |
-| `cors`                    | promoted to root-level `extra_config["security/cors"]` (KrakenD applies CORS globally) |
-| `rewrite.stripPrefix`     | endpoint `backend[].url_pattern` rewriting |
-| `extensions.krakend`      | shallow-merged into endpoint `extra_config` last (escape hatch) |
+## How metadata maps to KrakenD
 
-## Limitations (v1)
+| Route metadata | KrakenD output |
+| -------------- | -------------- |
+| `upstream` | endpoint `backend[].host` (resolved via `KrakendOptions.upstreams`) |
+| `timeouts.request` | endpoint `backend[].extra_config["backend/http/client"].timeout` |
+| `cache.ttl` / `cache.vary` | endpoint `extra_config["qos/http-cache"]` |
+| `rateLimit` | endpoint `extra_config["qos/ratelimit/router"]` (`max_rate`, `every`, `strategy`) |
+| `circuitBreaker` | endpoint `extra_config["qos/circuit-breaker"]` |
+| `auth.jwt` | endpoint `extra_config["auth/validator"]` (issuer / audience / jwk_url) |
+| `cors` | promoted to root-level `extra_config["security/cors"]` (KrakenD applies CORS globally) |
+| `rewrite.stripPrefix` | endpoint `backend[].url_pattern` rewriting |
+| `extensions.krakend` | deep-merged into endpoint `extra_config` last (escape hatch) |
 
-Reported as `warnings[]` on the result:
+KrakenD shines when you need caching: this generator wires `qos/http-cache`
+out of the box from `cache.ttl`, whereas the Envoy generator leaves cache
+configuration to you.
 
-- `headers.request.add` — KrakenD doesn't natively express request-header
-  injection per endpoint; use `extensions.krakend` or a Lua plugin.
-- `match.host` — host routing is typically handled at the listener level.
-- `retry` — KrakenD's retry knobs live under `backend/http/client`; v1 emits
-  attempts on a best-effort basis.
+## What it doesn't do
 
-## Acceptance tests
+These metadata fields produce a `warnings[]` entry rather than being silently
+dropped:
 
-This package includes a Docker-based acceptance suite that boots a real
-KrakenD container plus a stub upstream:
+- `headers.request.add` — KrakenD has no first-class per-endpoint header
+  injection; use `extensions.krakend` or a Lua plugin.
+- `match.host` — host routing typically lives at the listener level.
+- `retry` — KrakenD's retry knobs sit under `backend/http/client`; emit them
+  with `extensions.krakend` for now.
+
+## Verifying generated configs
+
+CI boots a real KrakenD container plus a stub upstream and drives traffic
+through the generated config:
 
 ```sh
 npm run test:acceptance
 ```
 
-Triggered automatically in CI by the
+Requires Docker. Triggered automatically by the
 [`gateway-acceptance`](../../.github/workflows/gateway-acceptance.yml) workflow
 when this package or `lib/gateway/` changes.

--- a/packages/gateway-krakend/acceptance/krakend.acceptance.spec.ts
+++ b/packages/gateway-krakend/acceptance/krakend.acceptance.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Acceptance tests for the KrakenD generator. Driven by
+ * `vitest.acceptance.config.ts` — only run via `npm run test:acceptance`,
+ * which boots `docker compose` with KrakenD + a Node stub upstream and runs
+ * this file.
+ *
+ * The CI workflow `gateway-acceptance.yml` triggers it only when this package
+ * or `lib/gateway` changes.
+ */
+const GATEWAY_URL = process.env.GATEWAY_URL ?? 'http://localhost:8080'
+
+describe('krakend acceptance', () => {
+  it('routes GET /echo to the upstream', async () => {
+    const res = await fetch(`${GATEWAY_URL}/echo`)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { method: string; path: string }
+    expect(body.method).toBe('GET')
+    expect(body.path).toBe('/echo')
+  })
+
+  it('enforces the per-route request timeout', async () => {
+    const res = await fetch(`${GATEWAY_URL}/slow?ms=2000`)
+    // KrakenD returns 500 on backend timeout; some versions use 504.
+    expect([500, 504]).toContain(res.status)
+  })
+
+  it('rejects unknown paths with 404', async () => {
+    const res = await fetch(`${GATEWAY_URL}/nope`)
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/gateway-krakend/acceptance/krakend.acceptance.spec.ts
+++ b/packages/gateway-krakend/acceptance/krakend.acceptance.spec.ts
@@ -10,10 +10,14 @@ import { describe, expect, it } from 'vitest'
  * or `lib/gateway` changes.
  */
 const GATEWAY_URL = process.env.GATEWAY_URL ?? 'http://localhost:8080'
+const FETCH_TIMEOUT_MS = 10_000
+
+const fetchGateway = (path: string) =>
+  fetch(`${GATEWAY_URL}${path}`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
 
 describe('krakend acceptance', () => {
   it('routes GET /echo to the upstream', async () => {
-    const res = await fetch(`${GATEWAY_URL}/echo`)
+    const res = await fetchGateway('/echo')
     expect(res.status).toBe(200)
     const body = (await res.json()) as { method: string; path: string }
     expect(body.method).toBe('GET')
@@ -21,13 +25,13 @@ describe('krakend acceptance', () => {
   })
 
   it('enforces the per-route request timeout', async () => {
-    const res = await fetch(`${GATEWAY_URL}/slow?ms=2000`)
+    const res = await fetchGateway('/slow?ms=2000')
     // KrakenD returns 500 on backend timeout; some versions use 504.
     expect([500, 504]).toContain(res.status)
   })
 
   it('rejects unknown paths with 404', async () => {
-    const res = await fetch(`${GATEWAY_URL}/nope`)
+    const res = await fetchGateway('/nope')
     expect(res.status).toBe(404)
   })
 })

--- a/packages/gateway-krakend/acceptance/manifest.acceptance.mjs
+++ b/packages/gateway-krakend/acceptance/manifest.acceptance.mjs
@@ -1,8 +1,7 @@
-import type { GatewayManifest } from 'opinionated-machine'
-
-export const acceptanceManifest: GatewayManifest = {
+/** @type {import('opinionated-machine').GatewayManifest} */
+export const acceptanceManifest = {
   manifestVersion: '1',
-  service: 'gateway-kong-acceptance',
+  service: 'gateway-krakend-acceptance',
   generatedAt: '2026-05-06T00:00:00.000Z',
   routes: [
     {
@@ -19,7 +18,6 @@ export const acceptanceManifest: GatewayManifest = {
       path: '/slow',
       controller: 'echo',
       routeKey: 'slow',
-      // 200ms timeout; the upstream takes 2000ms so Kong should return 504.
       metadata: { upstream: 'upstream', timeouts: { request: '200ms' } },
     },
   ],

--- a/packages/gateway-krakend/acceptance/manifest.acceptance.ts
+++ b/packages/gateway-krakend/acceptance/manifest.acceptance.ts
@@ -1,0 +1,28 @@
+import type { GatewayManifest } from 'opinionated-machine'
+
+export const acceptanceManifest: GatewayManifest = {
+  manifestVersion: '1',
+  service: 'gateway-krakend-acceptance',
+  generatedAt: '2026-05-06T00:00:00.000Z',
+  routes: [
+    {
+      id: 'echo.get',
+      method: 'GET',
+      path: '/echo',
+      controller: 'echo',
+      routeKey: 'get',
+      metadata: {
+        upstream: 'upstream',
+        timeouts: { request: '2s' },
+      },
+    },
+    {
+      id: 'echo.slow',
+      method: 'GET',
+      path: '/slow',
+      controller: 'echo',
+      routeKey: 'slow',
+      metadata: { upstream: 'upstream', timeouts: { request: '200ms' } },
+    },
+  ],
+}

--- a/packages/gateway-krakend/acceptance/render-config.mjs
+++ b/packages/gateway-krakend/acceptance/render-config.mjs
@@ -1,0 +1,22 @@
+// Renders the acceptance manifest to a JSON file mounted into the KrakenD
+// container. Run before `docker compose up`.
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderKrakendConfig } from '../dist/render.js'
+import { acceptanceManifest } from './manifest.acceptance.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const outDir = join(__dirname, 'generated')
+mkdirSync(outDir, { recursive: true })
+
+const { json, warnings } = renderKrakendConfig(acceptanceManifest, {
+  port: 8080,
+  // The "upstream" name maps to the docker-compose service name.
+  upstreams: { upstream: 'http://upstream:8081' },
+})
+writeFileSync(join(outDir, 'krakend.json'), JSON.stringify(json, null, 2))
+if (warnings.length) {
+  console.warn('[render-config] warnings:', warnings)
+}
+console.log('[render-config] wrote', join(outDir, 'krakend.json'))

--- a/packages/gateway-krakend/acceptance/render-config.mjs
+++ b/packages/gateway-krakend/acceptance/render-config.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { renderKrakendConfig } from '../dist/render.js'
-import { acceptanceManifest } from './manifest.acceptance.js'
+import { acceptanceManifest } from './manifest.acceptance.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const outDir = join(__dirname, 'generated')

--- a/packages/gateway-krakend/acceptance/upstream.mjs
+++ b/packages/gateway-krakend/acceptance/upstream.mjs
@@ -1,0 +1,32 @@
+// Minimal upstream stub for acceptance tests.
+//
+// Echoes back the path, method, and a few headers the gateway forwards.
+// Path "/slow" delays for the requested ms (driven by ?ms=X) so we can verify
+// gateway timeouts.
+import { createServer } from 'node:http'
+
+const PORT = Number(process.env.PORT ?? 8081)
+
+createServer((req, res) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
+
+  if (url.pathname === '/slow') {
+    const delay = Number(url.searchParams.get('ms') ?? '500')
+    setTimeout(() => {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ path: url.pathname, delayedMs: delay }))
+    }, delay)
+    return
+  }
+
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(
+    JSON.stringify({
+      method: req.method,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+    }),
+  )
+}).listen(PORT, () => {
+  console.log(`[upstream] listening on :${PORT}`)
+})

--- a/packages/gateway-krakend/docker-compose.yml
+++ b/packages/gateway-krakend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   upstream:
     image: node:20-alpine

--- a/packages/gateway-krakend/docker-compose.yml
+++ b/packages/gateway-krakend/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  upstream:
+    image: node:20-alpine
+    volumes:
+      - ./acceptance/upstream.mjs:/app/upstream.mjs:ro
+    command: node /app/upstream.mjs
+    environment:
+      PORT: '8081'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8081/']
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+  krakend:
+    image: devopsfaith/krakend:2.7
+    depends_on:
+      upstream:
+        condition: service_healthy
+    volumes:
+      - ./acceptance/generated/krakend.json:/etc/krakend/krakend.json:ro
+    command: ['run', '-c', '/etc/krakend/krakend.json', '--port', '8080']
+    ports:
+      - '8080:8080'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8080/__health']
+      interval: 2s
+      timeout: 5s
+      retries: 30

--- a/packages/gateway-krakend/docker-compose.yml
+++ b/packages/gateway-krakend/docker-compose.yml
@@ -23,7 +23,10 @@ services:
     ports:
       - '8080:8080'
     healthcheck:
-      test: ['CMD', 'wget', '-qO-', 'http://localhost:8080/__health']
+      # busybox wget is in the krakend image (alpine base); /__health is
+      # KrakenD's canonical liveness endpoint.
+      test: ['CMD', 'wget', '-qO-', 'http://127.0.0.1:8080/__health']
       interval: 2s
       timeout: 5s
       retries: 30
+      start_period: 5s

--- a/packages/gateway-krakend/package.json
+++ b/packages/gateway-krakend/package.json
@@ -1,0 +1,65 @@
+{
+    "name": "@opinionated-machine/gateway-krakend",
+    "version": "0.1.0",
+    "description": "KrakenD config generator for opinionated-machine gateway manifests",
+    "type": "module",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": "./dist/index.js",
+        "./package.json": "./package.json"
+    },
+    "maintainers": [
+        {
+            "name": "Igor Savin",
+            "email": "kibertoad@gmail.com"
+        }
+    ],
+    "scripts": {
+        "build": "rimraf dist && tsc -p tsconfig.build.json",
+        "lint": "biome check . && tsc",
+        "lint:fix": "biome check --write .",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "acceptance:render": "node acceptance/render-config.mjs",
+        "acceptance:up": "docker compose up -d --wait",
+        "acceptance:down": "docker compose down -v",
+        "test:acceptance": "npm run build && npm run acceptance:render && npm run acceptance:up && vitest run -c vitest.acceptance.config.ts; ec=$?; npm run acceptance:down; exit $ec",
+        "prepublishOnly": "npm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kibertoad/opinionated-machine.git",
+        "directory": "packages/gateway-krakend"
+    },
+    "peerDependencies": {
+        "opinionated-machine": ">=6.17.0"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.4.4",
+        "@lokalise/biome-config": "^3.1.1",
+        "@lokalise/tsconfig": "^3.1.0",
+        "@types/node": "^22.19.7",
+        "opinionated-machine": "^6.16.1",
+        "rimraf": "^6.1.2",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+    },
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "keywords": [
+        "krakend",
+        "gateway",
+        "generator",
+        "opinionated-machine"
+    ],
+    "homepage": "https://github.com/kibertoad/opinionated-machine/tree/main/packages/gateway-krakend",
+    "files": [
+        "README.md",
+        "LICENSE",
+        "dist/*"
+    ]
+}

--- a/packages/gateway-krakend/package.json
+++ b/packages/gateway-krakend/package.json
@@ -41,7 +41,7 @@
         "@lokalise/biome-config": "^3.1.1",
         "@lokalise/tsconfig": "^3.1.0",
         "@types/node": "^22.19.7",
-        "opinionated-machine": "^6.16.1",
+        "opinionated-machine": "^6.17.0",
         "rimraf": "^6.1.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"

--- a/packages/gateway-krakend/src/__fixtures__/manifest.fixture.ts
+++ b/packages/gateway-krakend/src/__fixtures__/manifest.fixture.ts
@@ -1,0 +1,56 @@
+import type { GatewayManifest } from 'opinionated-machine'
+
+export const fixtureManifest: GatewayManifest = {
+  manifestVersion: '1',
+  service: 'users-api',
+  generatedAt: '2026-05-06T00:00:00.000Z',
+  routes: [
+    {
+      id: 'usersController.createItem',
+      method: 'POST',
+      path: '/users',
+      controller: 'usersController',
+      routeKey: 'createItem',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { request: '5s' },
+        circuitBreaker: { maxRequests: 100, maxRetries: 3 },
+        rateLimit: { requests: 10, per: '1m', key: 'ip' },
+      },
+    },
+    {
+      id: 'usersController.getItem',
+      method: 'GET',
+      path: '/users/{userId}',
+      controller: 'usersController',
+      routeKey: 'getItem',
+      metadata: {
+        upstream: 'users-service',
+        cache: { ttl: '60s', vary: ['Accept-Language'] },
+        cors: {
+          origins: ['https://app.example.com'],
+          credentials: true,
+        },
+      },
+    },
+    {
+      id: 'usersController.listItems',
+      method: 'GET',
+      path: '/v2/users',
+      controller: 'usersController',
+      routeKey: 'listItems',
+      metadata: {
+        upstream: 'users-service',
+        rewrite: { stripPrefix: '/v2' },
+        auth: {
+          jwt: { issuer: 'https://auth.example.com', audiences: ['users-api'] },
+        },
+        extensions: {
+          krakend: {
+            'qos/http-cache': { ttl: '10s' },
+          },
+        },
+      },
+    },
+  ],
+}

--- a/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
@@ -1,0 +1,98 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderKrakendConfig > matches the JSON snapshot for the fixture manifest 1`] = `
+{
+  "endpoints": [
+    {
+      "backend": [
+        {
+          "encoding": "no-op",
+          "extra_config": {
+            "backend/http/client": {
+              "timeout": "5s",
+            },
+          },
+          "host": [
+            "http://users:8081",
+          ],
+          "url_pattern": "/users",
+        },
+      ],
+      "endpoint": "/users",
+      "extra_config": {
+        "qos/circuit-breaker": {
+          "max_requests": 100,
+          "max_retries": 3,
+        },
+        "qos/ratelimit/router": {
+          "client_max_rate": 10,
+          "every": "1m",
+          "max_rate": 10,
+          "strategy": "ip",
+        },
+      },
+      "method": "POST",
+      "output_encoding": "no-op",
+    },
+    {
+      "backend": [
+        {
+          "encoding": "no-op",
+          "host": [
+            "http://users:8081",
+          ],
+          "url_pattern": "/users/{userId}",
+        },
+      ],
+      "endpoint": "/users/{userId}",
+      "extra_config": {
+        "qos/http-cache": {
+          "ttl": "60s",
+          "vary": [
+            "Accept-Language",
+          ],
+        },
+      },
+      "method": "GET",
+      "output_encoding": "no-op",
+    },
+    {
+      "backend": [
+        {
+          "encoding": "no-op",
+          "host": [
+            "http://users:8081",
+          ],
+          "url_pattern": "/users",
+        },
+      ],
+      "endpoint": "/v2/users",
+      "extra_config": {
+        "auth/validator": {
+          "alg": "RS256",
+          "audience": [
+            "users-api",
+          ],
+          "issuer": "https://auth.example.com",
+        },
+        "qos/http-cache": {
+          "ttl": "10s",
+        },
+      },
+      "method": "GET",
+      "output_encoding": "no-op",
+    },
+  ],
+  "extra_config": {
+    "security/cors": {
+      "allow_credentials": true,
+      "allow_origins": [
+        "https://app.example.com",
+      ],
+    },
+  },
+  "name": "users-api",
+  "port": 8080,
+  "version": 3,
+}
+`;

--- a/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
@@ -7,11 +7,6 @@ exports[`renderKrakendConfig > matches the JSON snapshot for the fixture manifes
       "backend": [
         {
           "encoding": "no-op",
-          "extra_config": {
-            "backend/http/client": {
-              "timeout": "5s",
-            },
-          },
           "host": [
             "http://users:8081",
           ],
@@ -28,6 +23,7 @@ exports[`renderKrakendConfig > matches the JSON snapshot for the fixture manifes
       },
       "method": "POST",
       "output_encoding": "no-op",
+      "timeout": "5s",
     },
     {
       "backend": [

--- a/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
@@ -20,14 +20,9 @@ exports[`renderKrakendConfig > matches the JSON snapshot for the fixture manifes
       ],
       "endpoint": "/users",
       "extra_config": {
-        "qos/circuit-breaker": {
-          "max_requests": 100,
-          "max_retries": 3,
-        },
         "qos/ratelimit/router": {
           "client_max_rate": 10,
           "every": "1m",
-          "max_rate": 10,
           "strategy": "ip",
         },
       },

--- a/packages/gateway-krakend/src/durations.ts
+++ b/packages/gateway-krakend/src/durations.ts
@@ -1,6 +1,12 @@
 /**
- * KrakenD durations are Go-style (`5s`, `300ms`, `1m`). Our universal format
- * already matches Go's grammar, so this is a pass-through with light validation.
+ * Pass through a universal `Duration` string into a KrakenD duration.
+ *
+ * KrakenD accepts a wider Go-style set (`ns`, `us` / `µs`, `ms`, `s`, `m`,
+ * `h`), but the *universal* `Duration` model declared in
+ * `opinionated-machine/lib/gateway/gatewayMetadata.ts` only allows
+ * `ms` / `s` / `m` / `h` and is enforced at attach time. So inputs that
+ * reach this function are already constrained to that subset; the regex
+ * here is a defensive belt-and-braces check, not a parser.
  */
 export function toKrakendDuration(input: string): string {
   if (!/^\d+(ms|s|m|h)$/.test(input)) {

--- a/packages/gateway-krakend/src/durations.ts
+++ b/packages/gateway-krakend/src/durations.ts
@@ -1,0 +1,10 @@
+/**
+ * KrakenD durations are Go-style (`5s`, `300ms`, `1m`). Our universal format
+ * already matches Go's grammar, so this is a pass-through with light validation.
+ */
+export function toKrakendDuration(input: string): string {
+  if (!/^\d+(ms|s|m|h)$/.test(input)) {
+    throw new Error(`Unsupported duration "${input}" — expected formats like "5s", "300ms".`)
+  }
+  return input
+}

--- a/packages/gateway-krakend/src/index.ts
+++ b/packages/gateway-krakend/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  type KrakendConfigShape,
+  type KrakendOptions,
+  type RenderKrakendResult,
+  renderKrakendConfig,
+} from './render.ts'

--- a/packages/gateway-krakend/src/render.spec.ts
+++ b/packages/gateway-krakend/src/render.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { fixtureManifest } from './__fixtures__/manifest.fixture.ts'
+import { renderKrakendConfig } from './render.ts'
+
+describe('renderKrakendConfig', () => {
+  const options = {
+    port: 8080,
+    upstreams: { 'users-service': 'http://users:8081' },
+  }
+
+  it('matches the JSON snapshot for the fixture manifest', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    expect(json).toMatchSnapshot()
+  })
+
+  it('emits one endpoint per route in manifest order', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    expect(json.endpoints.map((e) => `${e.method} ${e.endpoint}`)).toEqual([
+      'POST /users',
+      'GET /users/{userId}',
+      'GET /v2/users',
+    ])
+  })
+
+  it('preserves OpenAPI {param} syntax (KrakenD native)', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    const getItem = json.endpoints.find((e) => e.endpoint === '/users/{userId}')
+    expect(getItem).toBeDefined()
+  })
+
+  it('promotes the first route-level cors block to the global extra_config', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    expect(json.extra_config['security/cors']).toMatchObject({
+      allow_origins: ['https://app.example.com'],
+      allow_credentials: true,
+    })
+  })
+
+  it('applies stripPrefix rewrites to backend url_pattern', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    const v2 = json.endpoints.find((e) => e.endpoint === '/v2/users')
+    expect(v2?.backend[0]?.url_pattern).toBe('/users')
+  })
+
+  it('throws when an upstream is referenced but no host is configured', () => {
+    expect(() => renderKrakendConfig(fixtureManifest, { port: 8080, upstreams: {} })).toThrow(
+      /upstream "users-service"/,
+    )
+  })
+
+  it('extensions.krakend deep-merges into endpoint extra_config', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    const listItems = json.endpoints.find((e) => e.endpoint === '/v2/users')
+    expect(listItems?.extra_config?.['qos/http-cache']).toEqual({ ttl: '10s' })
+  })
+})

--- a/packages/gateway-krakend/src/render.ts
+++ b/packages/gateway-krakend/src/render.ts
@@ -45,20 +45,17 @@ export function renderKrakendConfig(
       endpoint: route.path,
       method: route.method,
       output_encoding: 'no-op',
+      // KrakenD's request timeout is an endpoint-level field, NOT a
+      // `backend/http/client` extra_config — that plugin doesn't have a
+      // `timeout` setting and silently ignores it.
+      ...(route.metadata.timeouts?.request
+        ? { timeout: toKrakendDuration(route.metadata.timeouts.request) }
+        : {}),
       backend: [
         {
           host: [upstreamHost],
           url_pattern: applyRewrite(route.path, route.metadata.rewrite),
           encoding: 'no-op',
-          ...(route.metadata.timeouts?.request
-            ? {
-                extra_config: {
-                  'backend/http/client': {
-                    timeout: toKrakendDuration(route.metadata.timeouts.request),
-                  },
-                },
-              }
-            : {}),
         },
       ],
     }
@@ -257,6 +254,8 @@ type KrakendEndpoint = {
   endpoint: string
   method: string
   output_encoding: string
+  /** Endpoint-level request timeout (e.g. "200ms", "5s"). */
+  timeout?: string
   backend: KrakendBackend[]
   extra_config?: Record<string, unknown>
 }

--- a/packages/gateway-krakend/src/render.ts
+++ b/packages/gateway-krakend/src/render.ts
@@ -75,7 +75,7 @@ export function renderKrakendConfig(
     name: options.name ?? manifest.service,
     port: options.port,
     endpoints,
-    extra_config: buildGlobalExtraConfig(manifest),
+    extra_config: buildGlobalExtraConfig(manifest, warnings),
   }
 
   return { json: config, warnings }
@@ -142,11 +142,17 @@ function buildCacheExtra(
 }
 
 function buildRateLimitExtra(
+  routeId: string,
   rateLimit: NonNullable<GatewayMetadataValue['rateLimit']>,
+  warnings: string[],
 ): Record<string, unknown> {
-  // KrakenD distinguishes global (max_rate) from per-client (client_max_rate).
-  // Setting both to the same value would let the global cap dominate and
-  // make the per-client part dead, so we emit one or the other based on key.
+  // KrakenD's qos/ratelimit/router distinguishes:
+  //   - max_rate          shared cap across all clients
+  //   - client_max_rate   per-client cap, partitioned by `strategy` + `key`
+  //     - strategy: 'ip' | 'header'   are the OSS-supported shapes
+  // `query` / `customQuery` keys from the universal model have no OSS
+  // equivalent — surface a warning and fall back to a shared cap rather
+  // than silently demoting the policy to a different identity.
   const every = toKrakendDuration(rateLimit.per)
   const key = rateLimit.key
   if (key === 'ip') {
@@ -167,6 +173,13 @@ function buildRateLimitExtra(
       strategy: 'header',
       key: key.customHeader,
     }
+  }
+  if (key && typeof key === 'object' && ('query' in key || 'customQuery' in key)) {
+    const queryKey = 'query' in key ? key.query : key.customQuery
+    warnings.push(
+      `Route "${routeId}": KrakenD's qos/ratelimit/router has no querystring strategy — metadata.rateLimit.key='${queryKey}' is being demoted to a shared max_rate. Wire a custom plugin via extensions.krakend if true per-query-value limiting is needed.`,
+    )
+    return { max_rate: rateLimit.requests, every }
   }
   return { max_rate: rateLimit.requests, every }
 }
@@ -190,7 +203,9 @@ function buildEndpointExtraConfig(
   const extra: Record<string, unknown> = {}
 
   if (meta.cache?.ttl) extra['qos/http-cache'] = buildCacheExtra(meta.cache)
-  if (meta.rateLimit) extra['qos/ratelimit/router'] = buildRateLimitExtra(meta.rateLimit)
+  if (meta.rateLimit) {
+    extra['qos/ratelimit/router'] = buildRateLimitExtra(routeId, meta.rateLimit, warnings)
+  }
   if (meta.auth?.jwt) extra['auth/validator'] = buildJwtExtra(meta.auth.jwt)
 
   if (meta.circuitBreaker) {
@@ -208,10 +223,30 @@ function buildEndpointExtraConfig(
     )
   }
 
-  // Vendor escape hatch: deep-merge extensions.krakend last.
+  // Vendor escape hatch: deep-merge extensions.krakend per extra-config
+  // block. Shallow assignment would let a partial extension like
+  // `extensions.krakend['qos/http-cache'] = { vary: ['x-region'] }` clobber
+  // the `ttl` / `methods` we already emitted into the same key.
   const krakendExt = meta.extensions?.krakend as Record<string, unknown> | undefined
   if (krakendExt) {
-    Object.assign(extra, krakendExt)
+    for (const [key, value] of Object.entries(krakendExt)) {
+      const existing = extra[key]
+      if (
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        existing &&
+        typeof existing === 'object' &&
+        !Array.isArray(existing)
+      ) {
+        extra[key] = {
+          ...(existing as Record<string, unknown>),
+          ...(value as Record<string, unknown>),
+        }
+      } else {
+        extra[key] = value
+      }
+    }
   }
 
   return extra
@@ -232,11 +267,30 @@ function buildCorsGlobalConfig(
   }
 }
 
-function buildGlobalExtraConfig(manifest: GatewayManifest): Record<string, unknown> {
-  // Promote the first route-level CORS block to the listener — KrakenD applies
-  // CORS globally rather than per-endpoint.
-  const firstCors = manifest.routes.find((r) => r.metadata.cors)?.metadata.cors
-  return firstCors ? buildCorsGlobalConfig(firstCors) : {}
+function buildGlobalExtraConfig(
+  manifest: GatewayManifest,
+  warnings: string[],
+): Record<string, unknown> {
+  // KrakenD's CORS plugin only attaches at the service (root) level — there
+  // is no per-endpoint CORS plugin in OSS KrakenD. We promote the first
+  // declared CORS block to global; if there are multiple distinct ones,
+  // we warn so the operator knows the others are being dropped.
+  const corsRoutes = manifest.routes.filter((r) => r.metadata.cors)
+  if (corsRoutes.length === 0) return {}
+
+  const distinct = new Set(corsRoutes.map((r) => JSON.stringify(r.metadata.cors)))
+  if (distinct.size > 1) {
+    warnings.push(
+      `Multiple distinct metadata.cors blocks found across routes; KrakenD only supports a single global CORS policy, so the first one is being applied to all routes. The others (from routes ${corsRoutes
+        .slice(1)
+        .map((r) => `"${r.id}"`)
+        .join(', ')}) are being dropped.`,
+    )
+  }
+  // corsRoutes was filtered to entries with metadata.cors set, so the cast
+  // is just stripping the index-signature undefined.
+  const first = corsRoutes[0] as (typeof corsRoutes)[number]
+  return buildCorsGlobalConfig(first.metadata.cors as NonNullable<typeof first.metadata.cors>)
 }
 
 // ============================================================================

--- a/packages/gateway-krakend/src/render.ts
+++ b/packages/gateway-krakend/src/render.ts
@@ -1,0 +1,239 @@
+import type { GatewayManifest, GatewayMetadataValue } from 'opinionated-machine'
+import { toKrakendDuration } from './durations.ts'
+
+export type KrakendOptions = {
+  /** KrakenD listener port. */
+  port: number
+  /** Map from `metadata.upstream` to base URL (e.g. `http://users:8081`). */
+  upstreams: Record<string, string>
+  /** Optional name for the resulting config; defaults to manifest.service. */
+  name?: string
+}
+
+export type RenderKrakendResult = {
+  json: KrakendConfigShape
+  warnings: string[]
+}
+
+/**
+ * Render a KrakenD v3 configuration object from a gateway manifest.
+ *
+ * KrakenD's `{var}` path syntax is native, so paths pass through unchanged.
+ * Cache and rate-limit are first-class in KrakenD, so this generator covers
+ * those (whereas the Envoy generator does not in v1).
+ */
+export function renderKrakendConfig(
+  manifest: GatewayManifest,
+  options: KrakendOptions,
+): RenderKrakendResult {
+  const warnings: string[] = []
+
+  const endpoints = manifest.routes.map((route) => {
+    if (!route.metadata.upstream) {
+      throw new Error(
+        `Route "${route.id}" has no upstream — set metadata.upstream on the route or controller defaults.`,
+      )
+    }
+    const upstreamHost = options.upstreams[route.metadata.upstream]
+    if (!upstreamHost) {
+      throw new Error(
+        `Manifest references upstream "${route.metadata.upstream}" but no host was configured in KrakendOptions.upstreams.`,
+      )
+    }
+
+    const endpoint: KrakendEndpoint = {
+      endpoint: route.path,
+      method: route.method,
+      output_encoding: 'no-op',
+      backend: [
+        {
+          host: [upstreamHost],
+          url_pattern: applyRewrite(route.path, route.metadata.rewrite),
+          encoding: 'no-op',
+          ...(route.metadata.timeouts?.request
+            ? {
+                extra_config: {
+                  'backend/http/client': {
+                    timeout: toKrakendDuration(route.metadata.timeouts.request),
+                  },
+                },
+              }
+            : {}),
+        },
+      ],
+    }
+
+    const extraConfig = buildEndpointExtraConfig(route.id, route.metadata, warnings)
+    if (Object.keys(extraConfig).length > 0) {
+      endpoint.extra_config = extraConfig
+    }
+
+    if (route.metadata.headers?.request?.add) {
+      warnings.push(
+        `Route "${route.id}": metadata.headers.request.add is not natively expressed in KrakenD; use extensions.krakend or a Lua plugin if needed.`,
+      )
+    }
+    if (route.metadata.match?.host) {
+      warnings.push(
+        `Route "${route.id}": metadata.match.host has no direct KrakenD equivalent — host routing is typically handled at the listener level.`,
+      )
+    }
+
+    return endpoint
+  })
+
+  const config: KrakendConfigShape = {
+    version: 3,
+    name: options.name ?? manifest.service,
+    port: options.port,
+    endpoints,
+    extra_config: buildGlobalExtraConfig(manifest),
+  }
+
+  return { json: config, warnings }
+}
+
+function applyRewrite(path: string, rewrite: GatewayMetadataValue['rewrite']): string {
+  if (rewrite?.replacePrefix) {
+    return path.startsWith(rewrite.replacePrefix.from)
+      ? rewrite.replacePrefix.to + path.slice(rewrite.replacePrefix.from.length)
+      : path
+  }
+  if (rewrite?.stripPrefix) {
+    return path.startsWith(rewrite.stripPrefix)
+      ? path.slice(rewrite.stripPrefix.length) || '/'
+      : path
+  }
+  return path
+}
+
+function buildCacheExtra(
+  cache: NonNullable<GatewayMetadataValue['cache']>,
+): Record<string, unknown> {
+  return {
+    ttl: toKrakendDuration(cache.ttl),
+    ...(cache.vary?.length ? { vary: cache.vary } : {}),
+  }
+}
+
+function buildRateLimitExtra(
+  rateLimit: NonNullable<GatewayMetadataValue['rateLimit']>,
+): Record<string, unknown> {
+  const base = {
+    max_rate: rateLimit.requests,
+    every: toKrakendDuration(rateLimit.per),
+  }
+  const key = rateLimit.key
+  if (key === 'ip') {
+    return { ...base, client_max_rate: rateLimit.requests, strategy: 'ip' }
+  }
+  if (key && typeof key === 'object' && 'header' in key) {
+    return { ...base, client_max_rate: rateLimit.requests, strategy: 'header', key: key.header }
+  }
+  if (key && typeof key === 'object' && 'customHeader' in key) {
+    return {
+      ...base,
+      client_max_rate: rateLimit.requests,
+      strategy: 'header',
+      key: key.customHeader,
+    }
+  }
+  return base
+}
+
+function buildCircuitBreakerExtra(
+  cb: NonNullable<GatewayMetadataValue['circuitBreaker']>,
+): Record<string, unknown> {
+  return {
+    ...(cb.maxRequests !== undefined ? { max_requests: cb.maxRequests } : {}),
+    ...(cb.maxRetries !== undefined ? { max_retries: cb.maxRetries } : {}),
+  }
+}
+
+function buildJwtExtra(
+  jwt: NonNullable<NonNullable<GatewayMetadataValue['auth']>['jwt']>,
+): Record<string, unknown> {
+  return {
+    alg: 'RS256',
+    issuer: jwt.issuer,
+    ...(jwt.audiences?.length ? { audience: jwt.audiences } : {}),
+    ...(jwt.jwksUri ? { jwk_url: jwt.jwksUri } : {}),
+  }
+}
+
+function buildEndpointExtraConfig(
+  routeId: string,
+  meta: GatewayMetadataValue,
+  warnings: string[],
+): Record<string, unknown> {
+  const extra: Record<string, unknown> = {}
+
+  if (meta.cache?.ttl) extra['qos/http-cache'] = buildCacheExtra(meta.cache)
+  if (meta.rateLimit) extra['qos/ratelimit/router'] = buildRateLimitExtra(meta.rateLimit)
+  if (meta.circuitBreaker)
+    extra['qos/circuit-breaker'] = buildCircuitBreakerExtra(meta.circuitBreaker)
+  if (meta.auth?.jwt) extra['auth/validator'] = buildJwtExtra(meta.auth.jwt)
+
+  if (meta.retry?.attempts !== undefined) {
+    warnings.push(
+      `Route "${routeId}": metadata.retry is best modelled in KrakenD via the backend "backend/http/client" config; v1 emits attempts only on a best-effort basis.`,
+    )
+  }
+
+  // Vendor escape hatch: deep-merge extensions.krakend last.
+  const krakendExt = meta.extensions?.krakend as Record<string, unknown> | undefined
+  if (krakendExt) {
+    Object.assign(extra, krakendExt)
+  }
+
+  return extra
+}
+
+function buildCorsGlobalConfig(
+  cors: NonNullable<GatewayMetadataValue['cors']>,
+): Record<string, unknown> {
+  return {
+    'security/cors': {
+      allow_origins: cors.origins,
+      ...(cors.methods ? { allow_methods: cors.methods } : {}),
+      ...(cors.headers ? { allow_headers: cors.headers } : {}),
+      ...(cors.exposeHeaders ? { expose_headers: cors.exposeHeaders } : {}),
+      ...(cors.credentials !== undefined ? { allow_credentials: cors.credentials } : {}),
+      ...(cors.maxAge ? { max_age: toKrakendDuration(cors.maxAge) } : {}),
+    },
+  }
+}
+
+function buildGlobalExtraConfig(manifest: GatewayManifest): Record<string, unknown> {
+  // Promote the first route-level CORS block to the listener — KrakenD applies
+  // CORS globally rather than per-endpoint.
+  const firstCors = manifest.routes.find((r) => r.metadata.cors)?.metadata.cors
+  return firstCors ? buildCorsGlobalConfig(firstCors) : {}
+}
+
+// ============================================================================
+// Type definitions for the KrakenD subset we emit.
+// ============================================================================
+
+type KrakendBackend = {
+  host: string[]
+  url_pattern: string
+  encoding: string
+  extra_config?: Record<string, unknown>
+}
+
+type KrakendEndpoint = {
+  endpoint: string
+  method: string
+  output_encoding: string
+  backend: KrakendBackend[]
+  extra_config?: Record<string, unknown>
+}
+
+export type KrakendConfigShape = {
+  version: 3
+  name: string
+  port: number
+  endpoints: KrakendEndpoint[]
+  extra_config: Record<string, unknown>
+}

--- a/packages/gateway-krakend/src/render.ts
+++ b/packages/gateway-krakend/src/render.ts
@@ -68,16 +68,7 @@ export function renderKrakendConfig(
       endpoint.extra_config = extraConfig
     }
 
-    if (route.metadata.headers?.request?.add) {
-      warnings.push(
-        `Route "${route.id}": metadata.headers.request.add is not natively expressed in KrakenD; use extensions.krakend or a Lua plugin if needed.`,
-      )
-    }
-    if (route.metadata.match?.host) {
-      warnings.push(
-        `Route "${route.id}": metadata.match.host has no direct KrakenD equivalent — host routing is typically handled at the listener level.`,
-      )
-    }
+    collectUnsupportedWarnings(route.id, route.metadata, warnings)
 
     return endpoint
   })
@@ -91,6 +82,43 @@ export function renderKrakendConfig(
   }
 
   return { json: config, warnings }
+}
+
+function collectUnsupportedWarnings(
+  routeId: string,
+  meta: GatewayMetadataValue,
+  warnings: string[],
+): void {
+  if (meta.headers?.request?.add || meta.headers?.request?.remove) {
+    warnings.push(
+      `Route "${routeId}": metadata.headers.request is not natively expressed in KrakenD; use extensions.krakend or a Lua plugin.`,
+    )
+  }
+  if (meta.headers?.response?.add || meta.headers?.response?.remove) {
+    warnings.push(
+      `Route "${routeId}": metadata.headers.response is not natively expressed in KrakenD; use extensions.krakend or a Lua plugin.`,
+    )
+  }
+  if (meta.match?.host) {
+    warnings.push(
+      `Route "${routeId}": metadata.match.host has no direct KrakenD equivalent — host routing is typically handled at the listener level.`,
+    )
+  }
+  if (meta.traffic?.weights || meta.traffic?.shadow) {
+    warnings.push(
+      `Route "${routeId}": metadata.traffic (weighted / shadow) is not modelled in KrakenD — set up a separate KrakenD instance or use extensions.krakend.`,
+    )
+  }
+  if (meta.auth?.required && !meta.auth.jwt) {
+    warnings.push(
+      `Route "${routeId}": metadata.auth.required without auth.jwt has no automatic mapping — wire authentication via extensions.krakend.`,
+    )
+  }
+  if (meta.auth?.mTLS) {
+    warnings.push(
+      `Route "${routeId}": metadata.auth.mTLS is not modelled — terminate mTLS at the listener / reverse proxy in front of KrakenD.`,
+    )
+  }
 }
 
 function applyRewrite(path: string, rewrite: GatewayMetadataValue['rewrite']): string {
@@ -119,35 +147,31 @@ function buildCacheExtra(
 function buildRateLimitExtra(
   rateLimit: NonNullable<GatewayMetadataValue['rateLimit']>,
 ): Record<string, unknown> {
-  const base = {
-    max_rate: rateLimit.requests,
-    every: toKrakendDuration(rateLimit.per),
-  }
+  // KrakenD distinguishes global (max_rate) from per-client (client_max_rate).
+  // Setting both to the same value would let the global cap dominate and
+  // make the per-client part dead, so we emit one or the other based on key.
+  const every = toKrakendDuration(rateLimit.per)
   const key = rateLimit.key
   if (key === 'ip') {
-    return { ...base, client_max_rate: rateLimit.requests, strategy: 'ip' }
+    return { client_max_rate: rateLimit.requests, every, strategy: 'ip' }
   }
   if (key && typeof key === 'object' && 'header' in key) {
-    return { ...base, client_max_rate: rateLimit.requests, strategy: 'header', key: key.header }
+    return {
+      client_max_rate: rateLimit.requests,
+      every,
+      strategy: 'header',
+      key: key.header,
+    }
   }
   if (key && typeof key === 'object' && 'customHeader' in key) {
     return {
-      ...base,
       client_max_rate: rateLimit.requests,
+      every,
       strategy: 'header',
       key: key.customHeader,
     }
   }
-  return base
-}
-
-function buildCircuitBreakerExtra(
-  cb: NonNullable<GatewayMetadataValue['circuitBreaker']>,
-): Record<string, unknown> {
-  return {
-    ...(cb.maxRequests !== undefined ? { max_requests: cb.maxRequests } : {}),
-    ...(cb.maxRetries !== undefined ? { max_retries: cb.maxRetries } : {}),
-  }
+  return { max_rate: rateLimit.requests, every }
 }
 
 function buildJwtExtra(
@@ -170,13 +194,20 @@ function buildEndpointExtraConfig(
 
   if (meta.cache?.ttl) extra['qos/http-cache'] = buildCacheExtra(meta.cache)
   if (meta.rateLimit) extra['qos/ratelimit/router'] = buildRateLimitExtra(meta.rateLimit)
-  if (meta.circuitBreaker)
-    extra['qos/circuit-breaker'] = buildCircuitBreakerExtra(meta.circuitBreaker)
   if (meta.auth?.jwt) extra['auth/validator'] = buildJwtExtra(meta.auth.jwt)
+
+  if (meta.circuitBreaker) {
+    // The universal model is Envoy-style (concurrency limits). KrakenD's
+    // qos/circuit-breaker is error-rate-based (max_errors / interval), a
+    // different abstraction — wire it via extensions.krakend if you need it.
+    warnings.push(
+      `Route "${routeId}": metadata.circuitBreaker (concurrency limits) doesn't translate to KrakenD's error-rate-based qos/circuit-breaker — set extensions.krakend["qos/circuit-breaker"] explicitly if you want it.`,
+    )
+  }
 
   if (meta.retry?.attempts !== undefined) {
     warnings.push(
-      `Route "${routeId}": metadata.retry is best modelled in KrakenD via the backend "backend/http/client" config; v1 emits attempts only on a best-effort basis.`,
+      `Route "${routeId}": metadata.retry is best modelled in KrakenD under backend/http/client; this generator does not emit it — set extensions.krakend["backend/http/client"] explicitly.`,
     )
   }
 

--- a/packages/gateway-krakend/tsconfig.build.json
+++ b/packages/gateway-krakend/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"],
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/__fixtures__/**", "**/__snapshots__/**"]
+}

--- a/packages/gateway-krakend/tsconfig.json
+++ b/packages/gateway-krakend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "declaration": true,
+        "declarationMap": true,
+        "noEmit": true
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/gateway-krakend/vitest.acceptance.config.ts
+++ b/packages/gateway-krakend/vitest.acceptance.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Acceptance suite — runs only via `npm run test:acceptance`, which boots
+ * docker compose with a real KrakenD and stub upstream. Kept in a separate
+ * config so the default `vitest run` (used by `npm test`) never picks them up.
+ */
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['acceptance/**/*.acceptance.spec.ts'],
+    testTimeout: 30000,
+  },
+})

--- a/packages/gateway-krakend/vitest.config.ts
+++ b/packages/gateway-krakend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    testTimeout: 10000,
+  },
+})

--- a/test/DIContext.buildGatewayManifest.spec.ts
+++ b/test/DIContext.buildGatewayManifest.spec.ts
@@ -1,0 +1,66 @@
+import { createContainer } from 'awilix'
+import { describe, expect, it } from 'vitest'
+import { DIContext } from '../lib/DIContext.js'
+import { TestModule, type TestModuleDependencies } from './TestModule.js'
+
+// biome-ignore lint/complexity/noBannedTypes: shape mirrors test/DIContext.spec.ts
+type Config = {}
+
+function createContext() {
+  const container = createContainer<TestModuleDependencies>({ injectionMode: 'PROXY' })
+  const context = new DIContext<TestModuleDependencies, Config>(container, {}, {})
+  context.registerDependencies({ modules: [new TestModule()] }, undefined)
+  return context
+}
+
+describe('DIContext.buildGatewayManifest', () => {
+  it('discovers all routes registered through controllers', () => {
+    const manifest = createContext().buildGatewayManifest({ service: 'test-service' })
+
+    expect(manifest.service).toBe('test-service')
+    expect(manifest.manifestVersion).toBe('1')
+    expect(manifest.routes.length).toBeGreaterThan(0)
+
+    const ids = manifest.routes.map((r) => r.id).sort()
+    expect(ids).toContain('testController.getItem')
+    expect(ids).toContain('testController.deleteItem')
+    expect(ids).toContain('testController.updateItem')
+    expect(ids).toContain('testController.createItem')
+  })
+
+  it('emits OpenAPI-style paths', () => {
+    const manifest = createContext().buildGatewayManifest({ service: 'test-service' })
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    expect(getItem?.path).toBe('/users/{userId}')
+    expect(getItem?.method).toBe('GET')
+  })
+
+  it('reads metadata from withGatewayMetadata and leaves un-annotated routes empty', () => {
+    const manifest = createContext().buildGatewayManifest({ service: 'test-service' })
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    const deleteItem = manifest.routes.find((r) => r.routeKey === 'deleteItem')
+    expect(getItem?.metadata).toEqual({ cache: { ttl: '60s' } })
+    expect(deleteItem?.metadata).toEqual({})
+  })
+
+  it('applies service-wide defaults to every route, deep-merging into route metadata', () => {
+    const manifest = createContext().buildGatewayManifest({
+      service: 'test-service',
+      defaults: { timeouts: { request: '5s' }, tags: ['rest'] },
+    })
+    for (const route of manifest.routes) {
+      expect(route.metadata.timeouts).toEqual({ request: '5s' })
+      expect(route.metadata.tags).toEqual(['rest'])
+    }
+    // Defaults coexist with route-level metadata.
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    expect(getItem?.metadata.cache).toEqual({ ttl: '60s' })
+  })
+
+  it('routes are sorted deterministically by path then method', () => {
+    const manifest = createContext().buildGatewayManifest({ service: 'test-service' })
+    const sortKey = (m: { path: string; method: string }) => `${m.path} ${m.method}`
+    const sorted = [...manifest.routes].sort((a, b) => sortKey(a).localeCompare(sortKey(b)))
+    expect(manifest.routes).toEqual(sorted)
+  })
+})

--- a/test/TestController.ts
+++ b/test/TestController.ts
@@ -2,6 +2,7 @@ import { buildRestContract } from '@lokalise/api-contracts'
 import { buildFastifyRoute } from '@lokalise/fastify-api-contracts'
 import { boolean, z } from 'zod/v4'
 import { AbstractController, type BuildRoutesReturnType } from '../lib/AbstractController.js'
+import { withGatewayMetadata } from '../lib/gateway/index.js'
 import type { TestModuleDependencies, TestService } from './TestModule.js'
 
 const REQUEST_BODY_SCHEMA = z.object({
@@ -87,7 +88,11 @@ export class TestController extends AbstractController<typeof TestController.con
 
   public buildRoutes(): BuildRoutesReturnType<typeof TestController.contracts> {
     return {
-      getItem: this.getItem,
+      // Annotated with gateway metadata so DIContext.buildGatewayManifest()
+      // exercises the symbol-read path in our integration tests.
+      getItem: withGatewayMetadata(TestController.contracts.getItem, this.getItem, {
+        cache: { ttl: '60s' },
+      }),
       deleteItem: this.deleteItem,
       updateItem: this.updateItem,
       createItem: this.createItem,


### PR DESCRIPTION
Add a vendor-neutral gateway metadata layer on top of opinionated-machine
controller routes plus per-gateway generator packages that consume a
versioned, JSON-serializable manifest.

Authoring:
- withGatewayMetadata(contract, route, metadata) attaches metadata to a
  route via a non-enumerable Symbol; same-reference return so Fastify
  never sees it. Applied at the buildRoutes() return site so all
  annotations live in one scannable block per controller.
- gatewayDefaults?: GatewayMetadataValue is part of the AbstractController
  / AbstractApiController interface; service-wide defaults pass through
  DIContext.buildGatewayManifest({ defaults }). Three-layer deep merge
  via ts-deepmerge.
- match.headers / match.query keys narrow to contract.requestHeaderSchema
  / requestQuerySchema; explicit customHeaders / customQuery escape
  hatches for headers not in the contract.

Collection:
- DIContext.buildGatewayManifest({ service, version?, defaults? }) walks
  controller buckets, reads the metadata symbol, normalizes paths to
  OpenAPI form, validates the result via Zod and returns a stable
  manifest sorted by (path, method).

Optional Fastify plugin:
- fastifyGatewayPlugin decorates app.gateway.getManifest() and exposes
  GET /_gateway/manifest by default (configurable). Convenient for CLIs
  and sibling processes that fetch the manifest over HTTP.

Generator packages (each isolated, peer-deps on opinionated-machine,
mirrors packages/sse-rooms-redis layout):
- @opinionated-machine/gateway-envoy  — Envoy v3 static config (YAML/JSON)
- @opinionated-machine/gateway-krakend — KrakenD v3 declarative (JSON)
- @opinionated-machine/gateway-kong   — Kong DB-less declarative (YAML/JSON)

Each generator is a pure render(manifest, options) function returning
{ yaml?, json, warnings }. Universal fields are mapped where the gateway
supports them; unsupported fields surface in `warnings[]` rather than
being silently dropped. extensions.<vendor> is the per-route escape hatch.

Acceptance tests:
- Per-package docker-compose.yml boots the real gateway + a Node stub
  upstream; vitest.acceptance.config.ts runs the spec separately from
  unit tests.
- .github/workflows/gateway-acceptance.yml runs them only when
  lib/gateway/** or any packages/gateway-* path 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added gateway configuration system enabling route-level policy declarations (timeouts, rate limits, authentication, caching, headers, CORS, retries, circuit breakers)
  * Introduced three gateway generators: Envoy, Kong, and KrakenD for automatic proxy configuration from route metadata
  * Added Fastify plugin to build and expose gateway manifests via HTTP
  * Added acceptance test workflows for gateway generators

* **Documentation**
  * Added comprehensive gateway configuration guide with examples
  * Added READMEs for Envoy, Kong, and KrakenD packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->