### PR TITLE
feat: align api controller with existing controller

### DIFF
--- a/lib/DIContext.ts
+++ b/lib/DIContext.ts
@@ -247,7 +247,8 @@ export class DIContext<
     }
 
     for (const name of this.apiControllerNames) {
-      const controller: AbstractApiController = this.diContainer.resolve(name)
+      // biome-ignore lint/suspicious/noExplicitAny: any api controller works here
+      const controller: AbstractApiController<any> = this.diContainer.resolve(name)
       collected.push({ name, kind: 'api', controller })
     }
 

--- a/lib/DIContext.ts
+++ b/lib/DIContext.ts
@@ -199,9 +199,10 @@ export class DIContext<
     }
 
     for (const controllerName of this.apiControllerNames) {
-      const controller: AbstractApiController = this.diContainer.resolve(controllerName)
+      // biome-ignore lint/suspicious/noExplicitAny: any api controllers works here
+      const controller: AbstractApiController<any> = this.diContainer.resolve(controllerName)
 
-      for (const route of controller.routes) {
+      for (const route of Object.values(controller.routes)) {
         app.route(route)
       }
     }

--- a/lib/api-contracts/AbstractApiController.ts
+++ b/lib/api-contracts/AbstractApiController.ts
@@ -1,20 +1,34 @@
+import type { ApiContract } from '@lokalise/api-contracts'
 import type { RouteOptions } from 'fastify'
 
 /**
  * Abstract base class for controllers that use the `ApiContract` API.
  *
- * Concrete controllers declare a `routes` property built with `buildApiRoute()`.
+ * Concrete controllers declare a static `contracts` field and a `routes` object
+ * built with `buildApiRoute()`. The generic ensures every contract has a matching route.
  *
  * @example
  * ```typescript
- * class UserController extends AbstractApiController {
- *   readonly routes = [
- *     buildApiRoute(getUser, async (req) => ({ status: 200, body: { id: req.params.id } })),
- *     buildApiRoute(streamUpdates, async (_req, sse) => { sse.start('keepAlive') }),
- *   ]
+ * class UserController extends AbstractApiController<typeof UserController.contracts> {
+ *   static contracts = {
+ *     getUser: getUserContract,
+ *     streamUpdates: streamUpdatesContract,
+ *   } as const
+ *
+ *   readonly routes = {
+ *     getUser: buildApiRoute(UserController.contracts.getUser, async (req) => ({
+ *       status: 200,
+ *       body: { id: req.params.id },
+ *     })),
+ *     streamUpdates: buildApiRoute(UserController.contracts.streamUpdates, async (_req, sse) => {
+ *       sse.start('keepAlive')
+ *     }),
+ *   }
  * }
  * ```
  */
-export abstract class AbstractApiController {
-  abstract readonly routes: RouteOptions[]
+export abstract class AbstractApiController<
+  APIContracts extends Record<string, ApiContract>,
+> {
+  abstract readonly routes: Record<keyof APIContracts, RouteOptions>
 }

--- a/lib/api-contracts/AbstractApiController.ts
+++ b/lib/api-contracts/AbstractApiController.ts
@@ -27,8 +27,6 @@ import type { RouteOptions } from 'fastify'
  * }
  * ```
  */
-export abstract class AbstractApiController<
-  APIContracts extends Record<string, ApiContract>,
-> {
+export abstract class AbstractApiController<APIContracts extends Record<string, ApiContract>> {
   abstract readonly routes: Record<keyof APIContracts, RouteOptions>
 }

--- a/lib/api-contracts/docs.md
+++ b/lib/api-contracts/docs.md
@@ -94,7 +94,7 @@ TypeScript enforces the correct shape — passing `{ nonSse, sse }` to a non-dua
 
 ## Creating a Controller
 
-Extend `AbstractApiController` and declare a `routes` array. Use `buildApiRoute` to define each route:
+Extend `AbstractApiController` with a `static contracts` object and a `routes` object built with `buildApiRoute`. The generic ensures every contract has a matching named route:
 
 ```ts
 import {
@@ -102,7 +102,14 @@ import {
   buildApiRoute,
 } from 'opinionated-machine'
 
-class UserController extends AbstractApiController {
+class UserController extends AbstractApiController<typeof UserController.contracts> {
+  static contracts = {
+    getUser: getUserContract,
+    deleteUser: deleteUserContract,
+    streamUpdates: streamUpdatesContract,
+    chat: chatContract,
+  } as const
+
   private readonly userService: UserService
   private readonly aiService: AIService
 
@@ -111,26 +118,26 @@ class UserController extends AbstractApiController {
     this.aiService = deps.aiService
   }
 
-  readonly routes = [
+  readonly routes = {
     // Non-SSE: return { status, body }
-    buildApiRoute(getUserContract, async (request) => ({
+    getUser: buildApiRoute(UserController.contracts.getUser, async (request) => ({
       status: 200,
       body: await this.userService.findById(request.params.userId),
     })),
 
     // Non-SSE no-body response
-    buildApiRoute(deleteUserContract, async (request) => {
+    deleteUser: buildApiRoute(UserController.contracts.deleteUser, async (request) => {
       await this.userService.delete(request.params.userId)
       return { status: 204, body: null }
     }),
 
     // SSE-only: second param is the SSE context
-    buildApiRoute(streamUpdatesContract, async (_request, sse) => {
+    streamUpdates: buildApiRoute(UserController.contracts.streamUpdates, async (_request, sse) => {
       sse.start('keepAlive')
     }),
 
     // Dual-mode: { nonSse, sse } object
-    buildApiRoute(chatContract, {
+    chat: buildApiRoute(UserController.contracts.chat, {
       nonSse: async (request) => {
         const result = await this.aiService.complete(request.body.message)
         return { status: 200, body: { reply: result.text } }
@@ -143,7 +150,7 @@ class UserController extends AbstractApiController {
         await session.send('done', {})
       },
     }),
-  ]
+  }
 }
 ```
 
@@ -196,7 +203,7 @@ export class UserModule extends AbstractModule {
 }
 ```
 
-`asApiControllerClass` wraps the class in an awilix `asFunction` singleton resolver tagged with `isApiController: true`, so `DIContext` picks up its `routes` array automatically during `registerRoutes()`.
+`asApiControllerClass` wraps the class in an awilix `asFunction` singleton resolver tagged with `isApiController: true`, so `DIContext` picks up its `routes` object automatically during `registerRoutes()`.
 
 ## Route Options
 

--- a/lib/gateway/manifest/buildManifest.ts
+++ b/lib/gateway/manifest/buildManifest.ts
@@ -35,7 +35,8 @@ type CollectedController =
       // biome-ignore lint/suspicious/noExplicitAny: contract generic erased at the manifest boundary
       controller: AbstractController<any>
     }
-  | { name: string; kind: 'api'; controller: AbstractApiController }
+  // biome-ignore lint/suspicious/noExplicitAny: contract generic erased at the manifest boundary
+  | { name: string; kind: 'api'; controller: AbstractApiController<any> }
 
 const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
 type CanonicalMethod = (typeof HTTP_METHODS)[number]
@@ -69,9 +70,9 @@ function collectRouteEntries(
     const built = collected.controller.buildRoutes() as Record<string, RouteOptions>
     return Object.entries(built).map(([routeKey, route]) => ({ routeKey, route }))
   }
-  // AbstractApiController: routes is an array — index becomes the routeKey.
-  return collected.controller.routes.map((route, index) => ({
-    routeKey: String(index),
+  // AbstractApiController: routes is a Record — key becomes the routeKey.
+  return Object.entries(collected.controller.routes).map(([routeKey, route]) => ({
+    routeKey,
     route,
   }))
 }

--- a/test/api-contracts/fixtures/testControllers.ts
+++ b/test/api-contracts/fixtures/testControllers.ts
@@ -17,19 +17,27 @@ import {
   apiValidationFailContract,
 } from './testContracts.ts'
 
-export class TestApiController extends AbstractApiController {
-  readonly routes = [
-    buildApiRoute(apiGetUserContract, async (request) => ({
+export class TestApiController extends AbstractApiController<typeof TestApiController.contracts> {
+  static contracts = {
+    getUser: apiGetUserContract,
+    createUser: apiCreateUserContract,
+    feed: apiFeedContract,
+    sseKeepAlive: apiSseKeepAliveContract,
+    sseSendStream: apiSseSendStreamContract,
+  } as const
+
+  readonly routes = {
+    getUser: buildApiRoute(TestApiController.contracts.getUser, async (request) => ({
       status: 200,
       body: { id: request.params.userId, name: 'Alice' },
     })),
 
-    buildApiRoute(apiCreateUserContract, (request) => ({
+    createUser: buildApiRoute(TestApiController.contracts.createUser, (request) => ({
       status: 201,
       body: { id: '1', name: request.body.name },
     })),
 
-    buildApiRoute(apiFeedContract, {
+    feed: buildApiRoute(TestApiController.contracts.feed, {
       nonSse: async (request) => ({
         status: 200,
         body: { id: 'summary', name: `limit=${request.query.limit ?? 'none'}` },
@@ -40,71 +48,101 @@ export class TestApiController extends AbstractApiController {
       },
     }),
 
-    buildApiRoute(apiSseKeepAliveContract, async (_request, sse) => {
+    sseKeepAlive: buildApiRoute(TestApiController.contracts.sseKeepAlive, async (_request, sse) => {
       const session = sse.start('keepAlive')
       await session.send('tick', { n: 1 })
     }),
 
-    buildApiRoute(apiSseSendStreamContract, async (_request, sse) => {
-      const session = sse.start('autoClose')
-      // biome-ignore lint/suspicious/useAwait: async generator required for AsyncIterable
-      async function* items() {
-        yield { event: 'item' as const, data: { i: 1 } }
-        yield { event: 'item' as const, data: { i: 2 } }
-      }
-      await session.sendStream(items())
-    }),
-  ]
+    sseSendStream: buildApiRoute(
+      TestApiController.contracts.sseSendStream,
+      async (_request, sse) => {
+        const session = sse.start('autoClose')
+        // biome-ignore lint/suspicious/useAwait: async generator required for AsyncIterable
+        async function* items() {
+          yield { event: 'item' as const, data: { i: 1 } }
+          yield { event: 'item' as const, data: { i: 2 } }
+        }
+        await session.sendStream(items())
+      },
+    ),
+  }
 }
 
-export class TestApiErrorController extends AbstractApiController {
-  readonly routes = [
-    buildApiRoute(apiSseRespondContract, (_request, sse) => {
+export class TestApiErrorController extends AbstractApiController<
+  typeof TestApiErrorController.contracts
+> {
+  static contracts = {
+    sseRespond: apiSseRespondContract,
+    sseNoStart: apiSseNoStartContract,
+    ssePreError: apiSsePreErrorContract,
+    ssePostError: apiSsePostErrorContract,
+    validationFail: apiValidationFailContract,
+    headerSuccess: apiHeaderSuccessContract,
+    headerFail: apiHeaderFailContract,
+    sseRespondAfterStart: apiSseRespondAfterStartContract,
+    sseSendHeaders: apiSseSendHeadersContract,
+    sseInvalidEvent: apiSseInvalidEventContract,
+  } as const
+
+  readonly routes = {
+    sseRespond: buildApiRoute(TestApiErrorController.contracts.sseRespond, (_request, sse) => {
       sse.respond(404, { error: 'not found' })
     }),
 
-    buildApiRoute(apiSseNoStartContract, () => {
+    sseNoStart: buildApiRoute(TestApiErrorController.contracts.sseNoStart, () => {
       // intentionally does nothing — exercises the no-start/no-respond error path
     }),
 
-    buildApiRoute(apiSsePreErrorContract, () => {
+    ssePreError: buildApiRoute(TestApiErrorController.contracts.ssePreError, () => {
       throw Object.assign(new Error('pre-start error'), { httpStatusCode: 422 })
     }),
 
-    buildApiRoute(apiSsePostErrorContract, (_request, sse) => {
+    ssePostError: buildApiRoute(TestApiErrorController.contracts.ssePostError, (_request, sse) => {
       sse.start('autoClose')
       throw new Error('post-start error')
     }),
 
-    buildApiRoute(apiValidationFailContract, () => ({
+    validationFail: buildApiRoute(TestApiErrorController.contracts.validationFail, () => ({
       status: 200,
       body: { value: 123 as unknown as string },
     })),
 
-    buildApiRoute(apiHeaderSuccessContract, (_request, reply) => {
-      reply.header('x-api-version', '1.0')
-      return { status: 200, body: { ok: true } }
-    }),
+    headerSuccess: buildApiRoute(
+      TestApiErrorController.contracts.headerSuccess,
+      (_request, reply) => {
+        reply.header('x-api-version', '1.0')
+        return { status: 200, body: { ok: true } }
+      },
+    ),
 
-    buildApiRoute(apiHeaderFailContract, () => ({
+    headerFail: buildApiRoute(TestApiErrorController.contracts.headerFail, () => ({
       status: 200,
       body: { ok: true },
     })),
 
-    buildApiRoute(apiSseRespondAfterStartContract, (_request, sse) => {
-      sse.start('autoClose')
-      sse.respond(200, { text: 'too late' })
-    }),
+    sseRespondAfterStart: buildApiRoute(
+      TestApiErrorController.contracts.sseRespondAfterStart,
+      (_request, sse) => {
+        sse.start('autoClose')
+        sse.respond(200, { text: 'too late' })
+      },
+    ),
 
-    buildApiRoute(apiSseSendHeadersContract, async (_request, sse) => {
-      sse.sendHeaders()
-      const session = sse.start('autoClose')
-      await session.send('done', { ok: true })
-    }),
+    sseSendHeaders: buildApiRoute(
+      TestApiErrorController.contracts.sseSendHeaders,
+      async (_request, sse) => {
+        sse.sendHeaders()
+        const session = sse.start('autoClose')
+        await session.send('done', { ok: true })
+      },
+    ),
 
-    buildApiRoute(apiSseInvalidEventContract, async (_request, sse) => {
-      const session = sse.start('autoClose')
-      await session.send('typed', { value: 'not-a-number' as unknown as number })
-    }),
-  ]
+    sseInvalidEvent: buildApiRoute(
+      TestApiErrorController.contracts.sseInvalidEvent,
+      async (_request, sse) => {
+        const session = sse.start('autoClose')
+        await session.send('typed', { value: 'not-a-number' as unknown as number })
+      },
+    ),
+  }
 }


### PR DESCRIPTION
## AbstractApiController — align with AbstractController pattern

* Change `routes` from `RouteOptions[]` to `Record<keyof APIContracts, RouteOptions>` — use named routes instead of an anonymous array
* Add generic `APIContracts extends Record<string, ApiContract>` so each controller declares a static `contracts` object; TypeScript then enforces that every contract has a matching named route
* Update `DIContext.registerRoutes` to iterate over `Object.values(controller.routes)`
* Update documentation examples and test fixtures to follow the new pattern


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized API controller routing architecture to use contract-based mapping.

* **Tests**
  * Updated test fixtures to align with new routing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->