### PR TITLE
feat: support inline gatewayMetadata on buildApiRoute options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2914,17 +2914,34 @@ The rest of this section unpacks each piece in detail.
 
 ### Annotating Routes
 
-`withGatewayMetadata(contract, route, metadata)` takes:
+There are two equivalent ways to attach metadata. Pick whichever fits your
+controller style — both validate the metadata at the call site, both stamp
+the same hidden symbol on the route, and both are read identically by the
+manifest builder.
 
-- the **contract** — used purely for type inference on `match.headers`,
-  `match.query` and `rateLimit.key`,
-- the **route** built by `buildFastifyRoute(...)` (or `buildApiRoute(...)`),
-- the **metadata** — see [Field Reference](#field-reference).
+**For `buildApiRoute`-built routes** (`AbstractApiController`), pass
+`gatewayMetadata` inline via the options argument:
 
-Apply it inside `buildRoutes()` (or in the `routes` array for
-`AbstractApiController`) so every route's gateway policy is in one scannable
-block. Annotated and un-annotated routes mix freely, and your existing
-`buildFastifyRoute(...)` calls don't change at all:
+```ts
+class UsersApiController extends AbstractApiController<typeof UsersApiController.contracts> {
+  static readonly contracts = { getUser, createUser, deleteUser } as const
+
+  readonly routes = {
+    getUser: buildApiRoute(UsersApiController.contracts.getUser, async (req) => /* … */, {
+      gatewayMetadata: { cache: { ttl: '60s' } },
+    }),
+    createUser: buildApiRoute(UsersApiController.contracts.createUser, async (req) => /* … */, {
+      gatewayMetadata: { rateLimit: { requests: 10, per: '1m', key: 'ip' } },
+    }),
+    deleteUser: buildApiRoute(UsersApiController.contracts.deleteUser, async (req) => /* … */),
+    // ^ no per-route policy; inherits controller + service defaults
+  }
+}
+```
+
+**For `buildFastifyRoute`-built routes** (`AbstractController`), or when you
+prefer to keep all gateway annotations in one scannable block separate from
+route construction, wrap with `withGatewayMetadata(contract, route, metadata)`:
 
 ```ts
 buildRoutes() {
@@ -2936,19 +2953,15 @@ buildRoutes() {
 }
 ```
 
-For api-contract controllers, drop it directly into `routes`:
+The contract drives type inference on `match.headers`, `match.query`, and
+`rateLimit.key` — see [Type-Safe Matching](#type-safe-matching). Metadata
+fields are documented in [Field Reference](#field-reference).
 
-```ts
-class UsersApiController extends AbstractApiController {
-  readonly routes = [
-    withGatewayMetadata(getUser, buildApiRoute(getUser, async (req) => /* … */), { cache: { ttl: '60s' } }),
-    buildApiRoute(deleteUser, async (req) => /* … */),
-  ]
-}
-```
-
-Annotations are invisible to Fastify — adding them never changes runtime
-behaviour, so you can introduce them gradually on an existing service.
+Annotations are invisible to Fastify (stamped via a non-enumerable `Symbol`),
+so adding them never changes runtime behaviour and you can introduce them
+gradually on an existing service. If both inline `gatewayMetadata` and
+`withGatewayMetadata` are applied to the same route, the later call
+overwrites — there is no merge; pick one form per route.
 
 ### Avoiding Repetition With Defaults
 
@@ -2960,7 +2973,7 @@ in a service. Declare them once:
 | ----- | ----- | ----------- |
 | Service-wide | `buildGatewayManifest({ defaults: … })` | Cross-cutting policy: CORS, idle timeouts, observability tags |
 | Controller   | `override readonly gatewayDefaults = { … }` | Per-controller upstream, auth posture, base timeouts |
-| Per-route    | `withGatewayMetadata(...)` | Anything specific to one endpoint |
+| Per-route    | `buildApiRoute(..., { gatewayMetadata })` *or* `withGatewayMetadata(...)` | Anything specific to one endpoint |
 
 Layers deep-merge in that order: service → controller → route. **Arrays in
 later layers replace** (not append), which keeps `weights`, `tags`, and
@@ -3008,6 +3021,18 @@ withGatewayMetadata(getUser, this.getUser, {
 `rateLimit.key` narrows the same way — `{ header: 'x-trace-id' }` only works
 if `'x-trace-id'` is in `requestHeaderSchema`; otherwise use
 `{ customHeader: '…' }`.
+
+The inline form on `buildApiRoute` provides the same narrowing — the contract
+is the first argument, so TS infers it for `gatewayMetadata` automatically:
+
+```ts
+buildApiRoute(getUser, async (req) => /* … */, {
+  gatewayMetadata: {
+    match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } }, // ✅
+    // 'x-typo' here would be a compile error against the contract's schema.
+  },
+})
+```
 
 ### Field Reference
 

--- a/lib/api-contracts/AbstractApiController.ts
+++ b/lib/api-contracts/AbstractApiController.ts
@@ -34,9 +34,10 @@ export abstract class AbstractApiController<APIContracts extends Record<string, 
   /**
    * Optional controller-level defaults for gateway metadata.
    *
-   * Merged underneath per-route metadata (attached via `withGatewayMetadata`)
-   * when `DIContext.buildGatewayManifest()` assembles a manifest. See
-   * `AbstractController.gatewayDefaults` for full semantics.
+   * Merged underneath per-route metadata (passed inline via
+   * `buildApiRoute(..., { gatewayMetadata })` or attached post-hoc via
+   * `withGatewayMetadata`) when `DIContext.buildGatewayManifest()` assembles a
+   * manifest. See `AbstractController.gatewayDefaults` for full semantics.
    */
   public readonly gatewayDefaults?: GatewayMetadataValue
 }

--- a/lib/api-contracts/apiHandlerTypes.ts
+++ b/lib/api-contracts/apiHandlerTypes.ts
@@ -8,6 +8,7 @@ import type {
 import type { FastifyRequest, RouteOptions } from 'fastify'
 import type { z } from 'zod/v4'
 import type { DualModeType } from '../dualmode/dualModeTypes.ts'
+import type { GatewayMetadata } from '../gateway/gatewayTypes.ts'
 import type {
   FastifySSERouteOptions,
   SSEContext,
@@ -158,8 +159,15 @@ export type InferApiHandler<Contract extends ApiContract> = [
  *
  * SSE lifecycle options (`onConnect`, `onClose`, `onReconnect`) are only
  * relevant for SSE and dual-mode contracts and are ignored for non-SSE routes.
+ *
+ * Generic in `Contract` so `gatewayMetadata.match.headers` / `match.query`
+ * keys are narrowed to the contract's request schemas. Defaults to `unknown`,
+ * widening those keys to `string` for callers that don't pass the generic.
  */
-export type ApiRouteOptions = Omit<RouteOptions, 'method' | 'url' | 'schema' | 'handler' | 'sse'> &
+export type ApiRouteOptions<Contract = unknown> = Omit<
+  RouteOptions,
+  'method' | 'url' | 'schema' | 'handler' | 'sse'
+> &
   Omit<FastifySSERouteOptions, 'preHandler'> & {
     /**
      * Default response mode for dual-mode routes when the `Accept` header
@@ -167,4 +175,13 @@ export type ApiRouteOptions = Omit<RouteOptions, 'method' | 'url' | 'schema' | '
      * @default 'json'
      */
     defaultMode?: DualModeType
+    /**
+     * Per-route gateway metadata. `match.headers` / `match.query` keys are
+     * narrowed to the contract's request schemas; `customHeaders` /
+     * `customQuery` remain the escape hatch for headers and params not
+     * declared on the contract. Validated at runtime against the same Zod
+     * schema used by `withGatewayMetadata` and stamped on the route via the
+     * shared `GATEWAY_METADATA_SYMBOL`.
+     */
+    gatewayMetadata?: GatewayMetadata<Contract>
   }

--- a/lib/api-contracts/apiHandlerTypes.ts
+++ b/lib/api-contracts/apiHandlerTypes.ts
@@ -182,6 +182,26 @@ export type ApiRouteOptions<Contract = unknown> = Omit<
      * declared on the contract. Validated at runtime against the same Zod
      * schema used by `withGatewayMetadata` and stamped on the route via the
      * shared `GATEWAY_METADATA_SYMBOL`.
+     *
+     * Equivalent to wrapping the result with `withGatewayMetadata` — keep
+     * to one form per route. If both are used on the same route, the later
+     * call (typically `withGatewayMetadata`) overwrites the inline value;
+     * there is no merge.
+     *
+     * @example
+     * ```ts
+     * buildApiRoute(MyController.contracts.getItem, this.getItem, {
+     *   gatewayMetadata: {
+     *     cache: { ttl: '60s' },
+     *     match: {
+     *       // narrowed to keys of the contract's requestHeaderSchema:
+     *       headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } },
+     *       // escape hatch for headers not declared on the contract:
+     *       customHeaders: { 'x-tenant-id': { regex: '^t_' } },
+     *     },
+     *   },
+     * })
+     * ```
      */
     gatewayMetadata?: GatewayMetadata<Contract>
   }

--- a/lib/api-contracts/apiHandlerTypes.ts
+++ b/lib/api-contracts/apiHandlerTypes.ts
@@ -161,10 +161,12 @@ export type InferApiHandler<Contract extends ApiContract> = [
  * relevant for SSE and dual-mode contracts and are ignored for non-SSE routes.
  *
  * Generic in `Contract` so `gatewayMetadata.match.headers` / `match.query`
- * keys are narrowed to the contract's request schemas. Defaults to `unknown`,
- * widening those keys to `string` for callers that don't pass the generic.
+ * keys are narrowed to the contract's request schemas. The generic is always
+ * inferred from the contract argument at the `buildApiRoute` call site, so
+ * direct references should write `ApiRouteOptions<typeof myContract>` when
+ * gateway metadata typing is needed.
  */
-export type ApiRouteOptions<Contract = unknown> = Omit<
+export type ApiRouteOptions<Contract extends ApiContract> = Omit<
   RouteOptions,
   'method' | 'url' | 'schema' | 'handler' | 'sse'
 > &

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -304,6 +304,13 @@ const headerAwareContract = defineApiContract({
   responsesByStatusCode: { 200: userSchema },
 })
 
+const queryAwareContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/search',
+  requestQuerySchema: z.object({ q: z.string(), limit: z.coerce.number().optional() }),
+  responsesByStatusCode: { 200: userSchema },
+})
+
 describe('buildApiRoute — inline gatewayMetadata', () => {
   it('stamps validated metadata onto the route via the shared symbol', () => {
     const routeOptions = buildApiRoute(
@@ -410,5 +417,86 @@ describe('buildApiRoute — inline gatewayMetadata', () => {
       { gatewayMetadata: { tags: ['chat'] } },
     )
     expect(readGatewayMetadata(routeOptions)).toEqual({ tags: ['chat'] })
+  })
+
+  it('narrows match.query keys to the contract requestQuerySchema', () => {
+    const routeOptions = buildApiRoute(
+      queryAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        gatewayMetadata: {
+          match: { query: { q: { prefix: 'foo' }, limit: { exact: '10' } } },
+        },
+      },
+    )
+    expect(readGatewayMetadata(routeOptions)?.match?.query).toEqual({
+      q: { prefix: 'foo' },
+      limit: { exact: '10' },
+    })
+  })
+
+  it('coexists with passthrough Fastify options like preHandler', () => {
+    const preHandler = vi.fn()
+    const routeOptions = buildApiRoute(
+      headerAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        preHandler,
+        gatewayMetadata: { upstream: 'tenants-service' },
+      },
+    )
+    // preHandler reaches Fastify (own enumerable), gatewayMetadata reaches the symbol.
+    expect(routeOptions.preHandler).toBe(preHandler)
+    expect((routeOptions as { gatewayMetadata?: unknown }).gatewayMetadata).toBeUndefined()
+    expect(readGatewayMetadata(routeOptions)).toEqual({ upstream: 'tenants-service' })
+  })
+
+  it('rejects header keys not declared on the contract at compile time', () => {
+    buildApiRoute(
+      headerAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        gatewayMetadata: {
+          match: {
+            headers: {
+              'x-trace-id': { regex: '^[a-f0-9]+$' },
+              // @ts-expect-error 'x-not-on-contract' is not in requestHeaderSchema
+              'x-not-on-contract': 'foo',
+            },
+          },
+        },
+      },
+    )
+  })
+
+  it('rejects rateLimit.key.header values not declared on the contract at compile time', () => {
+    buildApiRoute(
+      headerAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        gatewayMetadata: {
+          // @ts-expect-error 'x-not-on-contract' is not in requestHeaderSchema
+          rateLimit: { requests: 10, per: '1s', key: { header: 'x-not-on-contract' } },
+        },
+      },
+    )
+  })
+
+  it('rejects query keys not declared on the contract at compile time', () => {
+    buildApiRoute(
+      queryAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        gatewayMetadata: {
+          match: {
+            query: {
+              q: { prefix: 'foo' },
+              // @ts-expect-error 'unknown' is not in requestQuerySchema
+              unknown: 'bar',
+            },
+          },
+        },
+      },
+    )
   })
 })

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -6,6 +6,8 @@ import {
 } from '@lokalise/api-contracts'
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod/v4'
+import { GATEWAY_METADATA_SYMBOL } from '../gateway/gatewaySymbol.ts'
+import { readGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
 import { buildApiRoute } from './apiRouteBuilder.ts'
 
 // ============================================================================
@@ -287,5 +289,126 @@ describe('buildApiRoute — no path params', () => {
     }))
     expect(routeOptions.url).toBe('/users')
     expect((routeOptions.schema as { params?: unknown })?.params).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// buildApiRoute — inline gatewayMetadata
+// ============================================================================
+
+const headerAwareContract = defineApiContract({
+  method: 'get',
+  pathResolver: (p: { tenantId: string }) => `/tenants/${p.tenantId}`,
+  requestPathParamsSchema: z.object({ tenantId: z.string() }),
+  requestHeaderSchema: z.object({ 'x-trace-id': z.string() }),
+  responsesByStatusCode: { 200: userSchema },
+})
+
+describe('buildApiRoute — inline gatewayMetadata', () => {
+  it('stamps validated metadata onto the route via the shared symbol', () => {
+    const routeOptions = buildApiRoute(
+      getUserContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      { gatewayMetadata: { upstream: 'users-service', cache: { ttl: '60s' } } },
+    )
+    expect(readGatewayMetadata(routeOptions)).toEqual({
+      upstream: 'users-service',
+      cache: { ttl: '60s' },
+    })
+  })
+
+  it('does not stamp the symbol when no gatewayMetadata is provided', () => {
+    const routeOptions = buildApiRoute(getUserContract, async () => ({
+      status: 200,
+      body: { id: '1', name: 'Alice' },
+    }))
+    expect(readGatewayMetadata(routeOptions)).toBeUndefined()
+  })
+
+  it('attaches metadata via a non-enumerable symbol (invisible to Fastify and JSON)', () => {
+    const routeOptions = buildApiRoute(
+      getUserContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      { gatewayMetadata: { upstream: 'users-service' } },
+    )
+    expect(Object.keys(routeOptions)).not.toContain(GATEWAY_METADATA_SYMBOL.toString())
+    expect(JSON.stringify(routeOptions)).not.toContain('users-service')
+    expect(Object.getOwnPropertyDescriptor(routeOptions, GATEWAY_METADATA_SYMBOL)?.enumerable).toBe(
+      false,
+    )
+  })
+
+  it('does not leak gatewayMetadata as an own property on the Fastify route', () => {
+    const routeOptions = buildApiRoute(
+      getUserContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      { gatewayMetadata: { upstream: 'users-service' } },
+    )
+    expect((routeOptions as { gatewayMetadata?: unknown }).gatewayMetadata).toBeUndefined()
+  })
+
+  it('throws at the call site when metadata is malformed (cache.ttl)', () => {
+    expect(() =>
+      buildApiRoute(
+        getUserContract,
+        async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+        { gatewayMetadata: { cache: { ttl: 'not-a-duration' } } as never },
+      ),
+    ).toThrow()
+  })
+
+  it('accepts contract-typed match.headers keys and reads them back', () => {
+    const routeOptions = buildApiRoute(
+      headerAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        gatewayMetadata: {
+          match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } },
+        },
+      },
+    )
+    expect(readGatewayMetadata(routeOptions)?.match?.headers?.['x-trace-id']).toEqual({
+      regex: '^[a-f0-9]+$',
+    })
+  })
+
+  it('customHeaders accepts free-form keys for headers not in the contract', () => {
+    const routeOptions = buildApiRoute(
+      headerAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      {
+        gatewayMetadata: {
+          match: { customHeaders: { 'x-cf-tenant': 'enterprise' } },
+        },
+      },
+    )
+    expect(readGatewayMetadata(routeOptions)?.match?.customHeaders).toEqual({
+      'x-cf-tenant': 'enterprise',
+    })
+  })
+
+  it('stamps metadata on SSE-only routes', () => {
+    const routeOptions = buildApiRoute(
+      sseOnlyContract,
+      (_req, sse) => {
+        sse.start('keepAlive')
+      },
+      { gatewayMetadata: { upstream: 'streams-service' } },
+    )
+    expect(readGatewayMetadata(routeOptions)).toEqual({ upstream: 'streams-service' })
+  })
+
+  it('stamps metadata on dual-mode routes', () => {
+    const routeOptions = buildApiRoute(
+      dualModeContract,
+      {
+        nonSse: async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+        sse: (_req, sse) => {
+          sse.start('autoClose')
+        },
+      },
+      { gatewayMetadata: { tags: ['chat'] } },
+    )
+    expect(readGatewayMetadata(routeOptions)).toEqual({ tags: ['chat'] })
   })
 })

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -7,7 +7,7 @@ import {
 import { describe, expect, it, vi } from 'vitest'
 import { z } from 'zod/v4'
 import { GATEWAY_METADATA_SYMBOL } from '../gateway/gatewaySymbol.ts'
-import { readGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
+import { readGatewayMetadata, withGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
 import { buildApiRoute } from './apiRouteBuilder.ts'
 
 // ============================================================================
@@ -498,5 +498,16 @@ describe('buildApiRoute — inline gatewayMetadata', () => {
         },
       },
     )
+  })
+
+  it('a later withGatewayMetadata call overwrites inline gatewayMetadata (no merge)', () => {
+    const route = buildApiRoute(
+      headerAwareContract,
+      async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
+      { gatewayMetadata: { upstream: 'inline-svc', cache: { ttl: '60s' } } },
+    )
+    withGatewayMetadata(headerAwareContract, route, { upstream: 'override-svc' })
+    // Documented "later call wins" semantic — `cache` is gone, not merged.
+    expect(readGatewayMetadata(route)).toEqual({ upstream: 'override-svc' })
   })
 })

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -17,7 +17,6 @@ import {
 import { InternalError } from '@lokalise/node-core'
 import type { FastifyReply, RouteOptions } from 'fastify'
 import type { z } from 'zod/v4'
-import type { GatewayMetadata } from '../gateway/gatewayTypes.ts'
 import { attachGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
 import type {
   SSEContext,
@@ -429,9 +428,7 @@ export function buildApiRoute<Contract extends ApiContract>(
   const contractMetadata = contractMetadataToRouteMapper?.(contract.metadata) ?? {}
 
   const finalize = (route: RouteOptions): RouteOptions =>
-    gatewayMetadata !== undefined
-      ? attachGatewayMetadata(route, gatewayMetadata as GatewayMetadata<unknown>)
-      : route
+    gatewayMetadata !== undefined ? attachGatewayMetadata(route, gatewayMetadata) : route
 
   if (mode === 'non-sse') {
     // biome-ignore lint/suspicious/noExplicitAny: handler shape validated by InferApiHandler at call site

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -17,6 +17,8 @@ import {
 import { InternalError } from '@lokalise/node-core'
 import type { FastifyReply, RouteOptions } from 'fastify'
 import type { z } from 'zod/v4'
+import type { GatewayMetadata } from '../gateway/gatewayTypes.ts'
+import { attachGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
 import type {
   SSEContext,
   SSESession,
@@ -53,8 +55,8 @@ function getContractResponseMode(contract: ApiContract): ResponseMode {
   return 'sse'
 }
 
-function buildSSERouteConfig(
-  options: ApiRouteOptions | undefined,
+function buildSSERouteConfig<C>(
+  options: ApiRouteOptions<C> | undefined,
 ): true | { serializer?: (data: unknown) => string; heartbeatInterval?: number } {
   if (!options?.serializer && options?.heartbeatInterval === undefined) return true
   const sseConfig: { serializer?: (data: unknown) => string; heartbeatInterval?: number } = {}
@@ -167,12 +169,12 @@ async function handleApiSyncRoute(
 // Internal Helpers — SSE Route (no controller, uses reply.sse directly)
 // ============================================================================
 
-function buildApiSSEContext(
+function buildApiSSEContext<C>(
   // biome-ignore lint/suspicious/noExplicitAny: Request types are validated by Fastify schema
   request: any,
   reply: FastifyReply,
   eventSchemas: SseSchemaByEventName,
-  options: ApiRouteOptions | undefined,
+  options: ApiRouteOptions<C> | undefined,
 ): {
   // biome-ignore lint/suspicious/noExplicitAny: SSE event schemas are contract-specific, cast at call site
   sseContext: SSEContext<any>
@@ -300,11 +302,11 @@ function buildApiSSEContext(
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Core SSE handler coordinates context, error handling, and lifecycle
-async function handleApiSseRoute(
+async function handleApiSseRoute<C>(
   // biome-ignore lint/suspicious/noExplicitAny: SSE handler types are validated by InferApiHandler at call site
   sseHandler: (request: any, sse: any) => unknown,
   eventSchemas: SseSchemaByEventName,
-  options: ApiRouteOptions | undefined,
+  options: ApiRouteOptions<C> | undefined,
   // biome-ignore lint/suspicious/noExplicitAny: Request types are validated by Fastify schema
   request: any,
   reply: FastifyReply,
@@ -403,12 +405,14 @@ function buildBaseSchema(contract: ApiContract): Record<string, unknown> {
 export function buildApiRoute<Contract extends ApiContract>(
   contract: Contract,
   handler: InferApiHandler<Contract>,
-  options?: ApiRouteOptions,
+  options?: ApiRouteOptions<Contract>,
 ): RouteOptions {
-  // Separate SSE-specific options (not in Fastify RouteOptions) from passthrough options
+  // Separate SSE-specific options (not in Fastify RouteOptions) and gateway
+  // metadata (stamped via Symbol, not spread) from passthrough options.
   const {
     defaultMode,
     contractMetadataToRouteMapper,
+    gatewayMetadata,
     serializer: _serializer,
     heartbeatInterval: _heartbeatInterval,
     onConnect: _onConnect,
@@ -424,24 +428,29 @@ export function buildApiRoute<Contract extends ApiContract>(
   const baseSchema = buildBaseSchema(contract)
   const contractMetadata = contractMetadataToRouteMapper?.(contract.metadata) ?? {}
 
+  const finalize = (route: RouteOptions): RouteOptions =>
+    gatewayMetadata !== undefined
+      ? attachGatewayMetadata(route, gatewayMetadata as GatewayMetadata<unknown>)
+      : route
+
   if (mode === 'non-sse') {
     // biome-ignore lint/suspicious/noExplicitAny: handler shape validated by InferApiHandler at call site
     const syncHandler = handler as any
-    return {
+    return finalize({
       ...fastifyOptions,
       ...contractMetadata,
       method: contract.method,
       url,
       schema: baseSchema,
       handler: async (request, reply) => handleApiSyncRoute(contract, syncHandler, request, reply),
-    }
+    })
   }
 
   if (mode === 'dual') {
     const resolvedDefaultMode = defaultMode ?? 'json'
     // biome-ignore lint/suspicious/noExplicitAny: handler shape validated by InferApiHandler at call site
     const dualHandlers = handler as any
-    return {
+    return finalize({
       ...fastifyOptions,
       ...contractMetadata,
       method: contract.method,
@@ -455,13 +464,13 @@ export function buildApiRoute<Contract extends ApiContract>(
         }
         return handleApiSseRoute(dualHandlers.sse, eventSchemas, options, request, reply)
       },
-    }
+    })
   }
 
   // SSE-only
   // biome-ignore lint/suspicious/noExplicitAny: handler shape validated by InferApiHandler at call site
   const sseHandler = handler as any
-  return {
+  return finalize({
     ...fastifyOptions,
     ...contractMetadata,
     method: contract.method,
@@ -470,5 +479,5 @@ export function buildApiRoute<Contract extends ApiContract>(
     schema: baseSchema,
     handler: async (request, reply) =>
       handleApiSseRoute(sseHandler, eventSchemas, options, request, reply),
-  }
+  })
 }

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -54,7 +54,7 @@ function getContractResponseMode(contract: ApiContract): ResponseMode {
   return 'sse'
 }
 
-function buildSSERouteConfig<C>(
+function buildSSERouteConfig<C extends ApiContract>(
   options: ApiRouteOptions<C> | undefined,
 ): true | { serializer?: (data: unknown) => string; heartbeatInterval?: number } {
   if (!options?.serializer && options?.heartbeatInterval === undefined) return true
@@ -168,7 +168,7 @@ async function handleApiSyncRoute(
 // Internal Helpers — SSE Route (no controller, uses reply.sse directly)
 // ============================================================================
 
-function buildApiSSEContext<C>(
+function buildApiSSEContext<C extends ApiContract>(
   // biome-ignore lint/suspicious/noExplicitAny: Request types are validated by Fastify schema
   request: any,
   reply: FastifyReply,
@@ -301,7 +301,7 @@ function buildApiSSEContext<C>(
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Core SSE handler coordinates context, error handling, and lifecycle
-async function handleApiSseRoute<C>(
+async function handleApiSseRoute<C extends ApiContract>(
   // biome-ignore lint/suspicious/noExplicitAny: SSE handler types are validated by InferApiHandler at call site
   sseHandler: (request: any, sse: any) => unknown,
   eventSchemas: SseSchemaByEventName,

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -399,6 +399,21 @@ function buildBaseSchema(contract: ApiContract): Record<string, unknown> {
 /**
  * Build a Fastify `RouteOptions` object from an `ApiContract` + handler.
  *
+ * The handler shape is inferred from the contract's response mode:
+ * - `'non-sse'` — bare async function returning `{ status, body }`
+ * - `'sse'`     — bare async function calling `sse.start(...)` / `sse.respond(...)`
+ * - `'dual'`    — `{ nonSse, sse }` object branched by the `Accept` header
+ *
+ * The optional `options` argument carries:
+ * - any Fastify route field (`preHandler`, `onRequest`, `config`, `bodyLimit`, …)
+ *   minus the ones the contract provides (`method`, `url`, `schema`, `handler`, `sse`),
+ * - SSE lifecycle hooks (`onConnect`, `onClose`, `onReconnect`, `serializer`,
+ *   `heartbeatInterval`) — applied for `'sse'` and `'dual'` contracts only,
+ * - `defaultMode` for `'dual'` contracts when the `Accept` header is ambiguous,
+ * - `gatewayMetadata` — per-route gateway policy with header / query keys
+ *   narrowed to the contract; equivalent to wrapping the result with
+ *   `withGatewayMetadata`. See `ApiRouteOptions` for full details.
+ *
  * @returns Fastify `RouteOptions` ready to pass to `app.route()`
  */
 export function buildApiRoute<Contract extends ApiContract>(

--- a/lib/gateway/gatewaySymbol.ts
+++ b/lib/gateway/gatewaySymbol.ts
@@ -1,7 +1,9 @@
 /**
  * Symbol used to attach gateway metadata to a Fastify route object.
  *
- * Stamped as a non-enumerable property by `withGatewayMetadata()` and read by
+ * Stamped as a non-enumerable property by `withGatewayMetadata()`, by
+ * `buildApiRoute(..., { gatewayMetadata })`, or by the shared
+ * `attachGatewayMetadata` helper. Read back by `readGatewayMetadata()` and by
  * `DIContext.buildGatewayManifest()`. Using `Symbol.for` ensures every module
  * resolving the same key gets the same symbol, even across realms or duplicate
  * package copies.

--- a/lib/gateway/manifest/buildManifest.spec.ts
+++ b/lib/gateway/manifest/buildManifest.spec.ts
@@ -1,8 +1,11 @@
-import { buildRestContract } from '@lokalise/api-contracts'
+import { buildRestContract, defineApiContract } from '@lokalise/api-contracts'
 import { buildFastifyRoute } from '@lokalise/fastify-api-contracts'
+import type { RouteOptions } from 'fastify'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod/v4'
 import { AbstractController, type BuildRoutesReturnType } from '../../AbstractController.ts'
+import { AbstractApiController } from '../../api-contracts/AbstractApiController.ts'
+import { buildApiRoute } from '../../api-contracts/apiRouteBuilder.ts'
 import type { GatewayMetadataValue } from '../gatewayMetadata.ts'
 import { withGatewayMetadata } from '../withGatewayMetadata.ts'
 import { buildGatewayManifestFrom, type CollectedController } from './buildManifest.ts'
@@ -116,6 +119,70 @@ describe('buildGatewayManifestFrom', () => {
       timeouts: { request: '5s' },
     })
     expect(createItem?.metadata.cache).toBeUndefined()
+  })
+
+  it('reads inline gatewayMetadata passed via buildApiRoute options', () => {
+    const apiGetUserContract = defineApiContract({
+      method: 'get',
+      pathResolver: (p: { userId: string }) => `/api/users/${p.userId}`,
+      requestPathParamsSchema: z.object({ userId: z.string() }),
+      requestHeaderSchema: z.object({ 'x-trace-id': z.string() }),
+      responsesByStatusCode: { 200: z.object({ id: z.string() }) },
+    })
+    const apiCreateUserContract = defineApiContract({
+      method: 'post',
+      pathResolver: () => '/api/users',
+      requestBodySchema: z.object({ name: z.string() }),
+      responsesByStatusCode: { 201: z.object({ id: z.string() }) },
+    })
+
+    class InlineApiController extends AbstractApiController<typeof InlineApiController.contracts> {
+      static contracts = {
+        getItem: apiGetUserContract,
+        createItem: apiCreateUserContract,
+      } as const
+
+      public override readonly gatewayDefaults: GatewayMetadataValue = {
+        upstream: 'users-service',
+        timeouts: { request: '5s' },
+      }
+
+      readonly routes: Record<keyof typeof InlineApiController.contracts, RouteOptions> = {
+        getItem: buildApiRoute(
+          InlineApiController.contracts.getItem,
+          async () => ({ status: 200, body: { id: '1' } }),
+          {
+            gatewayMetadata: {
+              cache: { ttl: '60s' },
+              match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } },
+              tags: ['users', 'cacheable'],
+            },
+          },
+        ),
+        createItem: buildApiRoute(InlineApiController.contracts.createItem, async (req) => ({
+          status: 201,
+          body: { id: req.body.name },
+        })),
+      }
+    }
+
+    const manifest = buildGatewayManifestFrom(
+      [{ name: 'inlineApi', kind: 'api', controller: new InlineApiController() }],
+      { service: 'users-api' },
+    )
+    const getItem = manifest.routes.find((r) => r.routeKey === 'getItem')
+    expect(getItem?.metadata).toMatchObject({
+      // From controller defaults
+      upstream: 'users-service',
+      timeouts: { request: '5s' },
+      // From inline route metadata
+      cache: { ttl: '60s' },
+      match: { headers: { 'x-trace-id': { regex: '^[a-f0-9]+$' } } },
+      tags: ['users', 'cacheable'],
+    })
+    const createItem = manifest.routes.find((r) => r.routeKey === 'createItem')
+    expect(createItem?.metadata.cache).toBeUndefined()
+    expect(createItem?.metadata).toMatchObject({ upstream: 'users-service' })
   })
 
   it('rejects invalid metadata at the manifest boundary', () => {

--- a/lib/gateway/withGatewayMetadata.ts
+++ b/lib/gateway/withGatewayMetadata.ts
@@ -1,10 +1,16 @@
-import type { CommonRouteDefinition } from '@lokalise/api-contracts'
+import type { ApiContract, CommonRouteDefinition } from '@lokalise/api-contracts'
 import { type GatewayMetadataValue, gatewayMetadataSchema } from './gatewayMetadata.ts'
 import { GATEWAY_METADATA_SYMBOL } from './gatewaySymbol.ts'
 import type { GatewayMetadata } from './gatewayTypes.ts'
 
-// biome-ignore lint/suspicious/noExplicitAny: shape-agnostic — we don't constrain contract generics here
-type AnyContract = CommonRouteDefinition<any, any, any, any, any, any, any, any>
+// Accepts both contract families: REST (`CommonRouteDefinition` from
+// `buildRestContract`) and API-contracts (`ApiContract` from `defineApiContract`).
+// The contract is used only for type inference on `match.headers`,
+// `match.query`, and `rateLimit.key` — both families share those request
+// schemas, so the narrowing works either way.
+type AnyContract =
+  // biome-ignore lint/suspicious/noExplicitAny: shape-agnostic — we don't constrain contract generics here
+  CommonRouteDefinition<any, any, any, any, any, any, any, any> | ApiContract
 
 /**
  * Validate gateway metadata and stamp it onto a route via the

--- a/lib/gateway/withGatewayMetadata.ts
+++ b/lib/gateway/withGatewayMetadata.ts
@@ -84,8 +84,10 @@ export function withGatewayMetadata<Contract extends AnyContract, Route extends 
 }
 
 /**
- * Read gateway metadata previously stamped on a route by `withGatewayMetadata`.
- * Returns `undefined` if no metadata was attached.
+ * Read gateway metadata previously stamped on a route — either by
+ * `withGatewayMetadata`, by `buildApiRoute(..., { gatewayMetadata })`, or by
+ * the shared `attachGatewayMetadata` helper. Returns `undefined` if no
+ * metadata was attached.
  */
 export function readGatewayMetadata(route: object): GatewayMetadataValue | undefined {
   return (route as Record<symbol, GatewayMetadataValue | undefined>)[GATEWAY_METADATA_SYMBOL]

--- a/lib/gateway/withGatewayMetadata.ts
+++ b/lib/gateway/withGatewayMetadata.ts
@@ -7,13 +7,38 @@ import type { GatewayMetadata } from './gatewayTypes.ts'
 type AnyContract = CommonRouteDefinition<any, any, any, any, any, any, any, any>
 
 /**
+ * Validate gateway metadata and stamp it onto a route via the
+ * `GATEWAY_METADATA_SYMBOL` non-enumerable property.
+ *
+ * Shared between `withGatewayMetadata` (the post-hoc helper) and
+ * `buildApiRoute` (which accepts `gatewayMetadata` inline via its options).
+ * Centralising the validate-and-stamp logic here keeps both authoring styles
+ * behaviourally identical: same Zod errors at the call site, same hidden
+ * symbol storage, same value visible to `readGatewayMetadata` and
+ * `buildGatewayManifest`.
+ */
+export function attachGatewayMetadata<Route extends object>(
+  route: Route,
+  metadata: GatewayMetadata<unknown>,
+): Route {
+  const validated = gatewayMetadataSchema.parse(metadata) as GatewayMetadataValue
+  Object.defineProperty(route, GATEWAY_METADATA_SYMBOL, {
+    value: validated,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  })
+  return route
+}
+
+/**
  * Attach gateway metadata to a route built by `buildFastifyRoute` / `buildApiRoute`.
  *
  * The metadata is stamped on the route via a non-enumerable `Symbol` property,
  * so Fastify never sees it (it walks own enumerable keys when registering
  * routes). The same route reference is returned — no copy, no spread.
  *
- * Apply at the `buildRoutes()` return site (or in the `routes` array for
+ * Apply at the `buildRoutes()` return site (or in the `routes` object for
  * `AbstractApiController`) so all gateway annotations for a controller live in
  * a single, scannable block:
  *
@@ -32,6 +57,10 @@ type AnyContract = CommonRouteDefinition<any, any, any, any, any, any, any, any>
  * }
  * ```
  *
+ * For `buildApiRoute`-built routes, `options.gatewayMetadata` is the simpler
+ * inline path; this helper remains the right tool for routes built with
+ * `buildFastifyRoute` and for cases where the route is constructed elsewhere.
+ *
  * @param _contract - The contract is taken purely to drive type inference for
  *   `match.headers`, `match.query`, and `rateLimit.key`. It is not stored.
  * @param route - The route returned by `buildFastifyRoute` or `buildApiRoute`.
@@ -43,17 +72,7 @@ export function withGatewayMetadata<Contract extends AnyContract, Route extends 
   route: Route,
   metadata: GatewayMetadata<Contract>,
 ): Route {
-  // Validate eagerly so a bad shape fails at the call site (with a clean
-  // Zod issue path) rather than later when DIContext.buildGatewayManifest
-  // walks every route at once.
-  const validated = gatewayMetadataSchema.parse(metadata) as GatewayMetadataValue
-  Object.defineProperty(route, GATEWAY_METADATA_SYMBOL, {
-    value: validated,
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  })
-  return route
+  return attachGatewayMetadata(route, metadata as GatewayMetadata<unknown>)
 }
 
 /**

--- a/lib/gateway/withGatewayMetadata.ts
+++ b/lib/gateway/withGatewayMetadata.ts
@@ -16,12 +16,20 @@ type AnyContract = CommonRouteDefinition<any, any, any, any, any, any, any, any>
  * behaviourally identical: same Zod errors at the call site, same hidden
  * symbol storage, same value visible to `readGatewayMetadata` and
  * `buildGatewayManifest`.
+ *
+ * Parameter is `unknown` because the contract-narrowed `GatewayMetadata<C>`
+ * shapes from the two call sites aren't structurally assignable to each
+ * other (variant `ContractRateLimitKey<C>`), and the runtime Zod schema is
+ * the actual source of truth either way.
  */
 export function attachGatewayMetadata<Route extends object>(
   route: Route,
-  metadata: GatewayMetadata<unknown>,
+  metadata: unknown,
 ): Route {
-  const validated = gatewayMetadataSchema.parse(metadata) as GatewayMetadataValue
+  // Validate eagerly so a bad shape fails at the call site (with a clean
+  // Zod issue path) rather than later when DIContext.buildGatewayManifest
+  // walks every route at once.
+  const validated = gatewayMetadataSchema.parse(metadata)
   Object.defineProperty(route, GATEWAY_METADATA_SYMBOL, {
     value: validated,
     enumerable: false,
@@ -72,7 +80,7 @@ export function withGatewayMetadata<Contract extends AnyContract, Route extends 
   route: Route,
   metadata: GatewayMetadata<Contract>,
 ): Route {
-  return attachGatewayMetadata(route, metadata as GatewayMetadata<unknown>)
+  return attachGatewayMetadata(route, metadata)
 }
 
 /**

--- a/test/api-contracts/fixtures/testControllers.ts
+++ b/test/api-contracts/fixtures/testControllers.ts
@@ -27,10 +27,14 @@ export class TestApiController extends AbstractApiController<typeof TestApiContr
   } as const
 
   readonly routes = {
-    getUser: buildApiRoute(TestApiController.contracts.getUser, async (request) => ({
-      status: 200,
-      body: { id: request.params.userId, name: 'Alice' },
-    })),
+    getUser: buildApiRoute(
+      TestApiController.contracts.getUser,
+      async (request) => ({
+        status: 200,
+        body: { id: request.params.userId, name: 'Alice' },
+      }),
+      { gatewayMetadata: { cache: { ttl: '60s' }, tags: ['users'] } },
+    ),
 
     createUser: buildApiRoute(TestApiController.contracts.createUser, (request) => ({
       status: 201,


### PR DESCRIPTION
Adds an optional `gatewayMetadata` field to `ApiRouteOptions`, narrowed to
the route's contract so `match.headers` / `match.query` / `rateLimit.key`
keys are checked against the contract's request schemas. The metadata is
validated and stamped via the same `GATEWAY_METADATA_SYMBOL` channel as
`withGatewayMetadata`, so `readGatewayMetadata` and the manifest builder
keep working unchanged. The `withGatewayMetadata` helper still works for
REST routes built by `buildFastifyRoute` and post-hoc annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway metadata can now be configured inline when building routes, providing an alternative to the post-build annotation method.
  * Type-safe header and query parameter matching constraints are now enforced at development time.

* **Documentation**
  * Updated configuration examples and clarified behavior when multiple metadata configuration methods are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->