### PR TITLE
ci: add zizmor workflow to audit GitHub Actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,13 +21,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Run zizmor
         run: uvx zizmor --format=sarif . > results.sarif
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,41 @@
+---
+name: zizmor
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Run zizmor
+        run: uvx zizmor --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/zizmor.yml` to lint all workflow files with [zizmor](https://github.com/zizmorcore/zizmor), a static analyzer for GitHub Actions security issues (template injection, overly broad permissions, unpinned actions, etc.).
- Runs on `pull_request` and `push` to `main`. Uses `uvx zizmor` so no Python/Rust toolchain setup is needed beyond `astral-sh/setup-uv`.
- Uploads SARIF output to GitHub code scanning so findings appear as alerts on the Security tab and inline on PR diffs.
- The job itself follows the same hardening rules zizmor enforces: empty top-level `permissions`, minimum job-level scopes (`contents: read`, `actions: read`, `security-events: write`), and `persist-credentials: false` on checkout.

## Test plan

- [ ] CI: confirm the new `zizmor` job runs on this PR
- [ ] Review any findings reported against the existing workflows on the Security → Code scanning tab and decide whether to fix or suppress them in a follow-up

https://claude.ai/code/session_01KEczH6j6TNJtCtRPxuHAj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEczH6j6TNJtCtRPxuHAj9)_