### PR TITLE
Handle stale SSE connection on room join

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ export {
 } from './lib/diConfigUtils.js'
 // Dual-mode (SSE + JSON)
 export * from './lib/dualmode/index.js'
+export { isErrorLike } from './lib/errorUtils.js'
 // Gateway metadata & manifest
 export * from './lib/gateway/index.js'
 export * from './lib/resolverFunctions.js'

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -17,6 +17,7 @@ import {
 import { InternalError } from '@lokalise/node-core'
 import type { FastifyReply, RouteOptions } from 'fastify'
 import type { z } from 'zod/v4'
+import { isErrorLike } from '../errorUtils.ts'
 import { attachGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
 import type {
   SSEContext,
@@ -27,7 +28,7 @@ import type {
   SyncModeReply,
 } from '../routes/fastifyRouteTypes.ts'
 import type { SSEReply } from '../routes/fastifyRouteUtils.ts'
-import { determineMode, hasHttpStatusCode, isErrorLike } from '../routes/fastifyRouteUtils.ts'
+import { determineMode, hasHttpStatusCode } from '../routes/fastifyRouteUtils.ts'
 import type { ApiRouteOptions, InferApiHandler } from './apiHandlerTypes.ts'
 
 // ============================================================================

--- a/lib/dualmode/dualModeTypes.ts
+++ b/lib/dualmode/dualModeTypes.ts
@@ -9,7 +9,7 @@ export type DualModeType = 'json' | 'sse'
  */
 export type DualModeLogger = {
   error: (obj: Record<string, unknown>, msg: string) => void
-  warn: (obj: Record<string, unknown>, msg: string) => void
+  warn?: (obj: Record<string, unknown>, msg: string) => void
 }
 
 /**

--- a/lib/dualmode/dualModeTypes.ts
+++ b/lib/dualmode/dualModeTypes.ts
@@ -9,6 +9,7 @@ export type DualModeType = 'json' | 'sse'
  */
 export type DualModeLogger = {
   error: (obj: Record<string, unknown>, msg: string) => void
+  warn: (obj: Record<string, unknown>, msg: string) => void
 }
 
 /**

--- a/lib/errorUtils.ts
+++ b/lib/errorUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Check if a value is an Error-like object (cross-realm safe).
+ * Uses duck typing instead of instanceof for reliability across realms.
+ */
+export function isErrorLike(err: unknown): err is { message: string } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as { message: unknown }).message === 'string'
+  )
+}

--- a/lib/routes/fastifyRouteBuilder.ts
+++ b/lib/routes/fastifyRouteBuilder.ts
@@ -8,6 +8,7 @@ import type { FastifyReply, RouteOptions } from 'fastify'
 import type { z } from 'zod'
 import { ZodObject } from 'zod'
 import type { AbstractDualModeController } from '../dualmode/AbstractDualModeController.ts'
+import { isErrorLike } from '../errorUtils.ts'
 import type { AbstractSSEController } from '../sse/AbstractSSEController.ts'
 import type {
   DualModeRouteHandler,
@@ -22,7 +23,6 @@ import {
   extractPathTemplate,
   handleSSEError,
   hasHttpStatusCode,
-  isErrorLike,
 } from './fastifyRouteUtils.ts'
 
 // Re-export for convenience
@@ -473,7 +473,13 @@ function buildSSERouteInternal<Contract extends AnySSEContractDefinition>(
         if (contextResult.isStarted()) {
           const connectionId = contextResult.getConnectionId()
           if (connectionId) {
-            await handleSSEError(contextResult.sseReply, controller, connectionId, err, options?.logger)
+            await handleSSEError(
+              contextResult.sseReply,
+              controller,
+              connectionId,
+              err,
+              options?.logger,
+            )
           }
           // Re-throw for Fastify's onError hooks (status can't change after headers sent)
           throw err

--- a/lib/routes/fastifyRouteBuilder.ts
+++ b/lib/routes/fastifyRouteBuilder.ts
@@ -312,7 +312,7 @@ async function handleSSEMode<Contract extends AnyDualModeContractDefinition>(
     if (contextResult.isStarted()) {
       const connectionId = contextResult.getConnectionId()
       if (connectionId) {
-        await handleSSEError(contextResult.sseReply, controller, connectionId, err)
+        await handleSSEError(contextResult.sseReply, controller, connectionId, err, options?.logger)
       }
       // Re-throw for Fastify's onError hooks (status can't change after headers sent)
       throw err
@@ -473,7 +473,7 @@ function buildSSERouteInternal<Contract extends AnySSEContractDefinition>(
         if (contextResult.isStarted()) {
           const connectionId = contextResult.getConnectionId()
           if (connectionId) {
-            await handleSSEError(contextResult.sseReply, controller, connectionId, err)
+            await handleSSEError(contextResult.sseReply, controller, connectionId, err, options?.logger)
           }
           // Re-throw for Fastify's onError hooks (status can't change after headers sent)
           throw err

--- a/lib/routes/fastifyRouteUtils.spec.ts
+++ b/lib/routes/fastifyRouteUtils.spec.ts
@@ -7,7 +7,6 @@ import {
   determineSyncFormat,
   hasHttpStatusCode,
   isErrorLike,
-  isSSEConnectionDead,
   type SSEControllerLike,
 } from './fastifyRouteUtils.ts'
 
@@ -39,42 +38,6 @@ describe('fastifyRouteUtils', () => {
 
     it('returns false for objects with non-string message property', () => {
       expect(isErrorLike({ message: 123 })).toBe(false)
-    })
-  })
-
-  describe('SSE session dead-state helpers', () => {
-    it('returns false for healthy connection', () => {
-      const session = {
-        id: 'conn-1',
-        request: { raw: { destroyed: false, aborted: false } },
-        reply: { raw: { destroyed: false, writableEnded: false } },
-        context: {},
-        connectedAt: new Date(),
-        send: vi.fn(),
-        isConnected: () => true,
-        getStream: vi.fn(),
-        sendStream: vi.fn(),
-        rooms: { join: vi.fn(), leave: vi.fn() },
-      } as unknown as Parameters<typeof isSSEConnectionDead>[0]
-
-      expect(isSSEConnectionDead(session)).toBe(false)
-    })
-
-    it('marks session as dead when connection is closed', () => {
-      const session = {
-        id: 'conn-1',
-        isConnected: () => false,
-        request: { raw: { destroyed: false, aborted: false } },
-        reply: { raw: { destroyed: false, writableEnded: false } },
-        context: {},
-        connectedAt: new Date(),
-        send: vi.fn(),
-        getStream: vi.fn(),
-        sendStream: vi.fn(),
-        rooms: { join: vi.fn(), leave: vi.fn() },
-      } as unknown as Parameters<typeof isSSEConnectionDead>[0]
-
-      expect(isSSEConnectionDead(session)).toBe(true)
     })
   })
 
@@ -138,8 +101,14 @@ describe('fastifyRouteUtils', () => {
       return { request, reply, controller, roomManager, logger, onCloseCallbacks, sseClose }
     }
 
-    it('skips room join and closes dead session', () => {
-      const fixture = createFixture({ requestDestroyed: true })
+    it.each([
+      { title: 'request is destroyed', overrides: { requestDestroyed: true } },
+      { title: 'request is aborted', overrides: { requestAborted: true } },
+      { title: 'response is destroyed', overrides: { responseDestroyed: true } },
+      { title: 'response writable ended', overrides: { responseWritableEnded: true } },
+      { title: 'session is disconnected', overrides: { isConnected: false } },
+    ])('skips room join and closes dead session when $title', ({ overrides }) => {
+      const fixture = createFixture(overrides)
       const context = createSSEContext(
         fixture.controller,
         fixture.request,
@@ -174,6 +143,51 @@ describe('fastifyRouteUtils', () => {
       expect(fixture.sseClose).not.toHaveBeenCalled()
       expect(fixture.controller.unregisterConnection).not.toHaveBeenCalled()
       expect(fixture.logger.warn).not.toHaveBeenCalled()
+    })
+
+    it('silently unregisters when close throws but reply is already disconnected', () => {
+      const fixture = createFixture({ requestDestroyed: true, isConnected: false })
+      fixture.sseClose.mockImplementation(() => {
+        throw new Error('stream already closed')
+      })
+      const context = createSSEContext(
+        fixture.controller,
+        fixture.request,
+        fixture.reply,
+        {},
+        { logger: fixture.logger },
+      )
+      const session = context.sseContext.start('keepAlive')
+
+      session.rooms.join('room-a')
+
+      expect(fixture.sseClose).toHaveBeenCalledTimes(1)
+      expect(fixture.controller.unregisterConnection).toHaveBeenCalledWith(session.id)
+      expect(fixture.logger.error).not.toHaveBeenCalled()
+    })
+
+    it('logs error when close throws and reply is still connected', () => {
+      const fixture = createFixture({ requestDestroyed: true, isConnected: true })
+      fixture.sseClose.mockImplementation(() => {
+        throw new Error('boom')
+      })
+      const context = createSSEContext(
+        fixture.controller,
+        fixture.request,
+        fixture.reply,
+        {},
+        { logger: fixture.logger },
+      )
+      const session = context.sseContext.start('keepAlive')
+
+      session.rooms.join('room-a')
+
+      expect(fixture.sseClose).toHaveBeenCalledTimes(1)
+      expect(fixture.controller.unregisterConnection).toHaveBeenCalledWith(session.id)
+      expect(fixture.logger.error).toHaveBeenCalledWith(
+        { connectionId: session.id, error: 'boom' },
+        'Failed to close SSE connection',
+      )
     })
   })
 

--- a/lib/routes/fastifyRouteUtils.spec.ts
+++ b/lib/routes/fastifyRouteUtils.spec.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from 'node:events'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { describe, expect, it, vi } from 'vitest'
+import { isErrorLike } from '../errorUtils.ts'
 import {
   createSSEContext,
   determineMode,
   determineSyncFormat,
   hasHttpStatusCode,
-  isErrorLike,
   type SSEControllerLike,
 } from './fastifyRouteUtils.ts'
 

--- a/lib/routes/fastifyRouteUtils.spec.ts
+++ b/lib/routes/fastifyRouteUtils.spec.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { EventEmitter } from 'node:events'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  createSSEContext,
   determineMode,
   determineSyncFormat,
   hasHttpStatusCode,
   isErrorLike,
+  isSSEConnectionDead,
+  type SSEControllerLike,
 } from './fastifyRouteUtils.ts'
 
 describe('fastifyRouteUtils', () => {
@@ -34,6 +39,141 @@ describe('fastifyRouteUtils', () => {
 
     it('returns false for objects with non-string message property', () => {
       expect(isErrorLike({ message: 123 })).toBe(false)
+    })
+  })
+
+  describe('SSE session dead-state helpers', () => {
+    it('returns false for healthy connection', () => {
+      const session = {
+        id: 'conn-1',
+        request: { raw: { destroyed: false, aborted: false } },
+        reply: { raw: { destroyed: false, writableEnded: false } },
+        context: {},
+        connectedAt: new Date(),
+        send: vi.fn(),
+        isConnected: () => true,
+        getStream: vi.fn(),
+        sendStream: vi.fn(),
+        rooms: { join: vi.fn(), leave: vi.fn() },
+      } as unknown as Parameters<typeof isSSEConnectionDead>[0]
+
+      expect(isSSEConnectionDead(session)).toBe(false)
+    })
+
+    it('marks session as dead when connection is closed', () => {
+      const session = {
+        id: 'conn-1',
+        isConnected: () => false,
+        request: { raw: { destroyed: false, aborted: false } },
+        reply: { raw: { destroyed: false, writableEnded: false } },
+        context: {},
+        connectedAt: new Date(),
+        send: vi.fn(),
+        getStream: vi.fn(),
+        sendStream: vi.fn(),
+        rooms: { join: vi.fn(), leave: vi.fn() },
+      } as unknown as Parameters<typeof isSSEConnectionDead>[0]
+
+      expect(isSSEConnectionDead(session)).toBe(true)
+    })
+  })
+
+  describe('room join guard in createSSEContext', () => {
+    const createFixture = (overrides?: {
+      requestDestroyed?: boolean
+      requestAborted?: boolean
+      responseDestroyed?: boolean
+      responseWritableEnded?: boolean
+      isConnected?: boolean
+    }) => {
+      const socket = new EventEmitter()
+      const request = {
+        headers: {},
+        socket,
+        raw: {
+          destroyed: overrides?.requestDestroyed ?? false,
+          aborted: overrides?.requestAborted ?? false,
+        },
+      } as unknown as FastifyRequest
+
+      const onCloseCallbacks: Array<() => Promise<void> | void> = []
+      const sseClose = vi.fn()
+      const sseReply = {
+        isConnected: overrides?.isConnected ?? true,
+        keepAlive: vi.fn(),
+        sendHeaders: vi.fn(),
+        stream: vi.fn(() => ({}) as NodeJS.WritableStream),
+        onClose: vi.fn((handler: () => Promise<void> | void) => {
+          onCloseCallbacks.push(handler)
+        }),
+        close: sseClose,
+      }
+
+      const reply = {
+        sse: sseReply,
+        raw: {
+          flushHeaders: vi.fn(),
+          destroyed: overrides?.responseDestroyed ?? false,
+          writableEnded: overrides?.responseWritableEnded ?? false,
+        },
+      } as unknown as FastifyReply
+
+      const roomManager = {
+        join: vi.fn(),
+        leave: vi.fn(),
+      }
+
+      const controller: SSEControllerLike = {
+        _sendEventRaw: vi.fn(async () => true),
+        registerConnection: vi.fn(),
+        unregisterConnection: vi.fn(),
+        _internalRoomManager: roomManager as unknown as SSEControllerLike['_internalRoomManager'],
+      }
+
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+      }
+
+      return { request, reply, controller, roomManager, logger, onCloseCallbacks, sseClose }
+    }
+
+    it('skips room join and closes dead session', () => {
+      const fixture = createFixture({ requestDestroyed: true })
+      const context = createSSEContext(
+        fixture.controller,
+        fixture.request,
+        fixture.reply,
+        {},
+        { logger: fixture.logger },
+      )
+      const session = context.sseContext.start('keepAlive')
+
+      session.rooms.join('room-a')
+
+      expect(fixture.roomManager.join).not.toHaveBeenCalled()
+      expect(fixture.sseClose).toHaveBeenCalledTimes(1)
+      expect(fixture.controller.unregisterConnection).toHaveBeenCalledWith(session.id)
+      expect(fixture.logger.warn).toHaveBeenCalledTimes(1)
+    })
+
+    it('joins room when session is alive', () => {
+      const fixture = createFixture()
+      const context = createSSEContext(
+        fixture.controller,
+        fixture.request,
+        fixture.reply,
+        {},
+        { logger: fixture.logger },
+      )
+      const session = context.sseContext.start('keepAlive')
+
+      session.rooms.join('room-a')
+
+      expect(fixture.roomManager.join).toHaveBeenCalledWith(session.id, 'room-a', fixture.logger)
+      expect(fixture.sseClose).not.toHaveBeenCalled()
+      expect(fixture.controller.unregisterConnection).not.toHaveBeenCalled()
+      expect(fixture.logger.warn).not.toHaveBeenCalled()
     })
   })
 

--- a/lib/routes/fastifyRouteUtils.ts
+++ b/lib/routes/fastifyRouteUtils.ts
@@ -181,13 +181,7 @@ export async function handleSSEError(
     // Connection might already be closed, ignore
   }
 
-  // Close the connection gracefully
-  try {
-    sseReply.sse.close()
-  } catch {
-    // Connection may already be closed
-  }
-  controller.unregisterConnection(connectionId)
+  closeSSESession(sseReply, controller, connectionId)
 }
 
 /**
@@ -204,10 +198,12 @@ export type SSESessionSetupResult<Events extends SSEEventSchemas = SSEEventSchem
  * Create room operations object for the session.
  * If room manager is not available, returns no-op functions.
  */
-function createRoomOperations(
-  connectionId: string,
-  roomManager: SSERoomManager | undefined,
+function createRoomOperations<Events extends SSEEventSchemas, Context = unknown>(
+  connection: SSESession<Events, Context>,
+  controller: SSEControllerLike,
+  logger?: SSELogger,
 ): SSERoomOperations {
+  const roomManager = controller._internalRoomManager
   if (!roomManager) {
     // Return no-op operations when rooms are not enabled
     return {
@@ -216,10 +212,61 @@ function createRoomOperations(
     }
   }
 
+  const connectionId = connection.id
+  const sseReply = connection.reply as SSEReply
+
   return {
-    join: (room) => roomManager.join(connectionId, room),
-    leave: (room) => roomManager.leave(connectionId, room),
+    join: (room) => {
+      // Guard against startup races where the stream is already aborted/destroyed:
+      // joining such session to a room can leave stale members and block room broadcast.
+      if (isSSEConnectionDead(connection)) {
+        logger?.warn(
+          {
+            connectionId,
+            room,
+          },
+          'Skipping room join for dead SSE session',
+        )
+
+        closeSSESession(sseReply, controller, connectionId, logger)
+        return
+      }
+
+      roomManager.join(connectionId, room, logger)
+    },
+    leave: (room) => roomManager.leave(connectionId, room, logger),
   }
+}
+
+export function isSSEConnectionDead<Events extends SSEEventSchemas, Context = unknown>(
+  connection: SSESession<Events, Context>,
+): boolean {
+  const rawRequest = connection.request.raw
+  const rawResponse = connection.reply.raw
+  return (
+    !connection.isConnected() ||
+    rawRequest.destroyed ||
+    rawRequest.aborted ||
+    rawResponse.destroyed ||
+    rawResponse.writableEnded
+  )
+}
+
+/**
+ * Close the underlying SSE stream and unregister the connection from the controller.
+ */
+function closeSSESession(
+  sseReply: SSEReply,
+  controller: SSEControllerLike,
+  connectionId: string,
+  logger?: SSELogger,
+): void {
+  try {
+    sseReply.sse.close()
+  } catch {
+    logger?.warn({ connectionId }, 'Connection is already closed')
+  }
+  controller.unregisterConnection(connectionId)
 }
 
 /**
@@ -237,6 +284,7 @@ function createSSESessionInternal<Events extends SSEEventSchemas, Context = unkn
   controller: SSEControllerLike,
   initialContext?: Context,
   reconnectionPromise?: Promise<void>,
+  logger?: SSELogger,
 ): SSESession<Events, Context> {
   // Create type-safe event sender for the handler
   // If reconnection is in progress, wait for it before sending to maintain event ordering
@@ -275,10 +323,7 @@ function createSSESessionInternal<Events extends SSEEventSchemas, Context = unkn
     }
   }
 
-  // Create room operations
-  const rooms = createRoomOperations(connectionId, controller._internalRoomManager)
-
-  return {
+  const connection: SSESession<Events, Context> = {
     id: connectionId,
     request,
     reply,
@@ -288,9 +333,16 @@ function createSSESessionInternal<Events extends SSEEventSchemas, Context = unkn
     isConnected: () => sseReply.sse.isConnected,
     getStream: () => sseReply.sse.stream(),
     sendStream,
-    rooms,
+    rooms: {
+      join: (_room) => {},
+      leave: (_room) => {},
+    },
     eventSchemas,
   }
+
+  connection.rooms = createRoomOperations(connection, controller, logger)
+
+  return connection
 }
 
 /**
@@ -447,6 +499,7 @@ export function createSSEContext<Events extends SSEEventSchemas>(
         controller,
         startOptions?.context,
         reconnectionPromise,
+        options?.logger,
       ) as SSESession<Events>
 
       // Register connection with controller

--- a/lib/routes/fastifyRouteUtils.ts
+++ b/lib/routes/fastifyRouteUtils.ts
@@ -3,6 +3,7 @@ import type { SSEReplyInterface } from '@fastify/sse'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import type { z } from 'zod'
 import type { DualModeType } from '../dualmode/dualModeTypes.ts'
+import { isErrorLike } from '../errorUtils.ts'
 import type { SSERoomManager } from '../sse/rooms/SSERoomManager.ts'
 import type { SSERoomOperations } from '../sse/rooms/types.ts'
 import type { SSEEventSchemas, SSEEventSender, SSELogger, SSEMessage } from '../sse/sseTypes.ts'
@@ -86,19 +87,6 @@ export function extractPathTemplate<Params>(
     placeholderParams[key] = `:${key}`
   }
   return pathResolver(placeholderParams as unknown as Params)
-}
-
-/**
- * Check if a value is an Error-like object (cross-realm safe).
- * Uses duck typing instead of instanceof for reliability across realms.
- */
-export function isErrorLike(err: unknown): err is { message: string } {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'message' in err &&
-    typeof (err as { message: unknown }).message === 'string'
-  )
 }
 
 /**

--- a/lib/routes/fastifyRouteUtils.ts
+++ b/lib/routes/fastifyRouteUtils.ts
@@ -170,6 +170,7 @@ export async function handleSSEError(
   controller: SSEControllerLike,
   connectionId: string,
   err: unknown,
+  logger?: SSELogger,
 ): Promise<void> {
   // Send error event to client (bypasses validation since this is framework-level)
   try {
@@ -181,7 +182,7 @@ export async function handleSSEError(
     // Connection might already be closed, ignore
   }
 
-  closeSSESession(sseReply, controller, connectionId)
+  closeSSESession(sseReply, controller, connectionId, logger)
 }
 
 /**

--- a/lib/routes/fastifyRouteUtils.ts
+++ b/lib/routes/fastifyRouteUtils.ts
@@ -331,6 +331,7 @@ function createSSESessionInternal<Events extends SSEEventSchemas, Context = unkn
     isConnected: () => sseReply.sse.isConnected,
     getStream: () => sseReply.sse.stream(),
     sendStream,
+    // Don't remove - rooms property is reassigned below as it needs connection object reference
     rooms: {
       join: (_room) => {},
       leave: (_room) => {},

--- a/lib/routes/fastifyRouteUtils.ts
+++ b/lib/routes/fastifyRouteUtils.ts
@@ -220,7 +220,7 @@ function createRoomOperations<Events extends SSEEventSchemas, Context = unknown>
       // Guard against startup races where the stream is already aborted/destroyed:
       // joining such session to a room can leave stale members and block room broadcast.
       if (isSSEConnectionDead(connection)) {
-        logger?.warn(
+        logger?.warn?.(
           {
             connectionId,
             room,
@@ -238,7 +238,7 @@ function createRoomOperations<Events extends SSEEventSchemas, Context = unknown>
   }
 }
 
-export function isSSEConnectionDead<Events extends SSEEventSchemas, Context = unknown>(
+function isSSEConnectionDead<Events extends SSEEventSchemas, Context = unknown>(
   connection: SSESession<Events, Context>,
 ): boolean {
   const rawRequest = connection.request.raw
@@ -263,8 +263,17 @@ function closeSSESession(
 ): void {
   try {
     sseReply.sse.close()
-  } catch {
-    logger?.warn({ connectionId }, 'Connection is already closed')
+  } catch (err) {
+    if (sseReply.sse.isConnected) {
+      // Log error if connection closure failed and connection is still live
+      logger?.error(
+        {
+          connectionId,
+          error: isErrorLike(err) ? err.message : 'Internal server error',
+        },
+        'Failed to close SSE connection',
+      )
+    }
   }
   controller.unregisterConnection(connectionId)
 }

--- a/lib/routes/index.ts
+++ b/lib/routes/index.ts
@@ -47,7 +47,6 @@ export {
   determineSyncFormat,
   handleReconnection,
   handleSSEError,
-  isErrorLike,
   type SSECloseReason,
   type SSEContextResult,
   type SSEControllerLike,

--- a/lib/routes/index.ts
+++ b/lib/routes/index.ts
@@ -48,6 +48,7 @@ export {
   handleReconnection,
   handleSSEError,
   isErrorLike,
+  isSSEConnectionDead,
   type SSECloseReason,
   type SSEContextResult,
   type SSEControllerLike,

--- a/lib/routes/index.ts
+++ b/lib/routes/index.ts
@@ -48,7 +48,6 @@ export {
   handleReconnection,
   handleSSEError,
   isErrorLike,
-  isSSEConnectionDead,
   type SSECloseReason,
   type SSEContextResult,
   type SSEControllerLike,

--- a/lib/sse/rooms/SSERoomManager.ts
+++ b/lib/sse/rooms/SSERoomManager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { SSEMessage } from '../sseTypes.js'
+import type { SSELogger, SSEMessage } from '../sseTypes.js'
 import { InMemoryAdapter } from './adapters/InMemoryAdapter.js'
 import type {
   RoomBroadcastOptions,
@@ -105,8 +105,9 @@ export class SSERoomManager {
    *
    * @param connectionId - The connection to add to rooms
    * @param room - Room name or array of room names
+   * @param logger
    */
-  join(connectionId: string, room: string | string[]): void {
+  join(connectionId: string, room: string | string[], logger?: SSELogger): void {
     const rooms = Array.isArray(room) ? room : [room]
 
     for (const r of rooms) {
@@ -140,6 +141,7 @@ export class SSERoomManager {
       if (wasEmpty) {
         this.adapter.subscribe(r).catch(() => {
           // Log error but don't throw - subscription failure shouldn't break join
+          logger?.error({ connectionId, room: r }, 'Adapter subscription failed')
         })
       }
     }
@@ -150,8 +152,9 @@ export class SSERoomManager {
    *
    * @param connectionId - The connection to remove from rooms
    * @param room - Room name or array of room names
+   * @param logger
    */
-  leave(connectionId: string, room: string | string[]): void {
+  leave(connectionId: string, room: string | string[], logger?: SSELogger): void {
     const rooms = Array.isArray(room) ? room : [room]
 
     for (const r of rooms) {
@@ -173,6 +176,7 @@ export class SSERoomManager {
           // Unsubscribe via adapter - no more local connections in this room
           this.adapter.unsubscribe(r).catch(() => {
             // Log error but don't throw
+            logger?.error({ connectionId, room: r }, 'Adapter subscription failed')
           })
         }
       }

--- a/lib/sse/rooms/SSERoomManager.ts
+++ b/lib/sse/rooms/SSERoomManager.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { isErrorLike } from '../../routes/fastifyRouteUtils.js'
 import type { SSELogger, SSEMessage } from '../sseTypes.js'
 import { InMemoryAdapter } from './adapters/InMemoryAdapter.js'
 import type {
@@ -139,9 +140,16 @@ export class SSERoomManager {
 
       // Subscribe via adapter if this is the first connection in the room on this node
       if (wasEmpty) {
-        this.adapter.subscribe(r).catch(() => {
+        this.adapter.subscribe(r).catch((err) => {
           // Log error but don't throw - subscription failure shouldn't break join
-          logger?.error({ connectionId, room: r }, 'Adapter subscription failed')
+          logger?.error(
+            {
+              connectionId,
+              room: r,
+              error: isErrorLike(err) ? err.message : 'Internal server error',
+            },
+            'Adapter subscription failed',
+          )
         })
       }
     }
@@ -174,9 +182,16 @@ export class SSERoomManager {
         if (roomConns.size === 0) {
           this.roomConnections.delete(r)
           // Unsubscribe via adapter - no more local connections in this room
-          this.adapter.unsubscribe(r).catch(() => {
+          this.adapter.unsubscribe(r).catch((err) => {
             // Log error but don't throw
-            logger?.error({ connectionId, room: r }, 'Adapter subscription failed')
+            logger?.error(
+              {
+                connectionId,
+                room: r,
+                error: isErrorLike(err) ? err.message : 'Internal server error',
+              },
+              'Adapter unsubscription failed',
+            )
           })
         }
       }

--- a/lib/sse/rooms/SSERoomManager.ts
+++ b/lib/sse/rooms/SSERoomManager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { isErrorLike } from '../../routes/fastifyRouteUtils.js'
+import { isErrorLike } from '../../errorUtils.js'
 import type { SSELogger, SSEMessage } from '../sseTypes.js'
 import { InMemoryAdapter } from './adapters/InMemoryAdapter.js'
 import type {

--- a/lib/sse/rooms/SSERoomManager.ts
+++ b/lib/sse/rooms/SSERoomManager.ts
@@ -106,7 +106,7 @@ export class SSERoomManager {
    *
    * @param connectionId - The connection to add to rooms
    * @param room - Room name or array of room names
-   * @param logger
+   * @param logger - Used to report adapter subscription failures (optional)
    */
   join(connectionId: string, room: string | string[], logger?: SSELogger): void {
     const rooms = Array.isArray(room) ? room : [room]
@@ -160,7 +160,7 @@ export class SSERoomManager {
    *
    * @param connectionId - The connection to remove from rooms
    * @param room - Room name or array of room names
-   * @param logger
+   * @param logger - Used to report adapter unsubscription failures (optional)
    */
   leave(connectionId: string, room: string | string[], logger?: SSELogger): void {
     const rooms = Array.isArray(room) ? room : [room]

--- a/lib/sse/sseTypes.ts
+++ b/lib/sse/sseTypes.ts
@@ -24,6 +24,7 @@ export type AllContractEvents<Contracts extends Record<string, AnySSEContractDef
  */
 export type SSELogger = {
   error: (obj: Record<string, unknown>, msg: string) => void
+  warn: (obj: Record<string, unknown>, msg: string) => void
 }
 
 /**

--- a/lib/sse/sseTypes.ts
+++ b/lib/sse/sseTypes.ts
@@ -24,7 +24,7 @@ export type AllContractEvents<Contracts extends Record<string, AnySSEContractDef
  */
 export type SSELogger = {
   error: (obj: Record<string, unknown>, msg: string) => void
-  warn: (obj: Record<string, unknown>, msg: string) => void
+  warn?: (obj: Record<string, unknown>, msg: string) => void
 }
 
 /**

--- a/test/dualmode/dualmode.keepalive.e2e.spec.ts
+++ b/test/dualmode/dualmode.keepalive.e2e.spec.ts
@@ -292,6 +292,21 @@ describe('Dual-Mode KeepAlive SSE with Rooms', () => {
     client2.close()
   })
 
+  it('does not add dead keepAlive session to room membership', { timeout: 10000 }, async () => {
+    const broadcaster = getBroadcaster()
+
+    const response = await server.app.inject({
+      method: 'get',
+      url: '/api/dashboard/updates?dashboardId=dead-room&simulateDeadBeforeJoin=true',
+      headers: {
+        accept: 'text/event-stream',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(broadcaster.getConnectionCountInRoom('dashboard:dead-room')).toBe(0)
+  })
+
   it(
     'multiple concurrent keepAlive SSE connections work alongside sync requests',
     { timeout: 10000 },

--- a/test/dualmode/dualmode.keepalive.e2e.spec.ts
+++ b/test/dualmode/dualmode.keepalive.e2e.spec.ts
@@ -187,7 +187,7 @@ describe('Dual-Mode KeepAlive SSE with Rooms', () => {
       server.baseUrl,
       '/api/dashboard/updates',
       {
-        query: { dashboardId: 'dash-1' },
+        query: { dashboardId: 'dash-1', simulateDeadBeforeJoin: 'false' },
         awaitServerConnection: { controller },
       },
     )

--- a/test/dualmode/fixtures/testContracts.ts
+++ b/test/dualmode/fixtures/testContracts.ts
@@ -193,7 +193,7 @@ export const keepaliveDashboardContract = buildContract({
   requestPathParamsSchema: z.object({}),
   requestQuerySchema: z.object({
     dashboardId: z.string().optional(),
-    simulateDeadBeforeJoin: z.coerce.boolean().optional(),
+    simulateDeadBeforeJoin: z.stringbool().optional(),
   }),
   requestHeaderSchema: z.object({}),
   successResponseBodySchema: z.object({

--- a/test/dualmode/fixtures/testContracts.ts
+++ b/test/dualmode/fixtures/testContracts.ts
@@ -191,7 +191,10 @@ export const keepaliveDashboardContract = buildContract({
   method: 'get',
   pathResolver: () => '/api/dashboard/updates',
   requestPathParamsSchema: z.object({}),
-  requestQuerySchema: z.object({ dashboardId: z.string().optional() }),
+  requestQuerySchema: z.object({
+    dashboardId: z.string().optional(),
+    simulateDeadBeforeJoin: z.coerce.boolean().optional(),
+  }),
   requestHeaderSchema: z.object({}),
   successResponseBodySchema: z.object({
     status: z.string(),

--- a/test/dualmode/fixtures/testControllers.ts
+++ b/test/dualmode/fixtures/testControllers.ts
@@ -458,6 +458,10 @@ export class TestKeepaliveDualModeController extends AbstractDualModeController<
       const session = sse.start('keepAlive')
       const dashboardId = request.query.dashboardId
       if (dashboardId) {
+        if (request.query.simulateDeadBeforeJoin) {
+          // Simulate a connection that is already unusable at join time.
+          session.reply.raw.destroy()
+        }
         session.rooms.join(`dashboard:${dashboardId}`)
       }
     },

--- a/test/sse/sse.http.e2e.spec.ts
+++ b/test/sse/sse.http.e2e.spec.ts
@@ -1391,6 +1391,7 @@ describe('SSE HTTP E2E (logger error handling)', () => {
     // Create mock logger to capture error calls
     mockLogger = {
       error: vi.fn(),
+      warn: vi.fn(),
     }
 
     const container = createContainer<TestLoggerSSEModuleDependencies>({ injectionMode: 'PROXY' })
@@ -1467,6 +1468,7 @@ describe('SSE HTTP E2E (onConnect error handling)', () => {
     // Create mock logger to capture error calls
     mockLogger = {
       error: vi.fn(),
+      warn: vi.fn(),
     }
 
     const container = createContainer<TestOnConnectErrorSSEModuleDependencies>({
@@ -1544,6 +1546,7 @@ describe('SSE HTTP E2E (onReconnect error handling)', () => {
     // Create mock logger to capture error calls
     mockLogger = {
       error: vi.fn(),
+      warn: vi.fn(),
     }
 
     const container = createContainer<TestOnReconnectErrorSSEModuleDependencies>({

--- a/test/sse/sse.inject.methods.e2e.spec.ts
+++ b/test/sse/sse.inject.methods.e2e.spec.ts
@@ -30,6 +30,7 @@ describe('SSE Inject E2E (onClose error handling)', () => {
   it('logs error when onClose callback throws', { timeout: 10000 }, async () => {
     const mockLogger: SSELogger = {
       error: vi.fn(),
+      warn: vi.fn(),
     }
 
     const container = createContainer<TestOnCloseErrorSSEModuleDependencies>({
@@ -83,7 +84,7 @@ describe('SSE Inject E2E (onClose error handling)', () => {
     { timeout: 10000 },
     async () => {
       const onCloseReason = vi.fn()
-      const mockLogger: SSELogger = { error: vi.fn() }
+      const mockLogger: SSELogger = { error: vi.fn(), warn: vi.fn() }
 
       const container = createContainer({ injectionMode: 'PROXY' })
       const context = new DIContext<object, object>(container, { isTestMode: true }, {})


### PR DESCRIPTION
## Summary
- Add a library-level guard in SSE room join flow to skip stale/dead sessions before they are added to a room.
- Introduce a private close-and-unregister utility used by join guard and SSE error handling for consistent cleanup.
- Add/adjust tests for route utils, dual-mode keepAlive flow, and SSE logger typing updates.

## What changed
- `createRoomOperations(...)` now checks session liveness before `join`, logs a warning, and closes/unregisters dead sessions.
- `handleSSEError(...)` uses shared close/unregister behavior.
- Added e2e coverage to verify dead keepAlive sessions are not added to room membership and do not affect broadcasts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning-level logging support to SSE and DualMode loggers.

* **Bug Fixes**
  * Improved handling of dead or disconnected SSE sessions during room operations.
  * Enhanced error reporting for room subscription and unsubscription failures.

* **Tests**
  * Added comprehensive test coverage for edge cases involving disconnected sessions and room join scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kibertoad/opinionated-machine/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->