### PR TITLE
fix(apiRouteBuilder): exclude NoBodyResponse from response schema resolution

### DIFF
--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -8,6 +8,7 @@ import {
   hasAnySuccessSseResponse,
   isAnyOfResponses,
   isBlobResponse,
+  isNoBodyResponse,
   isSseResponse,
   isTextResponse,
   mapApiContractToPath,
@@ -76,6 +77,7 @@ function getSchemaForStatusCode(contract: ApiContract, status: number): z.ZodTyp
   if (
     !entry ||
     entry === ContractNoBody ||
+    isNoBodyResponse(entry) ||
     isSseResponse(entry) ||
     isTextResponse(entry) ||
     isBlobResponse(entry)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "ts-deepmerge": "^7.0.3"
     },
     "peerDependencies": {
-        "@lokalise/api-contracts": ">=6.6.0",
+        "@lokalise/api-contracts": ">=6.12.0",
         "@lokalise/fastify-api-contracts": ">=5.3.1",
         "@lokalise/node-core": ">=14.7.4",
         "awilix": ">=13.0.0",
@@ -51,7 +51,7 @@
     "devDependencies": {
         "@types/node": "^22.19.7",
         "@biomejs/biome": "2.4.4",
-        "@lokalise/api-contracts": "^6.6.0",
+        "@lokalise/api-contracts": "^6.12.0",
         "@lokalise/biome-config": "^3.1.1",
         "@lokalise/fastify-api-contracts": "^5.3.1",
         "@lokalise/node-core": "^14.7.4",


### PR DESCRIPTION
@lokalise/api-contracts 6.12.0 added a NoBodyResponse tagged-object type to the ApiContractResponse union, distinct from the ContractNoBody symbol. getSchemaForStatusCode did not narrow it out, so it leaked into the branch typed as z.ZodType | null (TS2322). Guard with isNoBodyResponse so no-body entries resolve to null like ContractNoBody, and bump the peer dep floor to >=6.12.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response handling for requests that don't return a response body.

* **Chores**
  * Updated dependency version to support enhanced response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->