### PR TITLE
Support content-map response entries from api-contracts 6.15

### DIFF
--- a/lib/api-contracts/apiHandlerTypes.spec.ts
+++ b/lib/api-contracts/apiHandlerTypes.spec.ts
@@ -1,0 +1,126 @@
+import {
+  anyOfResponses,
+  defineApiContract,
+  type SSEEventSchemas,
+  sseBody,
+  sseResponse,
+} from '@lokalise/api-contracts'
+import { describe, expectTypeOf, it } from 'vitest'
+import { z } from 'zod/v4'
+import type { SSEContext } from '../routes/fastifyRouteTypes.ts'
+import type { ApiSseHandler, EnsureSseEventSchemas } from './apiHandlerTypes.ts'
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+const eventSchemas = {
+  update: z.object({ value: z.number() }),
+  done: z.object({ total: z.number() }),
+}
+type EventSchemas = typeof eventSchemas
+
+const userSchema = z.object({ id: z.string(), name: z.string() })
+
+// ============================================================================
+// EnsureSseEventSchemas — the fallback helper introduced for the SSEContext constraint
+// ============================================================================
+
+describe('EnsureSseEventSchemas', () => {
+  it('passes a valid schema map through unchanged', () => {
+    expectTypeOf<EnsureSseEventSchemas<EventSchemas>>().toEqualTypeOf<EventSchemas>()
+  })
+
+  it('preserves an empty schema map', () => {
+    expectTypeOf<EnsureSseEventSchemas<Record<string, never>>>().toEqualTypeOf<
+      Record<string, never>
+    >()
+  })
+
+  it('falls back to SSEEventSchemas when the inferred type is unknown', () => {
+    expectTypeOf<EnsureSseEventSchemas<unknown>>().toEqualTypeOf<SSEEventSchemas>()
+  })
+
+  it('falls back to SSEEventSchemas for a non-schema type', () => {
+    expectTypeOf<EnsureSseEventSchemas<string>>().toEqualTypeOf<SSEEventSchemas>()
+    expectTypeOf<EnsureSseEventSchemas<{ notASchema: number }>>().toEqualTypeOf<SSEEventSchemas>()
+  })
+})
+
+// ============================================================================
+// ApiSseHandler — the `sse` param resolves to a correctly-typed SSEContext
+// ============================================================================
+
+describe('ApiSseHandler — SSEContext inference', () => {
+  it('extracts event schemas from a legacy sseResponse entry', () => {
+    const contract = defineApiContract({
+      method: 'get',
+      pathResolver: () => '/stream',
+      responsesByStatusCode: { 200: sseResponse(eventSchemas) },
+    })
+    expectTypeOf<Parameters<ApiSseHandler<typeof contract>>[1]>().toEqualTypeOf<
+      SSEContext<EventSchemas>
+    >()
+  })
+
+  it('extracts event schemas from a content-map sseBody entry', () => {
+    const contract = defineApiContract({
+      method: 'get',
+      pathResolver: () => '/content-stream',
+      responsesByStatusCode: {
+        200: { content: { 'text/event-stream': sseBody(eventSchemas) } },
+      },
+    })
+    expectTypeOf<Parameters<ApiSseHandler<typeof contract>>[1]>().toEqualTypeOf<
+      SSEContext<EventSchemas>
+    >()
+  })
+
+  it('extracts event schemas from a content-map entry that also carries JSON (dual)', () => {
+    const contract = defineApiContract({
+      method: 'post',
+      pathResolver: () => '/content-chat',
+      requestBodySchema: z.object({ message: z.string() }),
+      responsesByStatusCode: {
+        200: {
+          content: { 'application/json': userSchema, 'text/event-stream': sseBody(eventSchemas) },
+        },
+      },
+    })
+    expectTypeOf<Parameters<ApiSseHandler<typeof contract>>[1]>().toEqualTypeOf<
+      SSEContext<EventSchemas>
+    >()
+  })
+
+  it('extracts event schemas nested inside anyOfResponses', () => {
+    const contract = defineApiContract({
+      method: 'post',
+      pathResolver: () => '/mixed',
+      requestBodySchema: z.object({ message: z.string() }),
+      responsesByStatusCode: {
+        200: anyOfResponses([userSchema, sseResponse(eventSchemas)]),
+      },
+    })
+    expectTypeOf<Parameters<ApiSseHandler<typeof contract>>[1]>().toEqualTypeOf<
+      SSEContext<EventSchemas>
+    >()
+  })
+
+  it('gives the handler a fully typed session sender', () => {
+    const contract = defineApiContract({
+      method: 'get',
+      pathResolver: () => '/stream',
+      responsesByStatusCode: { 200: sseResponse(eventSchemas) },
+    })
+
+    const handler: ApiSseHandler<typeof contract> = (_request, sse) => {
+      const session = sse.start('autoClose')
+      // Event names and payloads are inferred from the contract's SSE schemas.
+      void session.send('update', { value: 1 })
+      void session.send('done', { total: 2 })
+      // @ts-expect-error - 'nope' is not a declared event name
+      void session.send('nope', { value: 1 })
+    }
+    expectTypeOf(handler).toBeFunction()
+  })
+})

--- a/lib/api-contracts/apiHandlerTypes.ts
+++ b/lib/api-contracts/apiHandlerTypes.ts
@@ -4,6 +4,7 @@ import type {
   ContractResponseMode,
   InferSseSuccessResponses,
   PayloadApiContract,
+  SSEEventSchemas,
 } from '@lokalise/api-contracts'
 import type { FastifyRequest, RouteOptions } from 'fastify'
 import type { z } from 'zod/v4'
@@ -129,8 +130,20 @@ export type ApiNonSseHandler<Contract extends ApiContract> = (
  */
 export type ApiSseHandler<Contract extends ApiContract> = (
   request: InferApiRequest<Contract>,
-  sse: SSEContext<InferSseSuccessResponses<Contract['responsesByStatusCode']>>,
+  sse: SSEContext<
+    EnsureSseEventSchemas<InferSseSuccessResponses<Contract['responsesByStatusCode']>>
+  >,
 ) => SSEHandlerResult | Promise<SSEHandlerResult>
+
+/**
+ * `InferSseSuccessResponses` resolves to the contract's SSE event schema map, but for a
+ * generic `Contract` the content-map response path can widen it beyond `SSEEventSchemas`.
+ * This narrows it back so it satisfies the `SSEContext` constraint, falling back to the
+ * base `SSEEventSchemas` when the inferred type is not a valid schema map.
+ */
+type EnsureSseEventSchemas<TEvents> = [TEvents] extends [SSEEventSchemas]
+  ? TEvents
+  : SSEEventSchemas
 
 /**
  * Infer the handler shape based on the contract's response mode:

--- a/lib/api-contracts/apiHandlerTypes.ts
+++ b/lib/api-contracts/apiHandlerTypes.ts
@@ -141,7 +141,7 @@ export type ApiSseHandler<Contract extends ApiContract> = (
  * This narrows it back so it satisfies the `SSEContext` constraint, falling back to the
  * base `SSEEventSchemas` when the inferred type is not a valid schema map.
  */
-type EnsureSseEventSchemas<TEvents> = [TEvents] extends [SSEEventSchemas]
+export type EnsureSseEventSchemas<TEvents> = [TEvents] extends [SSEEventSchemas]
   ? TEvents
   : SSEEventSchemas
 

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -1,7 +1,9 @@
 import {
   anyOfResponses,
+  blobBody,
   ContractNoBody,
   defineApiContract,
+  sseBody,
   sseResponse,
 } from '@lokalise/api-contracts'
 import { describe, expect, it, vi } from 'vitest'
@@ -54,6 +56,55 @@ const dualModeContract = defineApiContract({
   requestBodySchema: z.object({ message: z.string() }),
   responsesByStatusCode: {
     200: anyOfResponses([userSchema, sseResponse(sseEventsSchema)]),
+  },
+})
+
+// Content-map response entries (api-contracts >= 6.15) — the new `{ content: {...} }` shape.
+const contentJsonContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/content-json',
+  responsesByStatusCode: {
+    200: { content: { 'application/json': userSchema } },
+  },
+})
+
+const contentSseOnlyContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/content-stream',
+  responsesByStatusCode: {
+    200: { content: { 'text/event-stream': sseBody(sseEventsSchema) } },
+  },
+})
+
+const contentDualContract = defineApiContract({
+  method: 'post',
+  pathResolver: () => '/content-chat',
+  requestBodySchema: z.object({ message: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: { 'application/json': userSchema, 'text/event-stream': sseBody(sseEventsSchema) },
+    },
+  },
+})
+
+const contentBlobDualContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/content-blob',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/octet-stream': blobBody(),
+        'text/event-stream': sseBody(sseEventsSchema),
+      },
+    },
+  },
+})
+
+const contentAllowNoBodyContract = defineApiContract({
+  method: 'get',
+  pathResolver: () => '/content-allow-no-body',
+  responsesByStatusCode: {
+    200: { content: { 'text/event-stream': sseBody(sseEventsSchema) }, allowNoBody: true },
   },
 })
 
@@ -273,6 +324,77 @@ describe('buildApiRoute — response schemas', () => {
       expect.objectContaining({
         schema: expect.objectContaining({ response: { 200: userSchema } }),
       }),
+    )
+  })
+})
+
+// ============================================================================
+// buildApiRoute — content-map response entries (api-contracts >= 6.15)
+// ============================================================================
+
+describe('buildApiRoute — content-map response entries', () => {
+  it('treats a JSON-only content entry as non-SSE', () => {
+    const routeOptions = buildApiRoute(contentJsonContract, async () => ({
+      status: 200,
+      body: undefined,
+    }))
+    expect((routeOptions as { sse?: unknown }).sse).toBeUndefined()
+    expect(routeOptions).toEqual(
+      expect.objectContaining({
+        schema: expect.objectContaining({ response: { 200: userSchema } }),
+      }),
+    )
+  })
+
+  it('treats an SSE-only content entry as SSE and omits its response schema', () => {
+    const routeOptions = buildApiRoute(contentSseOnlyContract, (_request, sse) => {
+      sse.start('keepAlive')
+    })
+    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
+    )
+  })
+
+  it('treats a JSON + SSE content entry as dual and resolves the JSON response schema', () => {
+    const routeOptions = buildApiRoute(contentDualContract, {
+      nonSse: async () => ({ status: 200, body: undefined }),
+      sse: (_request, sse) => {
+        sse.start('autoClose')
+      },
+    })
+    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect(routeOptions).toEqual(
+      expect.objectContaining({
+        schema: expect.objectContaining({ response: { 200: userSchema } }),
+      }),
+    )
+  })
+
+  it('treats a blob + SSE content entry as dual (non-JSON, non-SSE descriptor counts)', () => {
+    const routeOptions = buildApiRoute(contentBlobDualContract, {
+      nonSse: async () => ({ status: 200, body: undefined }),
+      sse: (_request, sse) => {
+        sse.start('autoClose')
+      },
+    })
+    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    // No JSON media type is declared, so no response schema is registered.
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
+    )
+  })
+
+  it('treats an allowNoBody content entry as dual', () => {
+    const routeOptions = buildApiRoute(contentAllowNoBodyContract, {
+      nonSse: async () => ({ status: 200, body: undefined }),
+      sse: (_request, sse) => {
+        sse.start('autoClose')
+      },
+    })
+    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect(routeOptions).toEqual(
+      expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
     )
   })
 })

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -8,10 +8,13 @@ import {
   hasAnySuccessSseResponse,
   isAnyOfResponses,
   isBlobResponse,
-  isNoBodyResponse,
+  isContentResponseEntry,
+  isSseBody,
   isSseResponse,
   isTextResponse,
   mapApiContractToPath,
+  type ResponseEntry,
+  resolveContractResponse,
   type SseSchemaByEventName,
   SUCCESSFUL_HTTP_STATUS_CODES,
 } from '@lokalise/api-contracts'
@@ -38,7 +41,13 @@ import type { ApiRouteOptions, InferApiHandler } from './apiHandlerTypes.ts'
 
 type ResponseMode = 'non-sse' | 'sse' | 'dual'
 
-function isSuccessResponseDual(value: ApiContractResponse): boolean {
+function isSuccessResponseDual(value: ApiContractResponse | ResponseEntry): boolean {
+  if (isContentResponseEntry(value)) {
+    // A content-map entry offers a non-SSE representation when it allows an empty
+    // body or declares any non-SSE media type descriptor.
+    if (value.allowNoBody || !value.content) return true
+    return Object.values(value.content).some((descriptor) => !isSseBody(descriptor))
+  }
   if (value === ContractNoBody || isTextResponse(value) || isBlobResponse(value)) return true
   if (!isSseResponse(value) && !isAnyOfResponses(value)) return true
   if (isAnyOfResponses(value)) {
@@ -73,34 +82,13 @@ function buildSSERouteConfig<C extends ApiContract>(
 
 function getSchemaForStatusCode(contract: ApiContract, status: number): z.ZodType | null {
   const entry = contract.responsesByStatusCode[status as HttpStatusCode]
+  if (!entry) return null
 
-  if (
-    !entry ||
-    entry === ContractNoBody ||
-    isNoBodyResponse(entry) ||
-    isSseResponse(entry) ||
-    isTextResponse(entry) ||
-    isBlobResponse(entry)
-  ) {
-    return null
-  }
-
-  if (isAnyOfResponses(entry)) {
-    for (const anyResponse of entry.responses) {
-      if (
-        isSseResponse(anyResponse) ||
-        isTextResponse(anyResponse) ||
-        isBlobResponse(anyResponse)
-      ) {
-        continue
-      }
-      return anyResponse
-    }
-
-    return null
-  } else {
-    return entry
-  }
+  // Resolve the JSON representation for this status code, covering both legacy
+  // response entries (bare Zod schema, anyOfResponses, …) and the new content-map
+  // entries. Non-JSON responses (text, blob, SSE, no-body) are not validated here.
+  const resolved = resolveContractResponse(entry, 'application/json', false)
+  return resolved?.kind === 'json' ? resolved.schema : null
 }
 
 function validateApiResponseHeaders(contract: ApiContract, reply: FastifyReply): void {


### PR DESCRIPTION
## What

`@lokalise/api-contracts` 6.15 added content-map response entries (`ResponseEntry = BodyContentResponseEntry | NoBodyContentResponseEntry`) to `ResponsesByStatusCode`. The existing type guards only handled the legacy `ApiContractResponse` shape.

## Changes

- **`apiRouteBuilder.ts`**: `isSuccessResponseDual` now handles content-map entries; `getSchemaForStatusCode` resolves both legacy and content-map entries via the library's `resolveContractResponse`.
- **`apiHandlerTypes.ts`**: added an `EnsureSseEventSchemas` guard so `InferSseSuccessResponses` still satisfies the `SSEContext` constraint after the content-map path can widen it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for content-map API response definitions, including dual (SSE + non-SSE) responses and SSE-only or optional-body scenarios.
  * Strengthened SSE handler typing by enforcing event schema correctness, with a safe fallback when schemas can’t be inferred.
* **Bug Fixes**
  * Improved classification of mixed SSE/non-SSE responses for routing and schema registration.
  * Enhanced JSON schema resolution so JSON validation is selected consistently across response formats.
* **Tests**
  * Added coverage for content-map response cases and SSE typing utilities, including compile-time type assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->