### PR TITLE
feat: SSE polling-fallback foundation (dual-mode fallback bindings, @fastify/sse 0.6 adaptation, gateway streaming support)

### DIFF
--- a/.changeset/api-contracts-rooms.md
+++ b/.changeset/api-contracts-rooms.md
@@ -1,0 +1,7 @@
+---
+"opinionated-machine": minor
+---
+
+Add SSE rooms support to the modern api-contracts path.
+
+`buildApiRoute` accepts a new `sseRooms: SSERoomBroadcaster` option: sessions started by the route's SSE handler get working `session.rooms.join()/leave()` (previously silent no-ops in this path), receive room broadcasts, and are cleaned up (rooms left, dedup cache cleared) when the connection closes. This makes the dual-mode fallback pattern possible with `AbstractApiController`: the sync branch answers polls while a domain service broadcasts into a room the SSE branch joined. The new `ApiSseConnectionRegistry` bridges connections to a shared broadcaster.

--- a/.changeset/gateway-streaming-support.md
+++ b/.changeset/gateway-streaming-support.md
@@ -1,0 +1,13 @@
+---
+"opinionated-machine": minor
+"@opinionated-machine/gateway-envoy": minor
+"@opinionated-machine/gateway-kong": minor
+"@opinionated-machine/gateway-krakend": minor
+---
+
+Mark streaming routes in the gateway manifest and map `timeouts.idle` in all generators.
+
+- Routes built from SSE/dual-mode contracts are stamped with a streaming mode (non-enumerable `Symbol.for('opinionated-machine.route.streaming')`), and the manifest gains an optional `streaming: 'sse' | 'dual'` field. Legacy `AbstractSSEController`/`AbstractDualModeController` routes can be included via the new `buildGatewayManifest({ includeStreamingControllers: true })` opt-in.
+- Envoy: `timeouts.idle` maps to route-level `idle_timeout` (previously silently ignored); streaming routes default to `timeout: 0s` and `idle_timeout: 0s` so Envoy's defaults (15s route timeout, 5m stream idle timeout) no longer reset SSE streams; new `EnvoyOptions.streamIdleTimeout` configures the listener-wide HCM value; declaring `timeouts.request` on a streaming route now warns (it bounds total stream lifetime).
+- Kong: `timeouts.idle` participates in the loosest-wins service `read_timeout`; streaming routes emit `response_buffering: false` (Kong ≥ 2.3); streaming routes without `timeouts.idle` warn that heartbeats must beat the effective `read_timeout`.
+- KrakenD: the endpoint `timeout` uses the looser of `timeouts.request`/`timeouts.idle`; streaming routes with neither warn about KrakenD's 2s default endpoint timeout.

--- a/.changeset/sse-event-ids.md
+++ b/.changeset/sse-event-ids.md
@@ -1,0 +1,5 @@
+---
+"opinionated-machine": minor
+---
+
+Add monotonic event-id helpers for SSE streams: `createEventIdSequence()` produces lexicographically ordered ids (`"<epoch>-<zero-padded counter>"`) suitable for `Last-Event-ID` reconnection, client-side ordering, and the polling-fallback version gate; `compareEventIds()` orders ids within an epoch and returns `undefined` across epochs (a signal to resynchronize via a snapshot poll).

--- a/.changeset/sse-fallback-initial.md
+++ b/.changeset/sse-fallback-initial.md
@@ -1,0 +1,9 @@
+---
+"@opinionated-machine/sse-fallback": minor
+---
+
+Initial release: browser-safe, zero-dependency client core for SSE with a transparent polling fallback.
+
+- `defineFallbackBinding(contract, config)` declares the reconciliation (snapshot→events mapping, version extraction, terminal events, optional state reducer) on a dual-mode contract; `bindFallbackContracts` binds two separate contracts; `fromLegacyDualModeContract` adapts legacy `buildSseContract` contracts.
+- `createResilientSubscription(binding, { transport, params })` runs the client state machine: SSE as the low-latency channel, deadman-gated polls as the correctness backbone, a version gate for exactly-once-per-version delivery across both channels, subscribe-first hydration, byte-level stale-connection detection, `Last-Event-ID` reconnects, and degradation to pure polling with background SSE recovery.
+- Transport-agnostic (`FallbackTransport` seam) with a scripted `TestTransport` for deterministic fake-timer tests.

--- a/.changeset/sse-fastify-sse-06-adaptation.md
+++ b/.changeset/sse-fastify-sse-06-adaptation.md
@@ -1,0 +1,10 @@
+---
+"opinionated-machine": minor
+---
+
+Adapt SSE routes to @fastify/sse 0.6 route kinds and restore per-route heartbeats.
+
+- SSE-only routes are now registered with kind `'only'` (lenient Accept gate): a missing `Accept` header or `*/*` streams (previously errored with `FST_ERR_SSE_LEGACY_MISUSE`), and clients that explicitly refuse `text/event-stream` get a clean 406 (previously a 500).
+- Dual-mode routes are now registered with kind `'manual'`, making the framework's `determineMode()` the single Accept negotiator — `defaultMode: 'sse'` now works with ambiguous Accept headers (previously crashed).
+- Route-level and registration-time `heartbeatInterval` settings are effective again via a framework-managed heartbeat timer (both were silent no-ops under @fastify/sse 0.6, which only supports a plugin-level interval). The option type widened to `number | false`; `false`/`0` disables heartbeats for the route even when the plugin-level heartbeat is on.
+- `SSEHttpClient` gained an `onRawChunk` hook that observes raw stream chunks, including `: heartbeat` comment frames the SSE parser drops.

--- a/.github/workflows/sse-fallback.yml
+++ b/.github/workflows/sse-fallback.yml
@@ -1,0 +1,54 @@
+---
+name: sse-fallback
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/sse-fallback/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/sse-fallback/**'
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/sse-fallback
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+
+      - name: Install all dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
+
+      - name: Run Tests
+        run: pnpm test
+
+      - name: Run Linting
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ Very opinionated DI framework for fastify, built on top of awilix
   - [Field Reference](#field-reference)
   - [Generating Gateway Configs](#generating-gateway-configs)
   - [Inspecting the Manifest at Runtime](#inspecting-the-manifest-at-runtime)
+  - [Streaming Routes](#streaming-routes)
   - [What's Not Covered](#whats-not-covered)
+- [Polling Fallback for SSE](#polling-fallback-for-sse)
+  - [Serving the Pattern](#serving-the-pattern)
+  - [Monotonic Event IDs](#monotonic-event-ids)
+  - [Server-Side Guarantees Checklist](#server-side-guarantees-checklist)
 
 ## Basic usage
 
@@ -1097,7 +1102,7 @@ private handleAdminStream = buildHandler(adminStreamContract, {
 | `onReconnect` | Handle Last-Event-ID reconnection, return events to replay |
 | `logger` | Optional `SSELogger` for error handling (compatible with pino and `@lokalise/node-core`). If not provided, errors in lifecycle hooks are silently ignored |
 | `serializer` | Custom serializer for SSE data (e.g., for custom JSON encoding) |
-| `heartbeatInterval` | Interval in ms for heartbeat keep-alive messages |
+| `heartbeatInterval` | Interval in ms for `: heartbeat` keep-alive comments, managed by a framework timer (the @fastify/sse plugin heartbeat is disabled for the route). Set to `0` or `false` to disable heartbeats for the route entirely; leave unset to use the plugin-level default (30s) |
 | `contractMetadataToRouteMapper` | Maps contract metadata to Fastify route options (see below) |
 
 **onClose reason parameter:**
@@ -2619,6 +2624,13 @@ await app.ready()
 
 ### Accept Header Routing
 
+Dual-mode routes are registered with @fastify/sse kind `'manual'`, so the
+framework's `determineMode()` is the single Accept negotiator: q-value aware,
+`defaultMode` applies for `*/*` or a missing `Accept` header (including
+`defaultMode: 'sse'`). SSE-only routes use kind `'only'` — a missing header or
+`*/*` streams, and a client that explicitly refuses `text/event-stream`
+(e.g. `Accept: application/json`) receives a clean 406.
+
 The `Accept` header determines response mode:
 
 ```bash
@@ -3077,7 +3089,7 @@ time.
 | Field | Example | Notes |
 | ----- | ------- | ----- |
 | `upstream` | `'users-service'` | Logical cluster name; resolved to a host by the generator |
-| `timeouts` | `{ request: '5s', idle: '60s', connect: '1s' }` | Duration units: `ms` / `s` / `m` / `h` |
+| `timeouts` | `{ request: '5s', idle: '60s', connect: '1s' }` | Duration units: `ms` / `s` / `m` / `h`. `idle` maps to Envoy route `idle_timeout`, joins Kong's loosest-wins `read_timeout`, and raises KrakenD's endpoint `timeout` — declare it on streaming routes to bound liveness (pair with heartbeats) |
 | `retry` | `{ attempts: 2, on: ['5xx', 'connect-failure'], perTryTimeout: '2s' }` | |
 | `rateLimit` | `{ requests: 100, per: '1m', key: 'ip' }` | `key`: `'ip'`, `{ header }`, `{ customHeader }`, `{ query }`, `{ customQuery }` |
 | `cache` | `{ ttl: '60s', methods: ['GET'], vary: ['Accept-Language'] }` | |
@@ -3164,11 +3176,41 @@ const manifest = app.buildGatewayManifest()
 The manifest is rebuilt on every call, so it always reflects the current set
 of registered controllers.
 
+### Streaming Routes
+
+SSE and dual-mode routes need gateway treatment that request-response routes
+must not get: Envoy's defaults (15s route timeout, 5-minute stream idle
+timeout) reset long-lived streams, and buffering proxies hold SSE frames until
+the response completes. Routes built from SSE-capable contracts are therefore
+stamped with a streaming mode, and the manifest carries it as
+`streaming: 'sse' | 'dual'`:
+
+- **Envoy** — streaming routes default to `timeout: 0s` and `idle_timeout: 0s`
+  (declare `timeouts.idle` to reinstate a liveness bound; heartbeats are the
+  intended keep-alive). `EnvoyOptions.streamIdleTimeout` sets the listener-wide
+  HCM `stream_idle_timeout` for everything else. Declaring `timeouts.request`
+  on a streaming route warns — it bounds the stream's total lifetime.
+- **Kong** — streaming routes emit `response_buffering: false` (Kong ≥ 2.3);
+  `timeouts.idle` joins the loosest-wins service `read_timeout`. Streaming
+  routes without a declared idle warn: heartbeats must arrive within the
+  effective `read_timeout` (Kong default 60s) or the stream is reset.
+- **KrakenD** — the endpoint `timeout` uses the looser of `timeouts.request` /
+  `timeouts.idle`; streaming routes with neither warn about KrakenD's 2s
+  default endpoint timeout.
+
+Routes declared through `AbstractApiController` are always included in the
+manifest. Legacy `AbstractSSEController` / `AbstractDualModeController` routes
+are included when you opt in:
+
+```ts
+const manifest = context.buildGatewayManifest({
+  service: 'users-api',
+  includeStreamingControllers: true, // default false — existing manifests don't silently grow
+})
+```
+
 ### What's Not Covered
 
-- **SSE and dual-mode controllers.** Only routes from `AbstractController` and
-  `AbstractApiController` appear in the manifest today. Streaming routes still
-  proxy through every gateway, but they aren't listed.
 - **Fields a particular gateway can't natively express.** They show up in
   `result.warnings` rather than disappearing. Reach for `extensions.<vendor>`
   to hand-write the missing piece on a per-route basis.
@@ -3176,3 +3218,103 @@ of registered controllers.
   gateway runs separately. The generators don't compare deployed gateway
   state against the manifest.
 
+
+## Polling Fallback for SSE
+
+Push channels fail silently: connections die without an error event, proxies
+kill idle streams, a broadcast misses a rebalancing room. When the missed
+notification gates workflow progress ("upload finished"), the user is stuck.
+
+[`@opinionated-machine/sse-fallback`](./packages/sse-fallback/README.md) is a
+browser-safe, zero-dependency client core that makes **polling the correctness
+backbone** and SSE the latency optimization: the client subscribes to the SSE
+branch of a dual-mode route and keeps a deadman timer — when no data event
+arrives within the window, it polls the JSON branch of the same route. A
+version gate reconciles the two channels so app code sees exactly one uniform
+event stream:
+
+```ts
+// Shared contracts module — the binding is the reconciliation declaration
+export const uploadStatusBinding = defineFallbackBinding(uploadStatusContract, {
+  snapshotToEvents: (s) =>
+    s.status === 'completed' ? [{ event: 'uploadFinished', data: { result: s.result } }] : [],
+  version: { ofSnapshot: (s) => s.version },
+  terminalEvents: ['uploadFinished', 'uploadFailed'],
+})
+
+// Client — identical result whether it traveled over SSE, replay, or a poll
+const sub = createResilientSubscription(uploadStatusBinding, { transport, params })
+const { result } = await sub.waitFor('uploadFinished')
+```
+
+See the [package README](./packages/sse-fallback/README.md) for the state
+machine, reconciliation semantics, hydration (initial load + live updates),
+and the transport interface.
+
+### Serving the Pattern
+
+One dual-mode `AbstractApiController` route serves both channels — the sync
+branch answers the fallback polls, the SSE branch joins a room that the domain
+service broadcasts into:
+
+```ts
+readonly routes = {
+  jobStatus: buildApiRoute(jobStatusContract, {
+    // The fallback poll: return the current snapshot with its version
+    nonSse: async (request) => ({ status: 200, body: this.jobs.get(request.params.jobId) }),
+    // The push channel: join the job's room and stay open
+    sse: (request, sse) => {
+      const session = sse.start('keepAlive')
+      session.rooms.join(`job:${request.params.jobId}`)
+    },
+  }, {
+    sseRooms: this.sseRoomBroadcaster,   // enables session.rooms + broadcast delivery
+    heartbeatInterval: 15_000,           // fast client-side stale detection
+  }),
+}
+```
+
+```ts
+// Domain service — broadcast with a monotonic id so clients can order events
+await this.sseRoomBroadcaster.broadcastToRoom(`job:${jobId}`, doneEvent, { result }, {
+  id: String(job.version),
+})
+```
+
+### Monotonic Event IDs
+
+`Last-Event-ID` replay, client-side ordering, and the fallback version gate
+all need event ids a client can ORDER, not just deduplicate. Use
+`createEventIdSequence()` (one sequence per ordering scope — per room, per
+resource):
+
+```ts
+import { compareEventIds, createEventIdSequence } from 'opinionated-machine'
+
+const seq = createEventIdSequence()
+await broadcaster.broadcastToRoom(room, statusEvent, data, { id: seq.next() })
+
+// Ids order lexicographically within an epoch; across epochs (e.g. after a
+// process restart) compareEventIds returns undefined — clients resync via poll
+compareEventIds('e1-000000000001', 'e1-000000000002') // -1
+```
+
+### Server-Side Guarantees Checklist
+
+For a resource to participate in the fallback pattern:
+
+1. **Required** — a monotonic version per resource, present in both the
+   snapshot body and each event, and truthful: a snapshot at version *v*
+   reflects every event ≤ *v* (publish events after commit; read committed
+   state in the poll handler). Snapshots must **subsume** prior events.
+2. **Recommended** — stamp the SSE `id:` with that version; the client's
+   default version extraction and `Last-Event-ID` replay then compose free.
+3. **Recommended** — heartbeats every ~15s (route-level `heartbeatInterval`)
+   so clients detect silently dead connections fast; correctness holds
+   without them (polls bound staleness), detection latency improves with them.
+4. Optional — dense (consecutive) versions enable client gap detection;
+   `onReconnect` replay lets clients skip the post-reconnect poll
+   (`replay: 'trusted'` in the binding).
+5. Gateway — declare `timeouts.idle` on streaming routes (or rely on the
+   streaming-route defaults) so proxies don't reset quiet streams; see
+   [Streaming Routes](#streaming-routes).

--- a/lib/DIContext.ts
+++ b/lib/DIContext.ts
@@ -6,7 +6,6 @@ import type { RouteType } from '@lokalise/fastify-api-contracts'
 import type { AwilixContainer, NameAndRegistrationPair, Resolver } from 'awilix'
 import { AwilixManager } from 'awilix-manager'
 import type { FastifyInstance, RouteOptions } from 'fastify'
-import { merge } from 'ts-deepmerge'
 import type { AbstractController } from './AbstractController.js'
 import type { AbstractModule } from './AbstractModule.js'
 import type { AbstractApiController } from './api-contracts/index.ts'
@@ -24,6 +23,8 @@ import {
   type RegisterDualModeRoutesOptions,
   type RegisterSSERoutesOptions,
 } from './routes/index.js'
+import { SSE_ROUTE_CONFIG_KEY, type SSERouteRuntimeConfig } from './routes/sseHeartbeat.js'
+import { mergeSSERouteField } from './routes/sseRouteConfig.js'
 import type { AbstractSSEController } from './sse/AbstractSSEController.js'
 
 export type RegisterDependenciesParams<Dependencies, Config, ExternalDependencies> = {
@@ -225,7 +226,11 @@ export class DIContext<
    * like `@opinionated-machine/gateway-envoy` or
    * `@opinionated-machine/gateway-krakend` to produce a config.
    *
-   * SSE and dual-mode controllers are not included in v1.
+   * SSE and dual-mode routes declared through `AbstractApiController` are
+   * always included and carry a `streaming: 'sse' | 'dual'` marker. Routes
+   * from legacy `AbstractSSEController` / `AbstractDualModeController`
+   * controllers are included only when `includeStreamingControllers: true`
+   * is passed (off by default so existing manifests don't silently grow).
    *
    * @example
    * ```ts
@@ -250,6 +255,19 @@ export class DIContext<
       // biome-ignore lint/suspicious/noExplicitAny: any api controller works here
       const controller: AbstractApiController<any> = this.diContainer.resolve(name)
       collected.push({ name, kind: 'api', controller })
+    }
+
+    if (options.includeStreamingControllers) {
+      for (const name of this.sseControllerNames) {
+        // biome-ignore lint/suspicious/noExplicitAny: any SSE controller works here
+        const controller: AbstractSSEController<any> = this.diContainer.resolve(name)
+        collected.push({ name, kind: 'sse-legacy', controller })
+      }
+      for (const name of this.dualModeControllerNames) {
+        // biome-ignore lint/suspicious/noExplicitAny: any dual-mode controller works here
+        const controller: AbstractDualModeController<any> = this.diContainer.resolve(name)
+        collected.push({ name, kind: 'dualmode-legacy', controller })
+      }
     }
 
     return buildGatewayManifestFrom(collected, options)
@@ -361,46 +379,51 @@ export class DIContext<
     route: RouteOptions,
     options?: RegisterDualModeRoutesOptions,
   ): void {
-    if (options?.preHandler) {
-      this.applyPreHandlers(route, options.preHandler)
-    }
-    if (options?.rateLimit) {
-      this.applyRateLimit(route, options.rateLimit)
-    }
-    // Apply SSE-specific options (heartbeatInterval, serializer) for SSE mode
-    if (options?.heartbeatInterval !== undefined || options?.serializer !== undefined) {
-      // biome-ignore lint/suspicious/noExplicitAny: config types vary by plugins
-      const routeWithConfig = route as RouteOptions & { config?: any }
-      routeWithConfig.config = merge(routeWithConfig.config || {}, {
-        sse: {
-          ...(options.heartbeatInterval !== undefined && {
-            heartbeatInterval: options.heartbeatInterval,
-          }),
-          ...(options.serializer !== undefined && { serializer: options.serializer }),
-        },
-      })
-    }
+    this.applyStreamRouteOptions(route, options)
   }
 
   private applySSERouteOptions(route: RouteOptions, options?: RegisterSSERoutesOptions): void {
+    this.applyStreamRouteOptions(route, options)
+  }
+
+  /**
+   * Apply registration-time options to an SSE/dual-mode route before app.route().
+   *
+   * The serializer is merged into the route's `sse` field (honored by
+   * @fastify/sse per route); a heartbeat interval disables the plugin's own
+   * heartbeat on the `sse` field and is stashed under
+   * `route.config[SSE_ROUTE_CONFIG_KEY]` where the framework heartbeat reads
+   * it at request time. Route-level options (buildHandler) take precedence.
+   */
+  private applyStreamRouteOptions(
+    route: RouteOptions,
+    options?: RegisterSSERoutesOptions | RegisterDualModeRoutesOptions,
+  ): void {
     if (options?.preHandler) {
       this.applyPreHandlers(route, options.preHandler)
     }
     if (options?.rateLimit) {
       this.applyRateLimit(route, options.rateLimit)
     }
-    // Apply SSE-specific options (heartbeatInterval, serializer)
-    if (options?.heartbeatInterval !== undefined || options?.serializer !== undefined) {
-      // biome-ignore lint/suspicious/noExplicitAny: config types vary by plugins
-      const routeWithConfig = route as RouteOptions & { config?: any }
-      routeWithConfig.config = merge(routeWithConfig.config || {}, {
-        sse: {
-          ...(options.heartbeatInterval !== undefined && {
-            heartbeatInterval: options.heartbeatInterval,
-          }),
-          ...(options.serializer !== undefined && { serializer: options.serializer }),
-        },
-      })
+    if (options?.heartbeatInterval === undefined && options?.serializer === undefined) {
+      return
+    }
+
+    route.sse = mergeSSERouteField(route.sse, {
+      serializer: options.serializer,
+      disablePluginHeartbeat: options.heartbeatInterval !== undefined,
+    })
+
+    if (options.heartbeatInterval !== undefined) {
+      if (!route.config) {
+        route.config = {} as NonNullable<RouteOptions['config']>
+      }
+      const config = route.config as unknown as Record<string, unknown>
+      const existing = config[SSE_ROUTE_CONFIG_KEY] as SSERouteRuntimeConfig | undefined
+      config[SSE_ROUTE_CONFIG_KEY] = {
+        ...existing,
+        heartbeatInterval: options.heartbeatInterval,
+      } satisfies SSERouteRuntimeConfig
     }
   }
 

--- a/lib/api-contracts/apiHandlerTypes.ts
+++ b/lib/api-contracts/apiHandlerTypes.ts
@@ -16,6 +16,7 @@ import type {
   SSEHandlerResult,
   SyncModeReply,
 } from '../routes/fastifyRouteTypes.ts'
+import type { SSERoomBroadcaster } from '../sse/rooms/SSERoomBroadcaster.ts'
 
 // ============================================================================
 // Status+Body Response
@@ -196,6 +197,15 @@ export type ApiRouteOptions<Contract extends ApiContract> = Omit<
      * @default 'json'
      */
     defaultMode?: DualModeType
+    /**
+     * Enable SSE rooms for this route by passing the shared
+     * `SSERoomBroadcaster` from the DI container. Sessions started by the
+     * route's SSE handler get working `session.rooms.join()/leave()`, receive
+     * room broadcasts (`broadcastToRoom`/`broadcastMessage`), and are cleaned
+     * up (rooms left, dedup cache cleared) when the connection closes.
+     * Without this option, `session.rooms` operations are no-ops.
+     */
+    sseRooms?: SSERoomBroadcaster
     /**
      * Per-route gateway metadata. `match.headers` / `match.query` keys are
      * narrowed to the contract's request schemas; `customHeaders` /

--- a/lib/api-contracts/apiRouteBuilder.spec.ts
+++ b/lib/api-contracts/apiRouteBuilder.spec.ts
@@ -180,11 +180,11 @@ describe('buildApiRoute — non-SSE', () => {
 // ============================================================================
 
 describe('buildApiRoute — SSE-only', () => {
-  it('produces a route with sse: true', () => {
+  it("produces a route with sse: 'only'", () => {
     const routeOptions = buildApiRoute(sseOnlyContract, (_request, sse) => {
       sse.start('keepAlive')
     })
-    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect((routeOptions as { sse?: unknown }).sse).toBe('only')
   })
 
   it('produces correct url', () => {
@@ -200,14 +200,14 @@ describe('buildApiRoute — SSE-only', () => {
 // ============================================================================
 
 describe('buildApiRoute — dual-mode', () => {
-  it('produces a route with sse: true', () => {
+  it("produces a route with sse: 'manual' (determineMode owns Accept negotiation)", () => {
     const routeOptions = buildApiRoute(dualModeContract, {
       nonSse: async () => ({ status: 200, body: { id: '1', name: 'Alice' } }),
       sse: (_request, sse) => {
         sse.start('autoClose')
       },
     })
-    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect((routeOptions as { sse?: unknown }).sse).toBe('manual')
   })
 
   it('produces correct url and method', () => {
@@ -248,7 +248,7 @@ describe('buildApiRoute — SSE config via options', () => {
       },
       { serializer },
     )
-    expect((routeOptions as { sse?: unknown }).sse).toEqual({ serializer })
+    expect((routeOptions as { sse?: unknown }).sse).toEqual({ kind: 'only', serializer })
   })
 
   it('passes heartbeatInterval into sse config', () => {
@@ -259,7 +259,9 @@ describe('buildApiRoute — SSE config via options', () => {
       },
       { heartbeatInterval: 10000 },
     )
-    expect((routeOptions as { sse?: unknown }).sse).toEqual({ heartbeatInterval: 10000 })
+    // A route-level interval disables the plugin heartbeat; the framework
+    // timer (started on sse.start()) handles the interval itself.
+    expect((routeOptions as { sse?: unknown }).sse).toEqual({ kind: 'only', heartbeat: false })
   })
 })
 
@@ -361,7 +363,7 @@ describe('buildApiRoute — content-map response entries', () => {
     const routeOptions = buildApiRoute(contentSseOnlyContract, (_request, sse) => {
       sse.start('keepAlive')
     })
-    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect((routeOptions as { sse?: unknown }).sse).toBe('only')
     expect(routeOptions).toEqual(
       expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
     )
@@ -374,7 +376,7 @@ describe('buildApiRoute — content-map response entries', () => {
         sse.start('autoClose')
       },
     })
-    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect((routeOptions as { sse?: unknown }).sse).toBe('manual')
     expect(routeOptions).toEqual(
       expect.objectContaining({
         schema: expect.objectContaining({ response: { 200: userSchema } }),
@@ -389,7 +391,7 @@ describe('buildApiRoute — content-map response entries', () => {
         sse.start('autoClose')
       },
     })
-    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect((routeOptions as { sse?: unknown }).sse).toBe('manual')
     // No JSON media type is declared, so no response schema is registered.
     expect(routeOptions).toEqual(
       expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
@@ -403,7 +405,7 @@ describe('buildApiRoute — content-map response entries', () => {
         sse.start('autoClose')
       },
     })
-    expect((routeOptions as { sse?: unknown }).sse).toBe(true)
+    expect((routeOptions as { sse?: unknown }).sse).toBe('manual')
     expect(routeOptions).toEqual(
       expect.objectContaining({ schema: expect.objectContaining({ response: {} }) }),
     )

--- a/lib/api-contracts/apiRouteBuilder.ts
+++ b/lib/api-contracts/apiRouteBuilder.ts
@@ -18,6 +18,7 @@ import { InternalError } from '@lokalise/node-core'
 import type { FastifyReply, RouteOptions } from 'fastify'
 import type { z } from 'zod/v4'
 import { isErrorLike } from '../errorUtils.ts'
+import { attachRouteStreamingMode } from '../gateway/routeStreaming.ts'
 import { attachGatewayMetadata } from '../gateway/withGatewayMetadata.ts'
 import type {
   SSEContext,
@@ -29,7 +30,11 @@ import type {
 } from '../routes/fastifyRouteTypes.ts'
 import type { SSEReply } from '../routes/fastifyRouteUtils.ts'
 import { determineMode, hasHttpStatusCode } from '../routes/fastifyRouteUtils.ts'
+import { resolveHeartbeatInterval, startFrameworkHeartbeat } from '../routes/sseHeartbeat.ts'
+import { buildSSERouteField, type SSERouteKind } from '../routes/sseRouteConfig.ts'
+import type { SSERoomOperations } from '../sse/rooms/types.ts'
 import type { ApiRouteOptions, InferApiHandler } from './apiHandlerTypes.ts'
+import { getApiSseConnectionRegistry } from './apiSseConnectionRegistry.ts'
 
 // ============================================================================
 // Internal Helpers — Response Mode
@@ -57,15 +62,14 @@ function getContractResponseMode(contract: ApiContract): ResponseMode {
   return 'sse'
 }
 
-function buildSSERouteConfig<C extends ApiContract>(
+function buildApiSSERouteField<C extends ApiContract>(
+  kind: SSERouteKind,
   options: ApiRouteOptions<C> | undefined,
-): true | { serializer?: (data: unknown) => string; heartbeatInterval?: number } {
-  if (!options?.serializer && options?.heartbeatInterval === undefined) return true
-  const sseConfig: { serializer?: (data: unknown) => string; heartbeatInterval?: number } = {}
-  if (options.serializer) sseConfig.serializer = options.serializer
-  if (options.heartbeatInterval !== undefined)
-    sseConfig.heartbeatInterval = options.heartbeatInterval
-  return sseConfig
+) {
+  return buildSSERouteField(kind, {
+    serializer: options?.serializer,
+    heartbeatInterval: options?.heartbeatInterval,
+  })
 }
 
 // ============================================================================
@@ -168,6 +172,17 @@ function buildApiSSEContext<C extends ApiContract>(
   let responseData: { code: number; body: unknown } | undefined
   const sseReply = reply as SSEReply
 
+  // Framework-managed per-route heartbeat (plugin heartbeat is disabled via
+  // `heartbeat: false` on the route's `sse` field whenever an interval is set)
+  let stopHeartbeat: (() => void) | undefined
+  const maybeStartHeartbeat = () => {
+    if (stopHeartbeat) return
+    const intervalMs = resolveHeartbeatInterval(options?.heartbeatInterval, request)
+    if (!intervalMs) return
+    stopHeartbeat = startFrameworkHeartbeat(reply, intervalMs)
+    sseReply.sse.onClose(() => stopHeartbeat?.())
+  }
+
   const sseContext: SSEContext = {
     start: <Context = unknown>(mode: SSESessionMode, startOptions?: SSEStartOptions<Context>) => {
       started = true
@@ -180,6 +195,7 @@ function buildApiSSEContext<C extends ApiContract>(
       // flushHeaders() forces them onto the wire so the client's fetch() returns.
       sseReply.sse.sendHeaders()
       reply.raw.flushHeaders()
+      maybeStartHeartbeat()
 
       const connectionId = randomUUID()
 
@@ -211,6 +227,43 @@ function buildApiSSEContext<C extends ApiContract>(
         }
       }
 
+      // Wire up rooms when the route opted in via options.sseRooms
+      let rooms: SSERoomOperations = { join: () => {}, leave: () => {} }
+      const broadcaster = options?.sseRooms
+      if (broadcaster) {
+        const registry = getApiSseConnectionRegistry(broadcaster)
+        // Raw send for room broadcasts — returns false (never throws) so a
+        // failed delivery doesn't abort the broadcast fan-out.
+        registry.register(connectionId, async (message) => {
+          try {
+            await sseReply.sse.send({
+              event: message.event,
+              data: message.data,
+              id: message.id,
+              retry: message.retry,
+            })
+            return true
+          } catch {
+            return false
+          }
+        })
+        // Unconditional cleanup, independent of options.onClose
+        sseReply.sse.onClose(() => registry.unregister(connectionId))
+
+        const roomManager = broadcaster.roomManager
+        rooms = {
+          join: (room) => {
+            // Guard against startup races where the stream is already dead:
+            // joining such a session would leave stale room members behind.
+            if (!sseReply.sse.isConnected || reply.raw.destroyed || reply.raw.writableEnded) {
+              return
+            }
+            roomManager.join(connectionId, room)
+          },
+          leave: (room) => roomManager.leave(connectionId, room),
+        }
+      }
+
       const session: SSESession<typeof eventSchemas, Context> = {
         id: connectionId,
         request,
@@ -226,7 +279,7 @@ function buildApiSSEContext<C extends ApiContract>(
             await send(message.event, message.data, { id: message.id, retry: message.retry })
           }
         },
-        rooms: { join: () => {}, leave: () => {} },
+        rooms,
         eventSchemas,
       }
 
@@ -270,6 +323,7 @@ function buildApiSSEContext<C extends ApiContract>(
 
     sendHeaders: () => {
       sseReply.sse.sendHeaders()
+      maybeStartHeartbeat()
     },
 
     reply,
@@ -416,6 +470,7 @@ export function buildApiRoute<Contract extends ApiContract>(
     onClose: _onClose,
     onReconnect: _onReconnect,
     logger: _logger,
+    sseRooms: _sseRooms,
     ...fastifyOptions
   } = options ?? {}
 
@@ -425,8 +480,14 @@ export function buildApiRoute<Contract extends ApiContract>(
   const baseSchema = buildBaseSchema(contract)
   const contractMetadata = contractMetadataToRouteMapper?.(contract.metadata) ?? {}
 
-  const finalize = (route: RouteOptions): RouteOptions =>
-    gatewayMetadata !== undefined ? attachGatewayMetadata(route, gatewayMetadata) : route
+  const finalize = (route: RouteOptions): RouteOptions => {
+    // Mark streaming routes (derived from the contract's response mode) so
+    // gateway generators can apply streaming-appropriate timeouts/buffering.
+    if (mode !== 'non-sse') {
+      attachRouteStreamingMode(route, mode)
+    }
+    return gatewayMetadata !== undefined ? attachGatewayMetadata(route, gatewayMetadata) : route
+  }
 
   if (mode === 'non-sse') {
     // biome-ignore lint/suspicious/noExplicitAny: handler shape validated by InferApiHandler at call site
@@ -450,7 +511,9 @@ export function buildApiRoute<Contract extends ApiContract>(
       ...contractMetadata,
       method: contract.method,
       url,
-      sse: buildSSERouteConfig(options),
+      // 'manual' kind: the plugin does no Accept negotiation — determineMode()
+      // below is the single negotiator (q-value aware, honors defaultMode).
+      sse: buildApiSSERouteField('manual', options),
       schema: baseSchema,
       handler: (request, reply) => {
         const responseMode = determineMode(request.headers.accept, resolvedDefaultMode)
@@ -470,7 +533,9 @@ export function buildApiRoute<Contract extends ApiContract>(
     ...contractMetadata,
     method: contract.method,
     url,
-    sse: buildSSERouteConfig(options),
+    // 'only' kind: lenient Accept gate — `*/*` or a missing Accept header
+    // admits SSE; explicit refusal of text/event-stream gets a clean 406.
+    sse: buildApiSSERouteField('only', options),
     schema: baseSchema,
     handler: async (request, reply) =>
       handleApiSseRoute(sseHandler, eventSchemas, options, request, reply),

--- a/lib/api-contracts/apiSseConnectionRegistry.ts
+++ b/lib/api-contracts/apiSseConnectionRegistry.ts
@@ -1,0 +1,63 @@
+import type { SSERoomBroadcaster } from '../sse/rooms/SSERoomBroadcaster.ts'
+import type { SSEMessage } from '../sse/sseTypes.ts'
+
+/**
+ * Connection registry bridging `buildApiRoute` SSE sessions to a shared
+ * `SSERoomBroadcaster`.
+ *
+ * The legacy SSE/dual-mode controllers register their own `sendEvent` with
+ * the broadcaster; `buildApiRoute` routes have no controller, so this
+ * registry keeps the connection-id → raw-send mapping and registers itself
+ * as a single broadcaster sender. One registry exists per broadcaster
+ * (see {@link getApiSseConnectionRegistry}), shared by all routes and
+ * controllers that pass the same `sseRooms` broadcaster.
+ */
+export class ApiSseConnectionRegistry {
+  private readonly connections = new Map<string, (msg: SSEMessage) => Promise<boolean>>()
+  private readonly broadcaster: SSERoomBroadcaster
+
+  constructor(broadcaster: SSERoomBroadcaster) {
+    this.broadcaster = broadcaster
+    broadcaster.registerSender((connectionId, message) => {
+      const send = this.connections.get(connectionId)
+      return send ? send(message) : Promise.resolve(false)
+    })
+  }
+
+  /**
+   * Register an active SSE connection with its raw send function.
+   * The send function must return `false` (not throw) on delivery failure so
+   * room broadcasts keep fanning out to the remaining connections.
+   */
+  register(connectionId: string, send: (message: SSEMessage) => Promise<boolean>): void {
+    this.connections.set(connectionId, send)
+  }
+
+  /**
+   * Remove a connection: drops the sender, leaves all rooms, and clears the
+   * broadcaster's dedup cache for the connection.
+   */
+  unregister(connectionId: string): void {
+    this.connections.delete(connectionId)
+    this.broadcaster.roomManager.leaveAll(connectionId)
+    this.broadcaster.cleanupConnection(connectionId)
+  }
+}
+
+const registries = new WeakMap<SSERoomBroadcaster, ApiSseConnectionRegistry>()
+
+/**
+ * Get (or lazily create) the shared registry for a broadcaster.
+ * Ensures `registerSender` is called exactly once per broadcaster no matter
+ * how many routes opt into rooms.
+ */
+export function getApiSseConnectionRegistry(
+  broadcaster: SSERoomBroadcaster,
+): ApiSseConnectionRegistry {
+  let registry = registries.get(broadcaster)
+  if (!registry) {
+    registry = new ApiSseConnectionRegistry(broadcaster)
+    registries.set(broadcaster, registry)
+  }
+  return registry
+}

--- a/lib/api-contracts/docs.md
+++ b/lib/api-contracts/docs.md
@@ -10,6 +10,7 @@ The `lib/api-contracts/` module provides `AbstractApiController` and `buildApiRo
 - [Creating a Controller](#creating-a-controller)
 - [Registering with DI](#registering-with-di)
 - [Route Options](#route-options)
+- [SSE Rooms](#sse-rooms)
 - [Testing](#testing)
 
 ## Overview
@@ -264,11 +265,69 @@ buildApiRoute(contract, handler, {
 | `onClose` | Called when SSE session closes. `reason` is `'server'` or `'client'` |
 | `onReconnect` | Handle `Last-Event-ID` reconnection; return events to replay |
 | `serializer` | Custom serializer for SSE event data |
-| `heartbeatInterval` | Interval in ms for SSE keep-alive heartbeats |
+| `heartbeatInterval` | Interval in ms for SSE keep-alive heartbeats (framework-managed timer; `0`/`false` disables heartbeats for the route) |
 | `defaultMode` | Default response mode for dual-mode routes (`'json'` or `'sse'`). Default: `'json'` |
+| `sseRooms` | Enable SSE rooms for this route by passing the shared `SSERoomBroadcaster` (see [SSE Rooms](#sse-rooms)) |
 | `contractMetadataToRouteMapper` | Map contract metadata to Fastify `RouteOptions` fields |
 
 Any other [Fastify `RouteOptions`](https://fastify.dev/docs/latest/Reference/Routes/) fields (`bodyLimit`, `onRequest`, `config`, etc.) can also be passed and are forwarded directly to Fastify.
+
+## SSE Rooms
+
+Without configuration, `session.rooms.join()/leave()` are no-ops in
+`buildApiRoute` sessions. Pass the shared `SSERoomBroadcaster` via
+`options.sseRooms` to make them real: the session joins/leaves rooms on the
+shared `SSERoomManager`, receives `broadcastToRoom` / `broadcastMessage`
+deliveries, and is cleaned up (rooms left, dedup cache cleared) when the
+connection closes.
+
+This unlocks the polling-fallback serving pattern — one dual-mode route whose
+sync branch answers snapshot polls while a domain service broadcasts events
+into a room the SSE branch joined:
+
+```ts
+export class JobController extends AbstractApiController<typeof JobController.contracts> {
+  public static contracts = { jobStatus: jobStatusContract } as const
+  private readonly jobService: JobService
+  private readonly sseRoomBroadcaster: SSERoomBroadcaster
+
+  constructor({ jobService, sseRoomBroadcaster }: Dependencies) {
+    super()
+    this.jobService = jobService
+    this.sseRoomBroadcaster = sseRoomBroadcaster
+    this.routes = {
+      jobStatus: buildApiRoute(JobController.contracts.jobStatus, {
+        // Fallback poll: current snapshot, including its version
+        nonSse: async (request) => ({
+          status: 200,
+          body: this.jobService.get(request.params.jobId),
+        }),
+        // Push channel: join the job's room and stay open
+        sse: (request, sse) => {
+          const session = sse.start('keepAlive')
+          session.rooms.join(`job:${request.params.jobId}`)
+        },
+      }, {
+        sseRooms: this.sseRoomBroadcaster,
+        heartbeatInterval: 15_000,
+      }),
+    }
+  }
+
+  readonly routes: BuildApiRoutesReturnType<typeof JobController.contracts>
+}
+
+// Domain service, anywhere in the app — stamp monotonic ids so clients can
+// order events (see createEventIdSequence):
+await this.sseRoomBroadcaster.broadcastToRoom(`job:${jobId}`, doneEvent, { result }, {
+  id: String(job.version),
+})
+```
+
+Register `sseRoomManager` + `sseRoomBroadcaster` in DI exactly as for the
+legacy controllers (see the root README's "SSE Rooms" section); the same
+broadcaster instance can serve legacy controllers and `buildApiRoute` routes
+simultaneously.
 
 ## Testing
 

--- a/lib/api-contracts/index.ts
+++ b/lib/api-contracts/index.ts
@@ -8,4 +8,8 @@ export type {
   InferApiStatusResponse,
 } from './apiHandlerTypes.ts'
 export { buildApiRoute } from './apiRouteBuilder.ts'
+export {
+  ApiSseConnectionRegistry,
+  getApiSseConnectionRegistry,
+} from './apiSseConnectionRegistry.ts'
 export { asApiControllerClass } from './asApiControllerClass.ts'

--- a/lib/gateway/index.ts
+++ b/lib/gateway/index.ts
@@ -29,4 +29,10 @@ export {
   gatewayManifestSchema,
 } from './manifest/manifestSchema.ts'
 export { normalizePath } from './manifest/pathNormalize.ts'
+export {
+  attachRouteStreamingMode,
+  ROUTE_STREAMING_SYMBOL,
+  type RouteStreamingMode,
+  readRouteStreamingMode,
+} from './routeStreaming.ts'
 export { readGatewayMetadata, withGatewayMetadata } from './withGatewayMetadata.ts'

--- a/lib/gateway/manifest/buildManifest.spec.ts
+++ b/lib/gateway/manifest/buildManifest.spec.ts
@@ -207,3 +207,158 @@ describe('buildGatewayManifestFrom', () => {
     expect(() => buildGatewayManifestFrom(list, { service: 'svc' })).toThrow()
   })
 })
+
+// ============================================================================
+// Streaming marker
+// ============================================================================
+
+import { buildSseContract, sseBody } from '@lokalise/api-contracts'
+import {
+  AbstractDualModeController,
+  type BuildFastifyDualModeRoutesReturnType,
+  type BuildFastifySSERoutesReturnType,
+  buildHandler,
+} from '../../../index.js'
+import { AbstractSSEController } from '../../sse/AbstractSSEController.ts'
+
+const apiSseOnlyContract = defineApiContract({
+  method: 'get',
+  summary: 'stream',
+  pathResolver: () => '/stream',
+  responsesByStatusCode: {
+    200: { content: { 'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }) } },
+  },
+})
+
+const apiDualContract = defineApiContract({
+  method: 'get',
+  summary: 'dual',
+  pathResolver: () => '/dual',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({ ok: z.boolean() }),
+        'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }),
+      },
+    },
+  },
+})
+
+const apiPlainContract = defineApiContract({
+  method: 'get',
+  summary: 'plain',
+  pathResolver: () => '/plain',
+  responsesByStatusCode: { 200: z.object({ ok: z.boolean() }) },
+})
+
+class StreamingApiController extends AbstractApiController<{
+  stream: typeof apiSseOnlyContract
+  dual: typeof apiDualContract
+  plain: typeof apiPlainContract
+}> {
+  readonly routes = {
+    stream: buildApiRoute(apiSseOnlyContract, (_request, sse) => {
+      sse.start('keepAlive')
+    }),
+    dual: buildApiRoute(apiDualContract, {
+      nonSse: () => ({ status: 200, body: { ok: true } }),
+      sse: (_request, sse) => {
+        sse.start('autoClose')
+      },
+    }),
+    plain: buildApiRoute(apiPlainContract, () => ({ status: 200, body: { ok: true } })),
+  }
+}
+
+const legacySseContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/legacy-stream',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+const legacyDualContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/legacy-dual',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  successResponseBodySchema: z.object({ ok: z.boolean() }),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+class LegacyStreamingController extends AbstractSSEController<{
+  stream: typeof legacySseContract
+}> {
+  buildSSERoutes(): BuildFastifySSERoutesReturnType<{ stream: typeof legacySseContract }> {
+    return { stream: this.handleStream }
+  }
+
+  private handleStream = buildHandler(legacySseContract, {
+    sse: (_request, sse) => {
+      sse.start('keepAlive')
+    },
+  })
+}
+
+class LegacyDualStreamingController extends AbstractDualModeController<{
+  dual: typeof legacyDualContract
+}> {
+  buildDualModeRoutes(): BuildFastifyDualModeRoutesReturnType<{
+    dual: typeof legacyDualContract
+  }> {
+    return { dual: this.handleDual }
+  }
+
+  private handleDual = buildHandler(legacyDualContract, {
+    sync: async () => ({ ok: true }),
+    sse: (_request, sse) => {
+      sse.start('autoClose')
+    },
+  })
+}
+
+describe('buildGatewayManifestFrom — streaming marker', () => {
+  it('marks api-contract SSE and dual routes, leaves plain routes unmarked', () => {
+    const manifest = buildGatewayManifestFrom(
+      [{ name: 'streamingController', kind: 'api', controller: new StreamingApiController() }],
+      { service: 'svc' },
+    )
+    const byKey = Object.fromEntries(manifest.routes.map((r) => [r.routeKey, r]))
+    expect(byKey.stream?.streaming).toBe('sse')
+    expect(byKey.dual?.streaming).toBe('dual')
+    expect(byKey.plain?.streaming).toBeUndefined()
+    expect('streaming' in (byKey.plain ?? {})).toBe(false)
+  })
+
+  it('includes legacy SSE/dual-mode controllers with streaming markers', () => {
+    const manifest = buildGatewayManifestFrom(
+      [
+        {
+          name: 'legacySse',
+          kind: 'sse-legacy',
+          controller: new LegacyStreamingController({}),
+        },
+        {
+          name: 'legacyDual',
+          kind: 'dualmode-legacy',
+          controller: new LegacyDualStreamingController({}),
+        },
+      ],
+      { service: 'svc' },
+    )
+    const byPath = Object.fromEntries(manifest.routes.map((r) => [r.path, r]))
+    expect(byPath['/legacy-stream']).toMatchObject({
+      controller: 'legacySse',
+      streaming: 'sse',
+      method: 'GET',
+    })
+    expect(byPath['/legacy-dual']).toMatchObject({
+      controller: 'legacyDual',
+      streaming: 'dual',
+      method: 'GET',
+    })
+  })
+})

--- a/lib/gateway/manifest/buildManifest.ts
+++ b/lib/gateway/manifest/buildManifest.ts
@@ -2,7 +2,11 @@ import type { RouteOptions } from 'fastify'
 import { merge } from 'ts-deepmerge'
 import type { AbstractController } from '../../AbstractController.ts'
 import type { AbstractApiController } from '../../api-contracts/AbstractApiController.ts'
+import type { AbstractDualModeController } from '../../dualmode/AbstractDualModeController.ts'
+import { buildFastifyRoute } from '../../routes/fastifyRouteBuilder.ts'
+import type { AbstractSSEController } from '../../sse/AbstractSSEController.ts'
 import type { GatewayMetadataValue } from '../gatewayMetadata.ts'
+import { readRouteStreamingMode } from '../routeStreaming.ts'
 import { readGatewayMetadata } from '../withGatewayMetadata.ts'
 import {
   type GatewayManifest,
@@ -18,6 +22,14 @@ export type BuildGatewayManifestOptions = {
   version?: string
   /** Service-wide metadata defaults; merged underneath controller- and route-level metadata. */
   defaults?: GatewayMetadataValue
+  /**
+   * Include routes from legacy `AbstractSSEController` /
+   * `AbstractDualModeController` controllers in the manifest (marked with
+   * `streaming: 'sse' | 'dual'`). Off by default so existing manifests don't
+   * silently gain routes; routes declared through `AbstractApiController` are
+   * always included regardless of this flag.
+   */
+  includeStreamingControllers?: boolean
 }
 
 /**
@@ -37,6 +49,10 @@ type CollectedController =
     }
   // biome-ignore lint/suspicious/noExplicitAny: contract generic erased at the manifest boundary
   | { name: string; kind: 'api'; controller: AbstractApiController<any> }
+  // biome-ignore lint/suspicious/noExplicitAny: contract generic erased at the manifest boundary
+  | { name: string; kind: 'sse-legacy'; controller: AbstractSSEController<any> }
+  // biome-ignore lint/suspicious/noExplicitAny: contract generic erased at the manifest boundary
+  | { name: string; kind: 'dualmode-legacy'; controller: AbstractDualModeController<any> }
 
 const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
 type CanonicalMethod = (typeof HTTP_METHODS)[number]
@@ -69,6 +85,20 @@ function collectRouteEntries(
   if (collected.kind === 'rest') {
     const built = collected.controller.buildRoutes() as Record<string, RouteOptions>
     return Object.entries(built).map(([routeKey, route]) => ({ routeKey, route }))
+  }
+  if (collected.kind === 'sse-legacy' || collected.kind === 'dualmode-legacy') {
+    // Legacy streaming controllers return branded handler containers; build
+    // the Fastify RouteOptions from them (pure construction — no side
+    // effects, no registration) so path/method/streaming can be read.
+    const routeConfigs =
+      collected.kind === 'sse-legacy'
+        ? collected.controller.buildSSERoutes()
+        : collected.controller.buildDualModeRoutes()
+    return Object.entries(routeConfigs).map(([routeKey, routeConfig]) => ({
+      routeKey,
+      // biome-ignore lint/suspicious/noExplicitAny: overload selection erased at the manifest boundary
+      route: buildFastifyRoute(collected.controller as any, routeConfig as any),
+    }))
   }
   // AbstractApiController: routes is a Record — key becomes the routeKey.
   return Object.entries(collected.controller.routes).map(([routeKey, route]) => ({
@@ -117,12 +147,14 @@ export function buildGatewayManifestFrom(
       }
       idOrigin.set(id, origin)
 
+      const streaming = readRouteStreamingMode(route)
       routes.push({
         id,
         method,
         path,
         controller: collected.name,
         routeKey,
+        ...(streaming !== undefined ? { streaming } : {}),
         metadata: merged,
       })
     }

--- a/lib/gateway/manifest/manifestSchema.ts
+++ b/lib/gateway/manifest/manifestSchema.ts
@@ -14,6 +14,18 @@ export const gatewayManifestRouteSchema = z
     controller: z.string(),
     /** Key of the route inside the controller (`buildRoutes` map key, or array index for `AbstractApiController`). */
     routeKey: z.string(),
+    /**
+     * Streaming mode of the route: `'sse'` (always streams) or `'dual'`
+     * (Accept-negotiated JSON or stream). Absent for plain JSON routes.
+     * Generators use this to apply streaming-appropriate timeouts and
+     * disable response buffering.
+     *
+     * Additive optional field — manifests remain `manifestVersion: '1'`.
+     * Because the schemas are `.strict()`, generators must run against a
+     * library version that knows every field the manifest may carry (the
+     * gateway packages' peerDependency floor tracks this).
+     */
+    streaming: z.enum(['sse', 'dual']).optional(),
     /** Already-merged metadata: service defaults → controller defaults → route. */
     metadata: gatewayMetadataSchema,
   })

--- a/lib/gateway/routeStreaming.ts
+++ b/lib/gateway/routeStreaming.ts
@@ -1,0 +1,50 @@
+/**
+ * Streaming marker for Fastify routes, mirroring the gateway-metadata symbol
+ * pattern: stamped as a non-enumerable `Symbol.for` property by the route
+ * builders, read back by the gateway manifest builder.
+ *
+ * Gateway config generators need to distinguish streaming routes (SSE and
+ * dual-mode) from plain JSON routes — streaming routes must not inherit
+ * request/idle timeouts sized for request-response traffic (e.g. Envoy's 15 s
+ * route timeout and 5 min stream idle timeout both kill SSE streams).
+ */
+
+/**
+ * Symbol used to attach the streaming mode to a Fastify route object.
+ * `Symbol.for` ensures every module resolving the same key gets the same
+ * symbol, even across realms or duplicate package copies.
+ */
+export const ROUTE_STREAMING_SYMBOL = Symbol.for('opinionated-machine.route.streaming')
+
+/**
+ * How a route streams:
+ * - `'sse'` — SSE-only; every response is a `text/event-stream`.
+ * - `'dual'` — Accept-negotiated; responses may be JSON or a stream.
+ */
+export type RouteStreamingMode = 'sse' | 'dual'
+
+/**
+ * Stamp the streaming mode onto a route via the non-enumerable
+ * `ROUTE_STREAMING_SYMBOL` property. Fastify never sees it; the gateway
+ * manifest builder reads it back. Returns the same route reference.
+ */
+export function attachRouteStreamingMode<Route extends object>(
+  route: Route,
+  mode: RouteStreamingMode,
+): Route {
+  Object.defineProperty(route, ROUTE_STREAMING_SYMBOL, {
+    value: mode,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  })
+  return route
+}
+
+/**
+ * Read the streaming mode previously stamped on a route, or `undefined` for
+ * plain (non-streaming) routes.
+ */
+export function readRouteStreamingMode(route: object): RouteStreamingMode | undefined {
+  return (route as Record<symbol, RouteStreamingMode | undefined>)[ROUTE_STREAMING_SYMBOL]
+}

--- a/lib/routes/fastifyRouteBuilder.spec.ts
+++ b/lib/routes/fastifyRouteBuilder.spec.ts
@@ -106,7 +106,7 @@ describe('buildFastifyRoute', () => {
           querystring: sseGetContract.requestQuerySchema,
           headers: sseGetContract.requestHeaderSchema,
         },
-        sse: true,
+        sse: 'only',
         url: '/api/test/:testGetParam',
       })
     })
@@ -127,7 +127,7 @@ describe('buildFastifyRoute', () => {
           headers: ssePostContract.requestHeaderSchema,
           body: ssePostContract.requestBodySchema,
         },
-        sse: true,
+        sse: 'only',
         url: '/api/test/:testPostParam',
       })
     })
@@ -142,7 +142,7 @@ describe('buildFastifyRoute', () => {
 
       const routeOptions = buildFastifyRoute(new MinimalSSEController(handler), handler)
 
-      expect(routeOptions.sse).toEqual({ serializer })
+      expect(routeOptions.sse).toEqual({ kind: 'only', serializer })
     })
 
     it('should set sse config with heartbeatInterval when heartbeatInterval is provided', () => {
@@ -154,7 +154,9 @@ describe('buildFastifyRoute', () => {
 
       const routeOptions = buildFastifyRoute(new MinimalSSEController(handler), handler)
 
-      expect(routeOptions.sse).toEqual({ heartbeatInterval: 5000 })
+      // A route-level interval disables the plugin heartbeat; the framework
+      // timer (started on sse.start()) handles the interval itself.
+      expect(routeOptions.sse).toEqual({ kind: 'only', heartbeat: false })
     })
 
     describe('contractMetadataToRouteMapper', () => {
@@ -208,7 +210,7 @@ describe('buildFastifyRoute', () => {
           querystring: dualModeGetContract.requestQuerySchema,
           headers: dualModeGetContract.requestHeaderSchema,
         },
-        sse: true,
+        sse: 'manual',
         url: '/api/dual/:dualGetParam',
       })
     })
@@ -230,7 +232,7 @@ describe('buildFastifyRoute', () => {
           headers: dualModePostContract.requestHeaderSchema,
           body: dualModePostContract.requestBodySchema,
         },
-        sse: true,
+        sse: 'manual',
         url: '/api/dual/:dualPostParam',
       })
     })
@@ -248,7 +250,7 @@ describe('buildFastifyRoute', () => {
 
       const routeOptions = buildFastifyRoute(new MinimalDualModeController(handler), handler)
 
-      expect(routeOptions.sse).toEqual({ serializer })
+      expect(routeOptions.sse).toEqual({ kind: 'manual', serializer })
     })
 
     it('should set sse config with heartbeatInterval when heartbeatInterval is provided', () => {
@@ -263,7 +265,9 @@ describe('buildFastifyRoute', () => {
 
       const routeOptions = buildFastifyRoute(new MinimalDualModeController(handler), handler)
 
-      expect(routeOptions.sse).toEqual({ heartbeatInterval: 5000 })
+      // A route-level interval disables the plugin heartbeat; the framework
+      // timer (started on sse.start()) handles the interval itself.
+      expect(routeOptions.sse).toEqual({ kind: 'manual', heartbeat: false })
     })
 
     describe('contractMetadataToRouteMapper', () => {

--- a/lib/routes/fastifyRouteBuilder.ts
+++ b/lib/routes/fastifyRouteBuilder.ts
@@ -9,12 +9,12 @@ import type { z } from 'zod'
 import { ZodObject } from 'zod'
 import type { AbstractDualModeController } from '../dualmode/AbstractDualModeController.ts'
 import { isErrorLike } from '../errorUtils.ts'
+import { attachRouteStreamingMode } from '../gateway/routeStreaming.ts'
 import type { AbstractSSEController } from '../sse/AbstractSSEController.ts'
 import type {
   DualModeRouteHandler,
   FastifyDualModeHandlerConfig,
   FastifySSEHandlerConfig,
-  FastifySSERouteOptions,
   SSERouteHandler,
 } from './fastifyRouteTypes.ts'
 import {
@@ -24,33 +24,10 @@ import {
   handleSSEError,
   hasHttpStatusCode,
 } from './fastifyRouteUtils.ts'
+import { buildSSERouteField } from './sseRouteConfig.ts'
 
 // Re-export for convenience
 export { extractPathTemplate }
-
-/**
- * Build the SSE config object for route options.
- * Returns true for basic SSE support, or an object with custom serializer/heartbeat.
- */
-function buildSSEConfig(
-  options: FastifySSERouteOptions | undefined,
-): true | { serializer?: (data: unknown) => string; heartbeatInterval?: number } {
-  if (!options?.serializer && options?.heartbeatInterval === undefined) {
-    return true
-  }
-
-  const sseConfig: { serializer?: (data: unknown) => string; heartbeatInterval?: number } = {}
-
-  if (options.serializer) {
-    sseConfig.serializer = options.serializer
-  }
-
-  if (options.heartbeatInterval !== undefined) {
-    sseConfig.heartbeatInterval = options.heartbeatInterval
-  }
-
-  return sseConfig
-}
 
 /**
  * Validate response body against the successResponseBodySchema (for 2xx success responses).
@@ -366,7 +343,9 @@ function buildDualModeRouteInternal<Contract extends AnyDualModeContractDefiniti
     ...(options?.contractMetadataToRouteMapper?.(contract.metadata) ?? {}),
     method: contract.method,
     url,
-    sse: buildSSEConfig(options), // Enable SSE support with optional per-route config
+    // 'manual' kind: the plugin does no Accept negotiation — determineMode()
+    // below is the single negotiator (q-value aware, honors defaultMode).
+    sse: buildSSERouteField('manual', options),
     schema: {
       params: contract.requestPathParamsSchema,
       querystring: contract.requestQuerySchema,
@@ -391,7 +370,7 @@ function buildDualModeRouteInternal<Contract extends AnyDualModeContractDefiniti
     routeOptions.preHandler = options.preHandler
   }
 
-  return routeOptions
+  return attachRouteStreamingMode(routeOptions, 'dual')
 }
 
 /**
@@ -423,7 +402,9 @@ function buildSSERouteInternal<Contract extends AnySSEContractDefinition>(
     ...(options?.contractMetadataToRouteMapper?.(contract.metadata) ?? {}),
     method: contract.method,
     url,
-    sse: buildSSEConfig(options), // Enable SSE support with optional per-route config
+    // 'only' kind: lenient Accept gate — `*/*` or a missing Accept header
+    // admits SSE; explicit refusal of text/event-stream gets a clean 406.
+    sse: buildSSERouteField('only', options),
     schema: {
       params: contract.requestPathParamsSchema,
       querystring: contract.requestQuerySchema,
@@ -507,7 +488,7 @@ function buildSSERouteInternal<Contract extends AnySSEContractDefinition>(
     routeOptions.preHandler = options.preHandler
   }
 
-  return routeOptions
+  return attachRouteStreamingMode(routeOptions, 'sse')
 }
 
 // ============================================================================

--- a/lib/routes/fastifyRouteTypes.ts
+++ b/lib/routes/fastifyRouteTypes.ts
@@ -457,11 +457,14 @@ export type FastifySSERouteOptions = {
   serializer?: (data: unknown) => string
   /**
    * Heartbeat interval in milliseconds for this route.
-   * Overrides the global heartbeat interval if set.
-   * Set to 0 to disable heartbeats.
-   * @default 30000
+   *
+   * When set to a number, a framework-managed timer writes `: heartbeat`
+   * comment frames at that interval (the @fastify/sse plugin's own heartbeat
+   * is disabled for the route). Set to `0` or `false` to disable heartbeats
+   * for this route entirely. When unset, the plugin-level heartbeat applies
+   * (default 30000 ms, configured when registering @fastify/sse).
    */
-  heartbeatInterval?: number
+  heartbeatInterval?: number | false
 
   /**
    * Maps contract metadata to additional Fastify route options.
@@ -993,10 +996,12 @@ export function buildHandler<
  */
 export type RegisterSSERoutesOptions = {
   /**
-   * Heartbeat interval in milliseconds.
-   * @default 30000
+   * Heartbeat interval in milliseconds, applied to all registered SSE routes
+   * via a framework-managed timer (the @fastify/sse plugin heartbeat is
+   * disabled for those routes). Set to `0` or `false` to disable heartbeats.
+   * Route-level `heartbeatInterval` (buildHandler options) takes precedence.
    */
-  heartbeatInterval?: number
+  heartbeatInterval?: number | false
   /**
    * Custom serializer for SSE message data.
    * @default JSON.stringify
@@ -1029,10 +1034,13 @@ export type RegisterSSERoutesOptions = {
  */
 export type RegisterDualModeRoutesOptions = {
   /**
-   * Heartbeat interval in milliseconds for SSE mode.
-   * @default 30000
+   * Heartbeat interval in milliseconds for SSE mode, applied to all
+   * registered dual-mode routes via a framework-managed timer (the
+   * @fastify/sse plugin heartbeat is disabled for those routes). Set to `0`
+   * or `false` to disable heartbeats. Route-level `heartbeatInterval`
+   * (buildHandler options) takes precedence.
    */
-  heartbeatInterval?: number
+  heartbeatInterval?: number | false
   /**
    * Custom serializer for SSE message data.
    * @default JSON.stringify

--- a/lib/routes/fastifyRouteUtils.ts
+++ b/lib/routes/fastifyRouteUtils.ts
@@ -15,6 +15,7 @@ import type {
   SSEStartOptions,
   SSEStreamMessage,
 } from './fastifyRouteTypes.ts'
+import { resolveHeartbeatInterval, startFrameworkHeartbeat } from './sseHeartbeat.ts'
 
 /**
  * FastifyReply extended with SSE capabilities from @fastify/sse.
@@ -62,6 +63,12 @@ export type SSELifecycleOptions<TConnection = SSESession> = {
     lastEventId: string,
   ) => Iterable<SSEMessage> | AsyncIterable<SSEMessage> | void | Promise<void>
   logger?: SSELogger
+  /**
+   * Route-level heartbeat interval in ms (framework-managed timer), or
+   * `0`/`false` to disable heartbeats for this route. When unset, the
+   * registration-time value (route.config) or the plugin default applies.
+   */
+  heartbeatInterval?: number | false
 }
 
 /**
@@ -404,6 +411,17 @@ export function createSSEContext<Events extends SSEEventSchemas>(
   let onCloseCalled = false
   let responseData: { code: number; body: unknown } | undefined
 
+  // Framework-managed per-route heartbeat (plugin heartbeat is disabled via
+  // `heartbeat: false` on the route's `sse` field whenever an interval is set)
+  let stopHeartbeat: (() => void) | undefined
+  const maybeStartHeartbeat = () => {
+    if (stopHeartbeat) return
+    const intervalMs = resolveHeartbeatInterval(options?.heartbeatInterval, request)
+    if (!intervalMs) return
+    stopHeartbeat = startFrameworkHeartbeat(reply, intervalMs)
+    sseReply.sse.onClose(() => stopHeartbeat?.())
+  }
+
   // Helper to call onClose exactly once
   const callOnClose = async (reason: SSECloseReason) => {
     if (onCloseCalled || !connection) return
@@ -474,6 +492,7 @@ export function createSSEContext<Events extends SSEEventSchemas>(
         sseReply.sse.sendHeaders()
         reply.raw.flushHeaders()
         headersSent = true
+        maybeStartHeartbeat()
       }
 
       // Handle reconnection with Last-Event-ID
@@ -556,6 +575,7 @@ export function createSSEContext<Events extends SSEEventSchemas>(
       sseReply.sse.sendHeaders()
       reply.raw.flushHeaders()
       headersSent = true
+      maybeStartHeartbeat()
     },
 
     reply,

--- a/lib/routes/index.ts
+++ b/lib/routes/index.ts
@@ -57,3 +57,19 @@ export {
   sendReplayEvents,
   setupSSESession,
 } from './fastifyRouteUtils.js'
+
+// SSE route configuration for @fastify/sse 0.6 (route kinds + heartbeats)
+export {
+  resolveHeartbeatInterval,
+  SSE_ROUTE_CONFIG_KEY,
+  type SSERouteRuntimeConfig,
+  startFrameworkHeartbeat,
+} from './sseHeartbeat.js'
+export {
+  buildSSERouteField,
+  type FrameworkSSERouteOptions,
+  mergeSSERouteField,
+  type SSERouteField,
+  type SSERouteFieldObject,
+  type SSERouteKind,
+} from './sseRouteConfig.js'

--- a/lib/routes/sseHeartbeat.ts
+++ b/lib/routes/sseHeartbeat.ts
@@ -1,0 +1,67 @@
+import type { FastifyReply, FastifyRequest } from 'fastify'
+
+/**
+ * Key under `route.config` where the framework stores SSE runtime settings
+ * applied at registration time (DIContext.registerSSERoutes /
+ * registerDualModeRoutes). Route-level options passed to buildHandler /
+ * buildApiRoute are captured in handler closures instead and take precedence.
+ */
+export const SSE_ROUTE_CONFIG_KEY = 'opinionatedSse' as const
+
+/**
+ * SSE runtime settings stored under `route.config[SSE_ROUTE_CONFIG_KEY]`.
+ */
+export type SSERouteRuntimeConfig = {
+  /** Heartbeat interval in ms, or `0`/`false` to disable heartbeats. */
+  heartbeatInterval?: number | false
+}
+
+function readSSERouteRuntimeConfig(request: FastifyRequest): SSERouteRuntimeConfig | undefined {
+  const config = request.routeOptions?.config as unknown as Record<string, unknown> | undefined
+  return config?.[SSE_ROUTE_CONFIG_KEY] as SSERouteRuntimeConfig | undefined
+}
+
+/**
+ * Resolve the effective framework heartbeat interval for a request.
+ *
+ * Precedence: route-level option (from buildHandler / buildApiRoute) over
+ * registration-time option (from route.config). Returns `undefined` when no
+ * framework heartbeat should run — either nothing is configured (the plugin
+ * default applies) or heartbeats are explicitly disabled (`0`/`false`).
+ */
+export function resolveHeartbeatInterval(
+  routeLevel: number | false | undefined,
+  request: FastifyRequest,
+): number | undefined {
+  const effective =
+    routeLevel !== undefined ? routeLevel : readSSERouteRuntimeConfig(request)?.heartbeatInterval
+  if (typeof effective !== 'number' || effective <= 0) {
+    return undefined
+  }
+  return effective
+}
+
+/**
+ * Start a framework-managed heartbeat, writing `: heartbeat\n\n` comment
+ * frames on an interval. Must only be called after the SSE headers have been
+ * sent. The timer is unref'd and self-stops when the response ends.
+ *
+ * @returns a stop function (idempotent)
+ */
+export function startFrameworkHeartbeat(reply: FastifyReply, intervalMs: number): () => void {
+  const raw = reply.raw
+  const timer = setInterval(() => {
+    if (raw.writableEnded || raw.destroyed) {
+      clearInterval(timer)
+      return
+    }
+    try {
+      raw.write(': heartbeat\n\n')
+    } catch {
+      clearInterval(timer)
+    }
+  }, intervalMs)
+  timer.unref()
+
+  return () => clearInterval(timer)
+}

--- a/lib/routes/sseRouteConfig.spec.ts
+++ b/lib/routes/sseRouteConfig.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { buildSSERouteField, mergeSSERouteField } from './sseRouteConfig.ts'
+
+describe('buildSSERouteField', () => {
+  it('returns the bare kind when no options are set', () => {
+    expect(buildSSERouteField('only')).toBe('only')
+    expect(buildSSERouteField('manual', {})).toBe('manual')
+  })
+
+  it('includes the serializer and keeps the plugin heartbeat when only a serializer is set', () => {
+    const serializer = (data: unknown) => JSON.stringify(data)
+    expect(buildSSERouteField('only', { serializer })).toEqual({ kind: 'only', serializer })
+  })
+
+  it('disables the plugin heartbeat when a route-level interval is set', () => {
+    expect(buildSSERouteField('only', { heartbeatInterval: 5000 })).toEqual({
+      kind: 'only',
+      heartbeat: false,
+    })
+  })
+
+  it('disables the plugin heartbeat when heartbeats are explicitly off (0 / false)', () => {
+    expect(buildSSERouteField('manual', { heartbeatInterval: 0 })).toEqual({
+      kind: 'manual',
+      heartbeat: false,
+    })
+    expect(buildSSERouteField('manual', { heartbeatInterval: false })).toEqual({
+      kind: 'manual',
+      heartbeat: false,
+    })
+  })
+
+  it('combines serializer and heartbeat handling', () => {
+    const serializer = (data: unknown) => String(data)
+    expect(buildSSERouteField('manual', { serializer, heartbeatInterval: 100 })).toEqual({
+      kind: 'manual',
+      serializer,
+      heartbeat: false,
+    })
+  })
+})
+
+describe('mergeSSERouteField', () => {
+  it('upgrades a bare kind to the object form', () => {
+    const serializer = (data: unknown) => String(data)
+    expect(mergeSSERouteField('only', { serializer })).toEqual({ kind: 'only', serializer })
+  })
+
+  it('keeps a route-level serializer over the registration-time one', () => {
+    const routeSerializer = (data: unknown) => String(data)
+    const registrationSerializer = (data: unknown) => JSON.stringify(data)
+    expect(
+      mergeSSERouteField(
+        { kind: 'manual', serializer: routeSerializer },
+        { serializer: registrationSerializer },
+      ),
+    ).toEqual({ kind: 'manual', serializer: routeSerializer })
+  })
+
+  it('adds heartbeat: false when the plugin heartbeat should be disabled', () => {
+    expect(mergeSSERouteField('only', { disablePluginHeartbeat: true })).toEqual({
+      kind: 'only',
+      heartbeat: false,
+    })
+  })
+
+  it('never removes an existing heartbeat: false', () => {
+    expect(mergeSSERouteField({ kind: 'only', heartbeat: false }, {})).toEqual({
+      kind: 'only',
+      heartbeat: false,
+    })
+  })
+
+  it('treats a legacy `true` value as kind-less back-compat (kind omitted)', () => {
+    const serializer = (data: unknown) => String(data)
+    expect(mergeSSERouteField(true, { serializer })).toEqual({ serializer })
+  })
+})

--- a/lib/routes/sseRouteConfig.ts
+++ b/lib/routes/sseRouteConfig.ts
@@ -1,0 +1,115 @@
+/**
+ * Translation layer between framework-level SSE route options and the
+ * per-route `sse` field understood by @fastify/sse 0.6.
+ *
+ * @fastify/sse 0.6 introduced route "kinds" that control Accept-header
+ * negotiation, and reduced per-route heartbeat control to an on/off switch
+ * (`heartbeat: false`) — the interval itself is plugin-level only. The
+ * framework therefore:
+ * - picks the kind per route flavor ('only' for SSE-only routes, 'manual'
+ *   for dual-mode routes where `determineMode()` owns Accept negotiation),
+ * - disables the plugin heartbeat whenever a route-level interval is
+ *   configured and runs its own timer instead (see sseHeartbeat.ts).
+ */
+
+/**
+ * The @fastify/sse route kinds the framework emits.
+ *
+ * - `'only'` — SSE-only route. Lenient Accept gate: any spec-compliant
+ *   Accept header (including `*`/`*` or a missing header) admits SSE;
+ *   clients that explicitly refuse `text/event-stream` get a 406.
+ * - `'manual'` — no plugin-side Accept negotiation; `reply.sse` is always
+ *   attached and the framework's `determineMode()` decides sync vs SSE.
+ *   Used for dual-mode routes.
+ * - `'dual'` — plugin-side strict gate with handler fallback. Not currently
+ *   emitted (it would bypass `determineMode()`s q-value parsing and
+ *   `defaultMode` semantics), listed for completeness.
+ */
+export type SSERouteKind = 'only' | 'dual' | 'manual'
+
+/**
+ * Object form of the @fastify/sse 0.6 per-route `sse` field as emitted by
+ * the framework. `heartbeat: false` disables the plugin's own heartbeat
+ * timer (the framework timer takes over when an interval is configured).
+ */
+export type SSERouteFieldObject = {
+  kind: SSERouteKind
+  heartbeat?: false
+  serializer?: (data: unknown) => string
+}
+
+/** The per-route `sse` field: a bare kind or the object form. */
+export type SSERouteField = SSERouteKind | SSERouteFieldObject
+
+/**
+ * Framework-level SSE options relevant to the route `sse` field.
+ */
+export type FrameworkSSERouteOptions = {
+  /** Custom serializer for SSE data on this route (honored by the plugin). */
+  serializer?: (data: unknown) => string
+  /**
+   * Route-level heartbeat interval in milliseconds.
+   * A number enables the framework-managed heartbeat timer at that interval;
+   * `0` or `false` disables heartbeats for the route entirely.
+   * When set (either way), the plugin's own heartbeat is turned off.
+   */
+  heartbeatInterval?: number | false
+}
+
+/**
+ * Build the per-route `sse` field for @fastify/sse 0.6.
+ *
+ * Returns the bare kind when no route-level serializer/heartbeat options are
+ * present; otherwise the object form with `heartbeat: false` whenever a
+ * route-level interval (or explicit disable) is configured.
+ */
+export function buildSSERouteField(
+  kind: SSERouteKind,
+  options?: FrameworkSSERouteOptions,
+): SSERouteField {
+  if (!options?.serializer && options?.heartbeatInterval === undefined) {
+    return kind
+  }
+
+  const field: SSERouteFieldObject = { kind }
+  if (options.serializer) {
+    field.serializer = options.serializer
+  }
+  if (options.heartbeatInterval !== undefined) {
+    // The plugin can only switch its heartbeat off per route; the framework
+    // timer (sseHeartbeat.ts) handles numeric intervals.
+    field.heartbeat = false
+  }
+  return field
+}
+
+/**
+ * Merge registration-time overrides (RegisterSSERoutesOptions /
+ * RegisterDualModeRoutesOptions) into an already-built route's `sse` field.
+ *
+ * Route-level values win: a serializer already present on the field is kept,
+ * and `heartbeat: false` is only added (never removed).
+ */
+export function mergeSSERouteField(
+  existing: unknown,
+  patch: {
+    serializer?: (data: unknown) => string
+    disablePluginHeartbeat?: boolean
+  },
+): SSERouteField {
+  const base: SSERouteFieldObject =
+    typeof existing === 'string'
+      ? { kind: existing as SSERouteKind }
+      : existing && typeof existing === 'object'
+        ? { ...(existing as SSERouteFieldObject) }
+        : // `true` (legacy) or missing — preserve legacy negotiation by omitting `kind`
+          ({} as SSERouteFieldObject)
+
+  if (patch.serializer && !base.serializer) {
+    base.serializer = patch.serializer
+  }
+  if (patch.disablePluginHeartbeat) {
+    base.heartbeat = false
+  }
+  return base
+}

--- a/lib/sse/AbstractSSEController.ts
+++ b/lib/sse/AbstractSSEController.ts
@@ -8,6 +8,7 @@ import type {
 import { InternalError } from '@lokalise/node-core'
 import type { FastifyReply } from 'fastify'
 import type { z } from 'zod'
+import type { GatewayMetadataValue } from '../gateway/gatewayMetadata.ts'
 import type { BuildFastifySSERoutesReturnType, SSESession } from '../routes/fastifyRouteTypes.ts'
 import type { SSERoomBroadcaster } from './rooms/SSERoomBroadcaster.ts'
 import type { SSERoomManager } from './rooms/SSERoomManager.ts'
@@ -87,6 +88,16 @@ type SSEReply = FastifyReply & { sse: SSEReplyInterface }
 export abstract class AbstractSSEController<
   APIContracts extends Record<string, AnySSEContractDefinition>,
 > {
+  /**
+   * Optional controller-level defaults for gateway metadata.
+   *
+   * Only consulted when the controller is included in a gateway manifest via
+   * `buildGatewayManifest({ includeStreamingControllers: true })`. Merged
+   * underneath per-route metadata; see `AbstractController.gatewayDefaults`
+   * for full semantics.
+   */
+  public readonly gatewayDefaults?: GatewayMetadataValue
+
   /** Map of connection ID to connection object */
   protected connections: Map<string, SSESession> = new Map()
 

--- a/lib/sse/eventIds.spec.ts
+++ b/lib/sse/eventIds.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { compareEventIds, createEventIdSequence } from './eventIds.ts'
+
+describe('createEventIdSequence', () => {
+  it('produces monotonically increasing ids within an epoch', () => {
+    const seq = createEventIdSequence({ epoch: 'e1' })
+    const first = seq.next()
+    const second = seq.next()
+    const third = seq.next()
+
+    expect(first).toBe('e1-000000000001')
+    expect(second).toBe('e1-000000000002')
+    expect(third < first).toBe(false)
+    // Lexicographic order matches numeric order thanks to zero padding
+    expect([third, first, second].sort()).toEqual([first, second, third])
+  })
+
+  it('tracks the current id', () => {
+    const seq = createEventIdSequence({ epoch: 'e1' })
+    expect(seq.current).toBeUndefined()
+    const id = seq.next()
+    expect(seq.current).toBe(id)
+  })
+
+  it('supports a custom starting counter', () => {
+    const seq = createEventIdSequence({ epoch: 'e1', start: 41 })
+    expect(seq.next()).toBe('e1-000000000042')
+  })
+
+  it('defaults the epoch to a timestamp so restarts start a new epoch', () => {
+    const seq = createEventIdSequence()
+    expect(seq.next()).toMatch(/^\d+-\d{12}$/)
+  })
+})
+
+describe('compareEventIds', () => {
+  it('orders ids within the same epoch', () => {
+    const seq = createEventIdSequence({ epoch: 'e1' })
+    const first = seq.next()
+    const second = seq.next()
+
+    expect(compareEventIds(first, second)).toBe(-1)
+    expect(compareEventIds(second, first)).toBe(1)
+    expect(compareEventIds(first, first)).toBe(0)
+  })
+
+  it('returns undefined across epochs (client must resync via poll)', () => {
+    expect(compareEventIds('e1-000000000005', 'e2-000000000001')).toBeUndefined()
+  })
+
+  it('returns undefined for ids not produced by a sequence (e.g. UUIDs)', () => {
+    expect(compareEventIds('not-an-id', 'e1-000000000001')).toBeUndefined()
+    expect(compareEventIds('e1-000000000001', 'plainstring')).toBeUndefined()
+  })
+
+  it('handles epochs that themselves contain dashes', () => {
+    // The epoch is everything before the LAST dash
+    expect(compareEventIds('node-a-000000000001', 'node-a-000000000002')).toBe(-1)
+    expect(compareEventIds('node-a-000000000001', 'node-b-000000000001')).toBeUndefined()
+  })
+
+  it('compares counters numerically beyond Number.MAX_SAFE_INTEGER padding', () => {
+    expect(compareEventIds('e1-999999999998', 'e1-999999999999')).toBe(-1)
+  })
+})

--- a/lib/sse/eventIds.ts
+++ b/lib/sse/eventIds.ts
@@ -1,0 +1,94 @@
+/**
+ * Monotonic event-id helpers for SSE streams.
+ *
+ * The polling-fallback pattern (and `Last-Event-ID` reconnection/replay in
+ * general) needs event ids a client can ORDER, not just deduplicate: the
+ * client keeps a high-watermark and drops anything at or below it. Random
+ * UUIDs (the `broadcastToRoom` default) are unique but unordered; use a
+ * sequence from {@link createEventIdSequence} instead and pass its ids
+ * explicitly:
+ *
+ * ```ts
+ * const seq = createEventIdSequence()
+ * await broadcaster.broadcastToRoom(room, statusEvent, data, { id: seq.next() })
+ * ```
+ *
+ * Keep one sequence per ordering scope (per room, per resource, per stream) —
+ * ids from different scopes are not comparable. Stamp the same underlying
+ * version into the sync (poll) response body so the client can order
+ * snapshots against events.
+ */
+
+/**
+ * A monotonic id generator: ids are lexicographically AND numerically
+ * increasing within the sequence's epoch.
+ */
+export type EventIdSequence = {
+  /** Produce the next id (`"<epoch>-<zero-padded counter>"`). */
+  next(): string
+  /** The most recently produced id, or `undefined` before the first next(). */
+  readonly current: string | undefined
+}
+
+const COUNTER_PAD = 12
+
+export type CreateEventIdSequenceOptions = {
+  /**
+   * Epoch label prefixed to every id. Ids are only ordered *within* an epoch;
+   * clients seeing an epoch change should resynchronize via a snapshot poll
+   * rather than compare counters. Defaults to the creation timestamp in ms —
+   * a process restart naturally starts a new (larger) epoch.
+   */
+  epoch?: string
+  /** Starting counter value. Defaults to 0 (first id ends in ...000001). */
+  start?: number
+}
+
+/**
+ * Create a monotonic event-id sequence.
+ *
+ * Ids look like `"1754838000000-000000000042"`. Within one epoch they order
+ * lexicographically (fixed-width zero-padded counter). Sequences are
+ * in-memory and per-process — for cross-node monotonicity back the counter
+ * with shared storage (e.g. Redis INCR) and stamp ids at the publisher.
+ */
+export function createEventIdSequence(options?: CreateEventIdSequenceOptions): EventIdSequence {
+  const epoch = options?.epoch ?? String(Date.now())
+  let counter = options?.start ?? 0
+  let current: string | undefined
+
+  return {
+    next(): string {
+      counter += 1
+      current = `${epoch}-${String(counter).padStart(COUNTER_PAD, '0')}`
+      return current
+    },
+    get current(): string | undefined {
+      return current
+    },
+  }
+}
+
+const EVENT_ID_PATTERN = /^(.+)-(\d+)$/
+
+/**
+ * Compare two event ids produced by {@link createEventIdSequence}.
+ *
+ * Returns `-1` / `0` / `1` when both ids belong to the same epoch, and
+ * `undefined` when they don't (or when either id doesn't match the expected
+ * format). An `undefined` result means the ids are not ordered relative to
+ * each other — clients should treat that as "resynchronize via a snapshot
+ * poll" rather than guess.
+ */
+export function compareEventIds(a: string, b: string): -1 | 0 | 1 | undefined {
+  const parsedA = EVENT_ID_PATTERN.exec(a)
+  const parsedB = EVENT_ID_PATTERN.exec(b)
+  if (!parsedA || !parsedB) return undefined
+  if (parsedA[1] !== parsedB[1]) return undefined
+
+  const counterA = BigInt(parsedA[2] as string)
+  const counterB = BigInt(parsedB[2] as string)
+  if (counterA < counterB) return -1
+  if (counterA > counterB) return 1
+  return 0
+}

--- a/lib/sse/index.ts
+++ b/lib/sse/index.ts
@@ -31,6 +31,12 @@ export {
   type SSEMessage,
 } from './AbstractSSEController.js'
 export { defineEvent, type SSEEventDefinition } from './defineEvent.js'
+export {
+  type CreateEventIdSequenceOptions,
+  compareEventIds,
+  createEventIdSequence,
+  type EventIdSequence,
+} from './eventIds.js'
 // Re-export room types and classes
 export {
   defineRoom,

--- a/lib/testing/sseHttpClient.ts
+++ b/lib/testing/sseHttpClient.ts
@@ -98,6 +98,13 @@ export type SSEHttpConnectResult = {
 export class SSEHttpClient {
   /** The fetch Response object. Available immediately after connect() returns. */
   readonly response: Response
+  /**
+   * Optional hook invoked with every decoded raw text chunk as it arrives —
+   * including comment frames (e.g. `: heartbeat`) that the SSE parser drops.
+   * Useful for asserting heartbeat delivery or tracking byte-level liveness.
+   * Only fires while the stream is being consumed via events()/collectEvents().
+   */
+  onRawChunk?: (chunk: string) => void
   private readonly abortController: AbortController
   private readonly reader: ReadableStreamDefaultReader<Uint8Array>
   private readonly decoder = new TextDecoder()
@@ -240,7 +247,9 @@ export class SSEHttpClient {
         break
       }
 
-      this.buffer += this.decoder.decode(readResult.value, { stream: true })
+      const chunk = this.decoder.decode(readResult.value, { stream: true })
+      this.onRawChunk?.(chunk)
+      this.buffer += chunk
       const parseResult = parseSSEBuffer(this.buffer)
       this.buffer = parseResult.remaining
 

--- a/packages/gateway-envoy/acceptance/envoy.acceptance.spec.ts
+++ b/packages/gateway-envoy/acceptance/envoy.acceptance.spec.ts
@@ -50,4 +50,26 @@ describe('envoy acceptance', () => {
     const res = await fetchGateway('/nope')
     expect(res.status).toBe(404)
   })
+
+  describe('streaming routes (HCM stream_idle_timeout is 2s)', () => {
+    it('marked streaming route survives an idle gap longer than the listener idle timeout', async () => {
+      // The upstream sends the second event after a 3s silence — past the 2s
+      // HCM stream_idle_timeout. The route is marked streaming, so the
+      // generator disabled its route timeout and idle timeout.
+      const res = await fetchGateway('/sse?gapMs=3000')
+      expect(res.status).toBe(200)
+      const body = await res.text()
+      expect(body).toContain('event: first')
+      expect(body).toContain('event: second')
+    })
+
+    it('unmarked route stream is reset at the listener idle timeout', async () => {
+      // Same upstream behavior, but the route carries no streaming marker —
+      // Envoy resets the stream during the 3s gap. Depending on timing the
+      // reset surfaces as a truncated body or a network error.
+      const res = await fetchGateway('/sse-unmarked?gapMs=3000')
+      const body = await res.text().catch(() => '')
+      expect(body).not.toContain('event: second')
+    })
+  })
 })

--- a/packages/gateway-envoy/acceptance/manifest.acceptance.mjs
+++ b/packages/gateway-envoy/acceptance/manifest.acceptance.mjs
@@ -30,5 +30,27 @@ export const acceptanceManifest = {
       // Tight timeout so we can verify Envoy enforces it.
       metadata: { upstream: 'upstream', timeouts: { request: '200ms' } },
     },
+    {
+      id: 'sse.stream',
+      method: 'GET',
+      path: '/sse',
+      controller: 'sse',
+      routeKey: 'stream',
+      // Marked streaming: the generator disables the route timeout and idle
+      // timeout, so the stream must survive event gaps longer than the HCM
+      // stream_idle_timeout configured in render-config.mjs.
+      streaming: 'sse',
+      metadata: { upstream: 'upstream' },
+    },
+    {
+      id: 'sse.unmarked',
+      method: 'GET',
+      path: '/sse-unmarked',
+      controller: 'sse',
+      routeKey: 'unmarked',
+      // Same upstream behavior but NOT marked streaming: the HCM
+      // stream_idle_timeout applies and resets the stream mid-gap.
+      metadata: { upstream: 'upstream' },
+    },
   ],
 }

--- a/packages/gateway-envoy/acceptance/render-config.mjs
+++ b/packages/gateway-envoy/acceptance/render-config.mjs
@@ -14,6 +14,10 @@ const { yaml, warnings } = renderEnvoyConfig(acceptanceManifest, {
   listenPort: 10000,
   // The "upstream" name maps to the docker-compose service name.
   clusters: { upstream: { hosts: ['upstream:8081'], connectTimeout: '1s' } },
+  // Deliberately short listener-wide stream idle timeout: the acceptance
+  // tests prove that marked streaming routes override it (survive longer
+  // event gaps) while unmarked routes are reset by it.
+  streamIdleTimeout: '2s',
   // Expose the admin interface so /ready, /stats, /clusters etc. are
   // available — useful for debugging acceptance failures and for ops in
   // general. The docker-compose file forwards 9901.

--- a/packages/gateway-envoy/acceptance/upstream.mjs
+++ b/packages/gateway-envoy/acceptance/upstream.mjs
@@ -19,6 +19,24 @@ createServer((req, res) => {
     return
   }
 
+  // SSE stub: first event immediately, second after ?gapMs (default 3000),
+  // then the stream ends. The idle gap between the two events is what the
+  // streaming-route acceptance tests use to trip (or survive) idle timeouts.
+  if (url.pathname.startsWith('/sse')) {
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+    })
+    res.write('event: first\ndata: {"n":1}\n\n')
+    const gap = Number(url.searchParams.get('gapMs') ?? '3000')
+    const timer = setTimeout(() => {
+      res.write('event: second\ndata: {"n":2}\n\n')
+      res.end()
+    }, gap)
+    res.on('close', () => clearTimeout(timer))
+    return
+  }
+
   res.writeHead(200, { 'content-type': 'application/json' })
   res.end(
     JSON.stringify({

--- a/packages/gateway-envoy/package.json
+++ b/packages/gateway-envoy/package.json
@@ -34,7 +34,7 @@
         "directory": "packages/gateway-envoy"
     },
     "peerDependencies": {
-        "opinionated-machine": ">=6.17.0"
+        "opinionated-machine": ">=7.1.0"
     },
     "dependencies": {
         "yaml": "^2.5.1"

--- a/packages/gateway-envoy/src/__fixtures__/manifest.fixture.ts
+++ b/packages/gateway-envoy/src/__fixtures__/manifest.fixture.ts
@@ -64,5 +64,28 @@ export const fixtureManifest: GatewayManifest = {
         },
       },
     },
+    {
+      id: 'notificationsController.stream',
+      method: 'GET',
+      path: '/notifications/stream',
+      controller: 'notificationsController',
+      routeKey: 'stream',
+      streaming: 'sse',
+      metadata: {
+        upstream: 'users-service',
+      },
+    },
+    {
+      id: 'jobsController.status',
+      method: 'GET',
+      path: '/jobs/{jobId}/status',
+      controller: 'jobsController',
+      routeKey: 'status',
+      streaming: 'dual',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { idle: '10m' },
+      },
+    },
   ],
 }

--- a/packages/gateway-envoy/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-envoy/src/__snapshots__/render.spec.ts.snap
@@ -165,6 +165,48 @@ exports[`renderEnvoyConfig > matches the JSON snapshot for the fixture manifest 
                               "timeout": "3s",
                             },
                           },
+                          {
+                            "match": {
+                              "headers": [
+                                {
+                                  "name": ":method",
+                                  "string_match": {
+                                    "exact": "GET",
+                                  },
+                                },
+                              ],
+                              "safe_regex": {
+                                "regex": "/notifications/stream",
+                              },
+                            },
+                            "name": "notificationsController.stream",
+                            "route": {
+                              "cluster": "users-service",
+                              "idle_timeout": "0s",
+                              "timeout": "0s",
+                            },
+                          },
+                          {
+                            "match": {
+                              "headers": [
+                                {
+                                  "name": ":method",
+                                  "string_match": {
+                                    "exact": "GET",
+                                  },
+                                },
+                              ],
+                              "safe_regex": {
+                                "regex": "/jobs/[^/]+/status",
+                              },
+                            },
+                            "name": "jobsController.status",
+                            "route": {
+                              "cluster": "users-service",
+                              "idle_timeout": "600s",
+                              "timeout": "0s",
+                            },
+                          },
                         ],
                       },
                     ],
@@ -261,6 +303,30 @@ exports[`renderEnvoyConfig > matches the YAML snapshot for the fixture manifest 
                             timeout: 3s
                           decorator:
                             operation: usersController.deleteItem
+                        - name: notificationsController.stream
+                          match:
+                            safe_regex:
+                              regex: /notifications/stream
+                            headers:
+                              - name: :method
+                                string_match:
+                                  exact: GET
+                          route:
+                            cluster: users-service
+                            timeout: 0s
+                            idle_timeout: 0s
+                        - name: jobsController.status
+                          match:
+                            safe_regex:
+                              regex: /jobs/[^/]+/status
+                            headers:
+                              - name: :method
+                                string_match:
+                                  exact: GET
+                          route:
+                            cluster: users-service
+                            timeout: 0s
+                            idle_timeout: 600s
                 http_filters:
                   - name: envoy.filters.http.router
                     typed_config:

--- a/packages/gateway-envoy/src/render.spec.ts
+++ b/packages/gateway-envoy/src/render.spec.ts
@@ -63,4 +63,78 @@ describe('renderEnvoyConfig', () => {
       address: { socket_address: { address: '0.0.0.0', port_value: 9901 } },
     })
   })
+
+  describe('streaming routes', () => {
+    const findRoute = (json: ReturnType<typeof renderEnvoyConfig>['json'], name: string) => {
+      const typedConfig = json.static_resources.listeners[0]?.filter_chains[0]?.filters[0]
+        ?.typed_config as {
+        route_config: { virtual_hosts: Array<{ routes: Array<Record<string, unknown>> }> }
+      }
+      return typedConfig.route_config.virtual_hosts[0]?.routes.find((r) => r.name === name)
+    }
+
+    it('disables route timeout and idle timeout for streaming routes without declared timeouts', () => {
+      const { json } = renderEnvoyConfig(fixtureManifest, options)
+      // Envoy defaults (15s route timeout, 5m stream idle) would reset streams.
+      expect(findRoute(json, 'notificationsController.stream')?.route).toEqual({
+        cluster: 'users-service',
+        timeout: '0s',
+        idle_timeout: '0s',
+      })
+    })
+
+    it('maps timeouts.idle to route idle_timeout while still disabling the route timeout', () => {
+      const { json } = renderEnvoyConfig(fixtureManifest, options)
+      expect(findRoute(json, 'jobsController.status')?.route).toEqual({
+        cluster: 'users-service',
+        timeout: '0s',
+        idle_timeout: '600s',
+      })
+    })
+
+    it('maps timeouts.idle on non-streaming routes too', () => {
+      const manifest = {
+        ...fixtureManifest,
+        routes: [
+          {
+            ...(fixtureManifest.routes[0] as (typeof fixtureManifest.routes)[number]),
+            metadata: { upstream: 'users-service', timeouts: { request: '5s', idle: '30s' } },
+          },
+        ],
+      }
+      const { json } = renderEnvoyConfig(manifest, options)
+      const route = findRoute(json, fixtureManifest.routes[0]?.id as string)
+      expect(route?.route).toMatchObject({ timeout: '5s', idle_timeout: '30s' })
+    })
+
+    it('warns when a streaming route declares timeouts.request (bounds stream lifetime)', () => {
+      const manifest = {
+        ...fixtureManifest,
+        routes: [
+          {
+            ...(fixtureManifest.routes.find(
+              (r) => r.id === 'notificationsController.stream',
+            ) as (typeof fixtureManifest.routes)[number]),
+            metadata: { upstream: 'users-service', timeouts: { request: '30s' } },
+          },
+        ],
+      }
+      const { warnings } = renderEnvoyConfig(manifest, options)
+      expect(
+        warnings.some(
+          (w) => w.includes('notificationsController.stream') && w.includes('TOTAL lifetime'),
+        ),
+      ).toBe(true)
+    })
+
+    it('emits HCM stream_idle_timeout when options.streamIdleTimeout is set', () => {
+      const { json } = renderEnvoyConfig(fixtureManifest, {
+        ...options,
+        streamIdleTimeout: '10m',
+      })
+      const typedConfig = json.static_resources.listeners[0]?.filter_chains[0]?.filters[0]
+        ?.typed_config as Record<string, unknown>
+      expect(typedConfig.stream_idle_timeout).toBe('600s')
+    })
+  })
 })

--- a/packages/gateway-envoy/src/render.ts
+++ b/packages/gateway-envoy/src/render.ts
@@ -34,6 +34,13 @@ export type EnvoyOptions = {
   /** Optional name for the route_config; defaults to "<service>_routes". */
   routeConfigName?: string
   /**
+   * Optional HCM-level `stream_idle_timeout` (e.g. `'5m'`, `'0s'` to
+   * disable). Envoy's default is 5 minutes. Streaming routes (SSE/dual)
+   * override it per route via `idle_timeout` regardless of this setting;
+   * this knob controls the listener-wide default for everything else.
+   */
+  streamIdleTimeout?: string
+  /**
    * Optional admin listener config. Off by default. When set, Envoy exposes
    * its admin interface (/ready, /stats, /clusters, /config_dump) on the
    * given port — usually 9901 in production deployments.
@@ -97,6 +104,9 @@ export function renderEnvoyConfig(
                     '@type':
                       'type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager',
                     stat_prefix: manifest.service,
+                    ...(options.streamIdleTimeout !== undefined
+                      ? { stream_idle_timeout: toEnvoyDuration(options.streamIdleTimeout) }
+                      : {}),
                     route_config: {
                       name: options.routeConfigName ?? `${manifest.service}_routes`,
                       virtual_hosts: [
@@ -230,12 +240,44 @@ function collectUnsupportedWarnings(
   }
 }
 
-function buildRouteAction(meta: GatewayMetadataValue, upstream: string): EnvoyRouteAction {
+function buildRouteAction(
+  route: GatewayManifestRoute,
+  upstream: string,
+  warnings: string[],
+): EnvoyRouteAction {
+  const meta = route.metadata
+  const streaming = route.streaming !== undefined
+
+  let timeout: string | undefined
+  if (meta.timeouts?.request !== undefined) {
+    timeout = toEnvoyDuration(meta.timeouts.request)
+    if (streaming) {
+      warnings.push(
+        `Route "${route.id}": timeouts.request bounds the TOTAL lifetime of a streaming (${route.streaming}) response — long-lived SSE streams are reset when it elapses. Prefer timeouts.idle for streaming routes.`,
+      )
+    }
+  } else if (streaming) {
+    // Envoy's default route timeout (15s) would reset any stream longer than
+    // that. Disable it for streaming routes; liveness is bounded by
+    // idle_timeout + server heartbeats instead.
+    timeout = '0s'
+  }
+
+  let idleTimeout: string | undefined
+  if (meta.timeouts?.idle !== undefined) {
+    idleTimeout = toEnvoyDuration(meta.timeouts.idle)
+  } else if (streaming) {
+    // Route-level idle_timeout overrides the HCM stream_idle_timeout
+    // (Envoy default: 5m), which would otherwise reset quiet streams.
+    // With no declared timeouts.idle we disable it — heartbeats are the
+    // intended liveness bound; declare timeouts.idle to reinstate one.
+    idleTimeout = '0s'
+  }
+
   return {
     cluster: upstream,
-    ...(meta.timeouts?.request !== undefined
-      ? { timeout: toEnvoyDuration(meta.timeouts.request) }
-      : {}),
+    ...(timeout !== undefined ? { timeout } : {}),
+    ...(idleTimeout !== undefined ? { idle_timeout: idleTimeout } : {}),
     ...(meta.retry ? { retry_policy: buildRetryPolicy(meta.retry) } : {}),
   }
 }
@@ -285,7 +327,7 @@ function buildRoute(
       ...(headerMatchers.length > 0 ? { headers: headerMatchers } : {}),
       ...(queryMatchers.length > 0 ? { query_parameters: queryMatchers } : {}),
     },
-    route: buildRouteAction(meta, meta.upstream),
+    route: buildRouteAction(route, meta.upstream, warnings),
     ...buildRouteHeaderRules(meta),
   }
 
@@ -411,6 +453,7 @@ type EnvoyRetryPolicy = {
 type EnvoyRouteAction = {
   cluster: string
   timeout?: string
+  idle_timeout?: string
   prefix_rewrite?: string
   retry_policy?: EnvoyRetryPolicy
 }

--- a/packages/gateway-kong/package.json
+++ b/packages/gateway-kong/package.json
@@ -34,7 +34,7 @@
         "directory": "packages/gateway-kong"
     },
     "peerDependencies": {
-        "opinionated-machine": ">=6.17.0"
+        "opinionated-machine": ">=7.1.0"
     },
     "dependencies": {
         "yaml": "^2.5.1"

--- a/packages/gateway-kong/src/__fixtures__/manifest.fixture.ts
+++ b/packages/gateway-kong/src/__fixtures__/manifest.fixture.ts
@@ -51,5 +51,28 @@ export const fixtureManifest: GatewayManifest = {
         circuitBreaker: { maxRequests: 100 },
       },
     },
+    {
+      id: 'notificationsController.stream',
+      method: 'GET',
+      path: '/notifications/stream',
+      controller: 'notificationsController',
+      routeKey: 'stream',
+      streaming: 'sse',
+      metadata: {
+        upstream: 'users-service',
+      },
+    },
+    {
+      id: 'jobsController.status',
+      method: 'GET',
+      path: '/jobs/{jobId}/status',
+      controller: 'jobsController',
+      routeKey: 'status',
+      streaming: 'dual',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { idle: '10m' },
+      },
+    },
   ],
 }

--- a/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-kong/src/__snapshots__/render.spec.ts.snap
@@ -12,8 +12,32 @@ exports[`renderKongConfig > matches the JSON snapshot for the fixture manifest 1
       "path": undefined,
       "port": 8081,
       "protocol": "http",
-      "read_timeout": 5000,
+      "read_timeout": 600000,
       "routes": [
+        {
+          "methods": [
+            "GET",
+          ],
+          "name": "jobsController.status",
+          "paths": [
+            "~/jobs/(?<jobId>[^/]+)/status$",
+          ],
+          "preserve_host": false,
+          "response_buffering": false,
+          "strip_path": false,
+        },
+        {
+          "methods": [
+            "GET",
+          ],
+          "name": "notificationsController.stream",
+          "paths": [
+            "/notifications/stream",
+          ],
+          "preserve_host": false,
+          "response_buffering": false,
+          "strip_path": false,
+        },
         {
           "methods": [
             "POST",
@@ -117,8 +141,24 @@ services:
     protocol: http
     host: users
     port: 8081
-    read_timeout: 5000
+    read_timeout: 600000
     routes:
+      - name: jobsController.status
+        methods:
+          - GET
+        paths:
+          - ~/jobs/(?<jobId>[^/]+)/status$
+        strip_path: false
+        preserve_host: false
+        response_buffering: false
+      - name: notificationsController.stream
+        methods:
+          - GET
+        paths:
+          - /notifications/stream
+        strip_path: false
+        preserve_host: false
+        response_buffering: false
       - name: usersController.createItem
         methods:
           - POST

--- a/packages/gateway-kong/src/render.spec.ts
+++ b/packages/gateway-kong/src/render.spec.ts
@@ -22,6 +22,8 @@ describe('renderKongConfig', () => {
     expect(json.services).toHaveLength(1)
     expect(json.services[0]?.name).toBe('users-service')
     expect(json.services[0]?.routes.map((r) => r.name).sort()).toEqual([
+      'jobsController.status',
+      'notificationsController.stream',
       'usersController.createItem',
       'usersController.deleteItem',
       'usersController.getItem',
@@ -83,10 +85,12 @@ describe('renderKongConfig', () => {
 
   it('reads service-level read_timeout from the LOOSEST route timeout in that upstream', () => {
     // Kong CE has no per-route timeout override; using the loosest avoids
-    // silently shortening timeouts on routes that asked for more.
+    // silently shortening timeouts on routes that asked for more. Both
+    // timeouts.request and timeouts.idle participate — Kong's read_timeout
+    // fires between successive reads, so it is the idle bound for streams.
     const { json } = renderKongConfig(fixtureManifest, options)
-    // Loosest among 5s / 2s / (no timeout) is 5s = 5000ms.
-    expect(json.services[0]?.read_timeout).toBe(5000)
+    // Loosest among 5s / 2s / 10m (streaming idle) is 10m = 600000ms.
+    expect(json.services[0]?.read_timeout).toBe(600000)
   })
 
   it('warns when a route asked for a tighter timeout than the service-level one allows', () => {
@@ -133,5 +137,36 @@ describe('renderKongConfig', () => {
       expect(route?.plugins?.some((p) => p.name === 'mtls-auth') ?? false).toBe(false)
       expect(warnings.some((w) => w.includes('auth.mTLS') && w.includes('Enterprise'))).toBe(true)
     })
+  })
+})
+
+describe('renderKongConfig — streaming routes', () => {
+  const options = { upstreams: { 'users-service': { url: 'http://users:8081' } } }
+
+  it('disables response buffering on streaming routes only', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    const routes = Object.fromEntries(json.services[0]?.routes.map((r) => [r.name, r]) ?? [])
+    expect(routes['notificationsController.stream']?.response_buffering).toBe(false)
+    expect(routes['jobsController.status']?.response_buffering).toBe(false)
+    expect('response_buffering' in (routes['usersController.getItem'] ?? {})).toBe(false)
+  })
+
+  it('lets timeouts.idle participate in the loosest-wins read_timeout', () => {
+    const { json } = renderKongConfig(fixtureManifest, options)
+    // 10m idle on the dual streaming route wins over 5s/2s request timeouts.
+    expect(json.services[0]?.read_timeout).toBe(600000)
+  })
+
+  it('warns for streaming routes without timeouts.idle (heartbeats must beat read_timeout)', () => {
+    const { warnings } = renderKongConfig(fixtureManifest, options)
+    expect(
+      warnings.some(
+        (w) => w.includes('notificationsController.stream') && w.includes('heartbeats'),
+      ),
+    ).toBe(true)
+    // The dual route declared timeouts.idle — no warning for it.
+    expect(
+      warnings.some((w) => w.includes('jobsController.status') && w.includes('heartbeats')),
+    ).toBe(false)
   })
 })

--- a/packages/gateway-kong/src/render.ts
+++ b/packages/gateway-kong/src/render.ts
@@ -103,19 +103,11 @@ function buildService(
   const url = new URL(upstreamOpts.url)
   // Kong CE's read_timeout is service-level — every route under this service
   // inherits the same value, so we use the LOOSEST timeout among the routes.
-  // Routes that asked for a tighter timeout get a warning so the operator
-  // knows to enforce it elsewhere (a Lua plugin, a sidecar, the upstream).
+  // Both timeouts.request and timeouts.idle participate: Kong's read_timeout
+  // fires between successive reads, so it is effectively the idle bound for
+  // streaming routes.
   const readTimeout = pickLoosestTimeout(routes)
-  for (const route of routes) {
-    const declared = route.metadata.timeouts?.request
-    if (!declared) continue
-    const declaredMs = toMilliseconds(declared)
-    if (readTimeout !== undefined && declaredMs < readTimeout) {
-      warnings.push(
-        `Route "${route.id}": metadata.timeouts.request (${declared}) is tighter than the service-level read_timeout (${readTimeout}ms) — Kong CE has no per-route timeout override; enforce this at the upstream or via a Lua plugin.`,
-      )
-    }
-  }
+  collectTimeoutWarnings(routes, readTimeout, warnings)
 
   return {
     name,
@@ -131,13 +123,45 @@ function buildService(
   }
 }
 
+/**
+ * Warn about timeout situations Kong cannot express per route: declared
+ * timeouts tighter than the loosest-wins service read_timeout, and streaming
+ * routes without a declared idle window (server heartbeats must arrive
+ * within the effective read_timeout — Kong default 60s — or Kong resets
+ * quiet streams).
+ */
+function collectTimeoutWarnings(
+  routes: GatewayManifest['routes'],
+  readTimeout: number | undefined,
+  warnings: string[],
+): void {
+  for (const route of routes) {
+    const declared = route.metadata.timeouts?.request
+    if (!declared) continue
+    const declaredMs = toMilliseconds(declared)
+    if (readTimeout !== undefined && declaredMs < readTimeout) {
+      warnings.push(
+        `Route "${route.id}": metadata.timeouts.request (${declared}) is tighter than the service-level read_timeout (${readTimeout}ms) — Kong CE has no per-route timeout override; enforce this at the upstream or via a Lua plugin.`,
+      )
+    }
+  }
+  for (const route of routes) {
+    if (route.streaming === undefined || route.metadata.timeouts?.idle !== undefined) continue
+    const effective = readTimeout !== undefined ? `${readTimeout}ms` : "Kong's default 60s"
+    warnings.push(
+      `Route "${route.id}": streaming (${route.streaming}) route without timeouts.idle — Kong resets the stream when no bytes arrive within the service-level read_timeout (${effective}); ensure server heartbeats are more frequent, or declare timeouts.idle to raise it.`,
+    )
+  }
+}
+
 function pickLoosestTimeout(routes: GatewayManifest['routes']): number | undefined {
   let loosest: number | undefined
   for (const route of routes) {
-    const timeout = route.metadata.timeouts?.request
-    if (!timeout) continue
-    const ms = toMilliseconds(timeout)
-    if (loosest === undefined || ms > loosest) loosest = ms
+    for (const timeout of [route.metadata.timeouts?.request, route.metadata.timeouts?.idle]) {
+      if (!timeout) continue
+      const ms = toMilliseconds(timeout)
+      if (loosest === undefined || ms > loosest) loosest = ms
+    }
   }
   return loosest
 }
@@ -172,6 +196,9 @@ function buildRoute(
     paths: [kongPath],
     strip_path: stripPath,
     preserve_host: false,
+    // Streaming routes must not be buffered — Kong would hold SSE frames
+    // until the response completes. Route-level field (Kong >= 2.3).
+    ...(route.streaming !== undefined ? { response_buffering: false } : {}),
     ...(headers ? { headers } : {}),
     plugins: collectRoutePlugins(route.id, meta, profile, warnings),
   }
@@ -389,6 +416,7 @@ type KongRoute = {
   paths: string[]
   strip_path: boolean
   preserve_host: boolean
+  response_buffering?: boolean
   headers?: Record<string, string[]>
   plugins?: KongPlugin[]
 }

--- a/packages/gateway-krakend/package.json
+++ b/packages/gateway-krakend/package.json
@@ -34,7 +34,7 @@
         "directory": "packages/gateway-krakend"
     },
     "peerDependencies": {
-        "opinionated-machine": ">=6.17.0"
+        "opinionated-machine": ">=7.1.0"
     },
     "devDependencies": {
         "@biomejs/biome": "2.4.4",

--- a/packages/gateway-krakend/src/__fixtures__/manifest.fixture.ts
+++ b/packages/gateway-krakend/src/__fixtures__/manifest.fixture.ts
@@ -52,5 +52,28 @@ export const fixtureManifest: GatewayManifest = {
         },
       },
     },
+    {
+      id: 'notificationsController.stream',
+      method: 'GET',
+      path: '/notifications/stream',
+      controller: 'notificationsController',
+      routeKey: 'stream',
+      streaming: 'sse',
+      metadata: {
+        upstream: 'users-service',
+      },
+    },
+    {
+      id: 'jobsController.status',
+      method: 'GET',
+      path: '/jobs/{jobId}/status',
+      controller: 'jobsController',
+      routeKey: 'status',
+      streaming: 'dual',
+      metadata: {
+        upstream: 'users-service',
+        timeouts: { idle: '10m' },
+      },
+    },
   ],
 }

--- a/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
+++ b/packages/gateway-krakend/src/__snapshots__/render.spec.ts.snap
@@ -73,6 +73,35 @@ exports[`renderKrakendConfig > matches the JSON snapshot for the fixture manifes
       "method": "GET",
       "output_encoding": "no-op",
     },
+    {
+      "backend": [
+        {
+          "encoding": "no-op",
+          "host": [
+            "http://users:8081",
+          ],
+          "url_pattern": "/notifications/stream",
+        },
+      ],
+      "endpoint": "/notifications/stream",
+      "method": "GET",
+      "output_encoding": "no-op",
+    },
+    {
+      "backend": [
+        {
+          "encoding": "no-op",
+          "host": [
+            "http://users:8081",
+          ],
+          "url_pattern": "/jobs/{jobId}/status",
+        },
+      ],
+      "endpoint": "/jobs/{jobId}/status",
+      "method": "GET",
+      "output_encoding": "no-op",
+      "timeout": "10m",
+    },
   ],
   "extra_config": {
     "security/cors": {

--- a/packages/gateway-krakend/src/durations.ts
+++ b/packages/gateway-krakend/src/durations.ts
@@ -14,3 +14,17 @@ export function toKrakendDuration(input: string): string {
   }
   return input
 }
+
+const UNIT_MS: Record<string, number> = { ms: 1, s: 1000, m: 60_000, h: 3_600_000 }
+
+/**
+ * Convert a universal `Duration` string to milliseconds, for comparing
+ * durations (e.g. picking the looser of `timeouts.request` / `timeouts.idle`).
+ */
+export function toMilliseconds(input: string): number {
+  const match = /^(\d+)(ms|s|m|h)$/.exec(input)
+  if (!match) {
+    throw new Error(`Unsupported duration "${input}" — expected formats like "5s", "300ms".`)
+  }
+  return Number(match[1]) * (UNIT_MS[match[2] as string] as number)
+}

--- a/packages/gateway-krakend/src/render.spec.ts
+++ b/packages/gateway-krakend/src/render.spec.ts
@@ -19,6 +19,8 @@ describe('renderKrakendConfig', () => {
       'POST /users',
       'GET /users/{userId}',
       'GET /v2/users',
+      'GET /notifications/stream',
+      'GET /jobs/{jobId}/status',
     ])
   })
 
@@ -52,5 +54,30 @@ describe('renderKrakendConfig', () => {
     const { json } = renderKrakendConfig(fixtureManifest, options)
     const listItems = json.endpoints.find((e) => e.endpoint === '/v2/users')
     expect(listItems?.extra_config?.['qos/http-cache']).toEqual({ ttl: '10s' })
+  })
+})
+
+describe('renderKrakendConfig — streaming routes', () => {
+  const options = { port: 8080, upstreams: { 'users-service': 'http://users:8081' } }
+
+  it('uses the looser of timeouts.request / timeouts.idle as the endpoint timeout', () => {
+    const { json } = renderKrakendConfig(fixtureManifest, options)
+    const status = json.endpoints.find((e) => e.endpoint === '/jobs/{jobId}/status')
+    expect(status?.timeout).toBe('10m')
+  })
+
+  it('warns for streaming routes without any timeout (KrakenD default 2s kills streams)', () => {
+    const { warnings } = renderKrakendConfig(fixtureManifest, options)
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes('notificationsController.stream') && w.includes('default endpoint timeout'),
+      ),
+    ).toBe(true)
+    expect(
+      warnings.some(
+        (w) => w.includes('jobsController.status') && w.includes('default endpoint timeout'),
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/gateway-krakend/src/render.ts
+++ b/packages/gateway-krakend/src/render.ts
@@ -1,5 +1,5 @@
 import type { GatewayManifest, GatewayMetadataValue } from 'opinionated-machine'
-import { toKrakendDuration } from './durations.ts'
+import { toKrakendDuration, toMilliseconds } from './durations.ts'
 
 export type KrakendOptions = {
   /** KrakenD listener port. */
@@ -41,6 +41,18 @@ export function renderKrakendConfig(
       )
     }
 
+    // KrakenD's endpoint timeout bounds the WHOLE request (there is no
+    // separate idle timeout), so the looser of timeouts.request /
+    // timeouts.idle wins. Streaming routes with neither declared get a
+    // warning: KrakenD's default endpoint timeout (2s) kills any long-lived
+    // stream.
+    const endpointTimeout = pickEndpointTimeout(route.metadata)
+    if (route.streaming !== undefined && endpointTimeout === undefined) {
+      warnings.push(
+        `Route "${route.id}": streaming (${route.streaming}) route without timeouts.request/timeouts.idle — KrakenD applies its default endpoint timeout (2s) to the whole response, which kills long-lived SSE streams. Declare a large timeouts.idle to raise it.`,
+      )
+    }
+
     const endpoint: KrakendEndpoint = {
       endpoint: route.path,
       method: route.method,
@@ -48,9 +60,7 @@ export function renderKrakendConfig(
       // KrakenD's request timeout is an endpoint-level field, NOT a
       // `backend/http/client` extra_config — that plugin doesn't have a
       // `timeout` setting and silently ignores it.
-      ...(route.metadata.timeouts?.request
-        ? { timeout: toKrakendDuration(route.metadata.timeouts.request) }
-        : {}),
+      ...(endpointTimeout !== undefined ? { timeout: toKrakendDuration(endpointTimeout) } : {}),
       backend: [
         {
           host: [upstreamHost],
@@ -116,6 +126,19 @@ function collectUnsupportedWarnings(
       `Route "${routeId}": metadata.auth.mTLS is not modelled — terminate mTLS at the listener / reverse proxy in front of KrakenD.`,
     )
   }
+}
+
+/**
+ * Pick the endpoint timeout: the looser of `timeouts.request` and
+ * `timeouts.idle` (KrakenD has a single whole-request timeout).
+ */
+function pickEndpointTimeout(meta: GatewayMetadataValue): string | undefined {
+  const request = meta.timeouts?.request
+  const idle = meta.timeouts?.idle
+  if (request !== undefined && idle !== undefined) {
+    return toMilliseconds(idle) > toMilliseconds(request) ? idle : request
+  }
+  return request ?? idle
 }
 
 function applyRewrite(path: string, rewrite: GatewayMetadataValue['rewrite']): string {

--- a/packages/sse-fallback/README.md
+++ b/packages/sse-fallback/README.md
@@ -1,0 +1,172 @@
+# @opinionated-machine/sse-fallback
+
+Browser-safe client core for **SSE with a transparent polling fallback**, built
+around `opinionated-machine` dual-mode contracts (one path serving JSON via
+`Accept: application/json` and SSE via `Accept: text/event-stream`).
+
+The client subscribes to the SSE branch for low-latency pushes and keeps a
+**deadman timer**: when no data event arrives within the window, it polls the
+JSON branch of the same route. A single **version gate** reconciles the two
+channels, so app code sees exactly one uniform event stream — whether an event
+was pushed, replayed after a reconnect, or synthesized from a poll snapshot is
+invisible.
+
+**Zero runtime dependencies.** `zod` and `@lokalise/api-contracts` are
+type-only optional peers; nothing from Node.js or Fastify is imported — the
+package is safe to ship to browsers (enforced by a source-tree check in CI).
+
+## Why
+
+Push channels fail silently: connections die without an error event, proxies
+kill idle streams, a room rebalance drops a message. When the missed
+notification gates workflow progress ("upload finished"), the user is stuck.
+This package makes **polling the correctness backbone** (bounded staleness,
+guaranteed) and SSE the latency optimization — instead of the other way
+around.
+
+Two failure detectors run independently:
+
+| Timer | Reset by | Catches |
+|---|---|---|
+| `staleConnection` | **any bytes** (incl. `: heartbeat` comments) | silently dead connections — force-close + reconnect + poll |
+| `deadman` | **data events only** | healthy-but-wrong streams (a dropped message on a live connection) — reconciliation poll |
+
+Heartbeats deliberately do *not* reset the deadman: transport liveness is not
+delivery correctness.
+
+## Declaring a binding
+
+The binding is the one thing that cannot be inferred: how a poll snapshot
+relates to the SSE events. Declare it once, colocated with the contract:
+
+```ts
+import { defineFallbackBinding } from '@opinionated-machine/sse-fallback'
+
+// Use case A — await async completion
+export const uploadStatusBinding = defineFallbackBinding(uploadStatusContract, {
+  // Translate a snapshot into events; [] = "no news" (still advances the watermark)
+  snapshotToEvents: (s) =>
+    s.status === 'completed'
+      ? [{ event: 'uploadFinished', data: { result: s.result } }]
+      : s.status === 'failed'
+        ? [{ event: 'uploadFailed', data: { error: s.error } }]
+        : [],
+  version: { ofSnapshot: (s) => s.version },
+  terminalEvents: ['uploadFinished', 'uploadFailed'],
+})
+
+// Use case B — initial state load + live hydration
+export const projectStateBinding = defineFallbackBinding(projectStateContract, {
+  snapshotEvent: 'stateChanged', // shorthand: snapshot body ≡ this event's payload
+  version: { ofSnapshot: (s) => s.revision, ofEvent: (e) => e.data.revision, dense: true },
+  state: {
+    init: (s) => s,
+    apply: (state, e) => applyDelta(state, e),
+  },
+})
+```
+
+Escape hatches: `bindFallbackContracts(pollContract, streamContract, config)`
+binds two pre-existing contracts on different paths;
+`fromLegacyDualModeContract(contract, config)` accepts legacy
+`buildSseContract` dual-mode contracts.
+
+## Subscribing
+
+```ts
+import { createResilientSubscription } from '@opinionated-machine/sse-fallback'
+
+const sub = createResilientSubscription(uploadStatusBinding, {
+  transport,                       // FallbackTransport (see below)
+  params: { pathParams: { uploadId } },
+})
+
+// Use case A: identical result whether it traveled over SSE or a poll
+const { result } = await sub.waitFor('uploadFinished')
+
+// Or consume the uniform stream
+for await (const event of sub.events()) { ... }
+
+// Use case B: reduced state
+sub.onStateChange((state) => render(state))
+
+sub.status                        // 'connecting' | 'live' | 'reconnecting' | 'polling' | 'stopped'
+sub.nudge()                       // force an immediate reconciliation poll
+sub.stop()
+```
+
+The state machine: `CONNECTING → HYDRATING → LIVE ⇄ RECONNECTING →
+POLLING_ONLY → STOPPED`. Hydration is **subscribe-first**: the stream opens,
+live events are buffered, the snapshot is fetched, then buffered events newer
+than the snapshot are flushed — a zero missed-event window. After N
+consecutive connect failures the subscription degrades to pure polling and
+keeps probing SSE in the background.
+
+## The version gate
+
+Every event and snapshot carries a version; an item is delivered iff its
+version exceeds the high-watermark. This one rule handles:
+
+- **duplicates** — an SSE event followed by a poll snapshot of the same update,
+- **the stale-poll race** — a slow poll response arriving *after* a newer
+  pushed event is dropped at arrival time,
+- **replay overlap** — server-side `Last-Event-ID` replay after reconnects.
+
+`version: 'none'` opts into at-least-once/last-writer-wins semantics as an
+adoption bridge — strongly prefer real versions.
+
+## Server-side guarantees (the adopting team's checklist)
+
+1. **Required**: a monotonic version per subscription scope, present in both
+   the snapshot body and each event; truthful (a snapshot at version *v*
+   reflects every event ≤ *v*). Snapshots must **subsume** prior events.
+2. **Recommended**: stamp the SSE `id:` with that version
+   (`createEventIdSequence` in `opinionated-machine` helps) — the client's
+   default `Number(event.id)` extraction and `Last-Event-ID` replay then
+   compose for free.
+3. Optional: dense versions (enables gap detection → instant repair polls),
+   `onReconnect` replay (declare `replay: 'trusted'` to skip post-reconnect
+   polls), heartbeats every ~15s (fast stale detection; correctness holds
+   without them).
+
+## Transport
+
+The core owns no HTTP. Implement two functions:
+
+```ts
+const transport: FallbackTransport = {
+  fetchSnapshot(request, { signal }) { ... },      // Accept: application/json
+  openStream(request, { signal, lastEventId }) { ... }, // Accept: text/event-stream,
+                                                   // yields decoded text chunks
+}
+```
+
+`openStream` must yield **raw text chunks** (not parsed events) — the core
+parses SSE framing itself and uses chunk arrival as byte-level liveness, so
+heartbeat comments count without any transport logic. A scripted
+`TestTransport` ships in the package for deterministic fake-timer tests.
+
+## Policy defaults
+
+| Setting | Default | Notes |
+|---|---|---|
+| `initialPoll` | `'eager'` | closes the startup race for one GET |
+| `deadmanDelayMs` | 10 000 | `LIVE_STATE_POLICY` preset: 120 000 |
+| `deadmanIdleBackoff` | ×1.5 up to 60 s | quiet subscriptions poll less |
+| `staleConnectionTimeoutMs` | 60 000 | `'off'` to disable byte-level liveness |
+| `pollFailureBackoff` / `sseRetryBackoff` | 1 s ×2 up to 30 s, full jitter | |
+| `degradedAfterFailures` | 3 | then `POLLING_ONLY` |
+| `degradedPollIntervalMs` | 15 000 | the "old polling world", kept humane |
+| `hydrationBufferLimit` | 1 000 | overflow → drop buffer + refetch |
+| `unretryableStatuses` | 401, 403, 404 | stop instead of retrying |
+
+## Known limitations (v1)
+
+- **Snapshots must subsume events.** Append-only feeds where every event
+  matters individually and the snapshot only shows the latest item don't fit —
+  expose a windowed snapshot (`{ items: [...], version }`) instead.
+- **One connection per browser tab.** SharedWorker-based connection sharing
+  can be built as an alternative `FallbackTransport` later; `nudge()` /
+  `stop()` give visibility-aware wrappers the hooks they need.
+- No reorder buffer: on a single TCP stream, gaps are losses, not reorders —
+  polling is the repair path.

--- a/packages/sse-fallback/package.json
+++ b/packages/sse-fallback/package.json
@@ -1,0 +1,74 @@
+{
+    "name": "@opinionated-machine/sse-fallback",
+    "version": "0.0.0",
+    "description": "Browser-safe SSE client core with transparent polling fallback for opinionated-machine dual-mode contracts",
+    "type": "module",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "sideEffects": false,
+    "exports": {
+        ".": "./dist/index.js",
+        "./package.json": "./package.json"
+    },
+    "maintainers": [
+        {
+            "name": "Igor Savin",
+            "email": "kibertoad@gmail.com"
+        }
+    ],
+    "scripts": {
+        "build": "rimraf dist && tsc -p tsconfig.build.json",
+        "lint": "biome check . && tsc",
+        "lint:fix": "biome check --write .",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "prepublishOnly": "pnpm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kibertoad/opinionated-machine.git",
+        "directory": "packages/sse-fallback"
+    },
+    "peerDependencies": {
+        "@lokalise/api-contracts": ">=7.0.0",
+        "zod": ">=4.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@lokalise/api-contracts": {
+            "optional": true
+        },
+        "zod": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.4.4",
+        "@lokalise/api-contracts": "^7.1.0",
+        "@lokalise/biome-config": "^3.1.1",
+        "@lokalise/tsconfig": "^3.1.0",
+        "rimraf": "^6.1.2",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
+        "zod": "^4.4.3"
+    },
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "keywords": [
+        "sse",
+        "server-sent-events",
+        "polling",
+        "fallback",
+        "realtime",
+        "browser",
+        "opinionated-machine"
+    ],
+    "homepage": "https://github.com/kibertoad/opinionated-machine/tree/main/packages/sse-fallback",
+    "files": [
+        "README.md",
+        "LICENSE",
+        "dist/*"
+    ]
+}

--- a/packages/sse-fallback/src/binding.spec.ts
+++ b/packages/sse-fallback/src/binding.spec.ts
@@ -1,0 +1,295 @@
+import { defineApiContract, sseBody } from '@lokalise/api-contracts'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { z } from 'zod/v4'
+import {
+  bindFallbackContracts,
+  defineFallbackBinding,
+  fromLegacyDualModeContract,
+  readFallbackBinding,
+} from './binding.ts'
+import type { FallbackEvent } from './bindingTypes.ts'
+
+// ============================================================================
+// Fixtures — real @lokalise/api-contracts contracts (devDependency)
+// ============================================================================
+
+const uploadStatusContract = defineApiContract({
+  method: 'get',
+  summary: 'Upload status',
+  pathResolver: ({ uploadId }) => `/uploads/${uploadId}/status`,
+  requestPathParamsSchema: z.object({ uploadId: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({
+          status: z.enum(['pending', 'completed', 'failed']),
+          result: z.string().optional(),
+          version: z.number(),
+        }),
+        'text/event-stream': sseBody({
+          progress: z.object({ percent: z.number() }),
+          uploadFinished: z.object({ result: z.string() }),
+          uploadFailed: z.object({ error: z.string() }),
+        }),
+      },
+    },
+  },
+})
+
+const plainPollContract = defineApiContract({
+  method: 'get',
+  summary: 'Poll only',
+  pathResolver: () => '/jobs/current',
+  responsesByStatusCode: {
+    200: z.object({ status: z.string(), version: z.number() }),
+  },
+})
+
+const sseOnlyContract = defineApiContract({
+  method: 'get',
+  summary: 'Stream only',
+  pathResolver: () => '/jobs/stream',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'text/event-stream': sseBody({
+          update: z.object({ status: z.string(), version: z.number() }),
+        }),
+      },
+    },
+  },
+})
+
+// ============================================================================
+// defineFallbackBinding (primary form)
+// ============================================================================
+
+describe('defineFallbackBinding', () => {
+  it('accepts a dual-mode contract and builds both requests from one path', () => {
+    const binding = defineFallbackBinding(uploadStatusContract, {
+      snapshotToEvents: (s) =>
+        s.status === 'completed'
+          ? [{ event: 'uploadFinished', data: { result: s.result as string } }]
+          : [],
+      version: { ofSnapshot: (s) => s.version },
+      terminalEvents: ['uploadFinished', 'uploadFailed'],
+    })
+
+    const params = { pathParams: { uploadId: 'u1' } }
+    expect(binding.buildSnapshotRequest(params)).toEqual({
+      path: '/uploads/u1/status',
+      method: 'get',
+    })
+    expect(binding.buildStreamRequest(params)).toEqual({
+      path: '/uploads/u1/status',
+      method: 'get',
+    })
+  })
+
+  it('infers snapshot and event payload types from the contract', () => {
+    defineFallbackBinding(uploadStatusContract, {
+      snapshotToEvents: (s) => {
+        expectTypeOf(s.status).toEqualTypeOf<'pending' | 'completed' | 'failed'>()
+        expectTypeOf(s.version).toEqualTypeOf<number>()
+        return []
+      },
+      version: {
+        ofSnapshot: (s) => s.version,
+        ofEvent: (e) => {
+          expectTypeOf(e).toExtend<{ event: string; origin: 'sse' | 'poll' }>()
+          return undefined
+        },
+      },
+    })
+  })
+
+  it('rejects event names / payloads not declared on the contract at compile time', () => {
+    defineFallbackBinding(uploadStatusContract, {
+      // @ts-expect-error 'nope' is not a declared event
+      snapshotToEvents: () => [{ event: 'nope', data: {} }],
+      version: { ofSnapshot: (s) => s.version },
+    })
+    defineFallbackBinding(uploadStatusContract, {
+      // @ts-expect-error payload shape mismatch for uploadFinished
+      snapshotToEvents: () => [{ event: 'uploadFinished', data: { wrong: true } }],
+      version: { ofSnapshot: (s) => s.version },
+    })
+  })
+
+  it('throws for a non-dual contract', () => {
+    expect(() =>
+      defineFallbackBinding(plainPollContract, {
+        snapshotToEvents: () => [],
+        version: 'none',
+      }),
+    ).toThrow(/dual-mode contract/)
+  })
+
+  it('expands the snapshotEvent shorthand', () => {
+    const contract = defineApiContract({
+      method: 'get',
+      summary: 'State',
+      pathResolver: () => '/state',
+      responsesByStatusCode: {
+        200: {
+          content: {
+            'application/json': z.object({ revision: z.number() }),
+            'text/event-stream': sseBody({ stateChanged: z.object({ revision: z.number() }) }),
+          },
+        },
+      },
+    })
+    const binding = defineFallbackBinding(contract, {
+      snapshotEvent: 'stateChanged',
+      version: { ofSnapshot: (s) => s.revision },
+    })
+    expect(binding.config.snapshotToEvents?.({ revision: 7 })).toEqual([
+      { event: 'stateChanged', data: { revision: 7 } },
+    ])
+  })
+
+  it('requires exactly one of snapshotToEvents / snapshotEvent', () => {
+    expect(() =>
+      defineFallbackBinding(uploadStatusContract, {
+        version: { ofSnapshot: (s) => s.version },
+      }),
+    ).toThrow(/exactly one/)
+  })
+
+  it('stamps the binding on the contract for server-side introspection', () => {
+    const binding = defineFallbackBinding(uploadStatusContract, {
+      snapshotToEvents: () => [],
+      version: { ofSnapshot: (s) => s.version },
+    })
+    expect(readFallbackBinding(uploadStatusContract)).toBe(binding)
+    // Non-enumerable: never serialized, never seen by Fastify.
+    expect(Object.keys(uploadStatusContract)).not.toContain('binding')
+    expect(
+      JSON.parse(JSON.stringify({ ...uploadStatusContract, pathResolver: undefined })),
+    ).toBeDefined()
+  })
+
+  it('serializes query params and passes headers/body through', () => {
+    const binding = defineFallbackBinding(uploadStatusContract, {
+      snapshotToEvents: () => [],
+      version: { ofSnapshot: (s) => s.version },
+    })
+    const request = binding.buildSnapshotRequest({
+      pathParams: { uploadId: 'u1' },
+      queryParams: { verbose: true, limit: 5, skip: undefined },
+      headers: { 'x-tenant': 't1' },
+    })
+    expect(request.query).toEqual({ verbose: 'true', limit: '5' })
+    expect(request.headers).toEqual({ 'x-tenant': 't1' })
+  })
+})
+
+// ============================================================================
+// bindFallbackContracts (escape hatch)
+// ============================================================================
+
+describe('bindFallbackContracts', () => {
+  it('binds a separate poll + stream contract pair with param mapping', () => {
+    const binding = bindFallbackContracts(plainPollContract, sseOnlyContract, {
+      snapshotToEvents: (s) => [
+        { event: 'update', data: { status: s.status, version: s.version } },
+      ],
+      version: { ofSnapshot: (s) => s.version, ofEvent: (e) => e.data.version },
+    })
+
+    expect(binding.buildSnapshotRequest({}).path).toBe('/jobs/current')
+    expect(binding.buildStreamRequest({}).path).toBe('/jobs/stream')
+    expect(readFallbackBinding(plainPollContract)).toBe(binding)
+    expect(readFallbackBinding(sseOnlyContract)).toBe(binding)
+  })
+
+  it('rejects an SSE-capable poll contract', () => {
+    expect(() =>
+      bindFallbackContracts(uploadStatusContract, sseOnlyContract, {
+        snapshotToEvents: () => [],
+        version: 'none',
+      }),
+    ).toThrow(/plain \(non-SSE\) contract/)
+  })
+
+  it('rejects a stream contract without SSE responses', () => {
+    expect(() =>
+      bindFallbackContracts(plainPollContract, plainPollContract, {
+        snapshotToEvents: () => [],
+        version: 'none',
+      }),
+    ).toThrow(/SSE success response/)
+  })
+
+  it('applies mapParams to each side independently', () => {
+    const binding = bindFallbackContracts(plainPollContract, sseOnlyContract, {
+      snapshotToEvents: () => [],
+      version: 'none',
+      mapParams: {
+        toStream: (params) => ({ ...params, queryParams: { channel: 'jobs' } }),
+      },
+    })
+    expect(binding.buildSnapshotRequest({ queryParams: { a: '1' } }).query).toEqual({ a: '1' })
+    expect(binding.buildStreamRequest({ queryParams: { a: '1' } }).query).toEqual({
+      channel: 'jobs',
+    })
+  })
+})
+
+// ============================================================================
+// fromLegacyDualModeContract
+// ============================================================================
+
+describe('fromLegacyDualModeContract', () => {
+  // Structural legacy contract (buildSseContract output shape) — avoids
+  // depending on the legacy builder at runtime.
+  const legacyContract = {
+    method: 'get' as const,
+    pathResolver: (p: { jobId: string }) => `/jobs/${p.jobId}/status`,
+    isSSE: true as const,
+    isDualMode: true as const,
+    successResponseBodySchema: z.object({ status: z.string(), version: z.number() }),
+    serverSentEventSchemas: {
+      done: z.object({ result: z.string() }),
+    },
+  }
+
+  it('accepts a legacy dual-mode contract', () => {
+    const binding = fromLegacyDualModeContract(legacyContract, {
+      snapshotToEvents: (s) => {
+        expectTypeOf(s.version).toEqualTypeOf<number>()
+        return s.status === 'done' ? [{ event: 'done', data: { result: s.status } }] : []
+      },
+      version: { ofSnapshot: (s) => s.version },
+      terminalEvents: ['done'],
+    })
+    expect(binding.buildStreamRequest({ pathParams: { jobId: 'j1' } }).path).toBe('/jobs/j1/status')
+  })
+
+  it('rejects non-dual legacy contracts', () => {
+    expect(() =>
+      fromLegacyDualModeContract(
+        { ...legacyContract, isDualMode: false as unknown as true },
+        { snapshotToEvents: () => [], version: 'none' },
+      ),
+    ).toThrow(/legacy dual-mode contract/)
+  })
+})
+
+// ============================================================================
+// FallbackEvent typing
+// ============================================================================
+
+describe('FallbackEvent typing', () => {
+  it('is a discriminated union over event names', () => {
+    type Events = { a: { x: number }; b: { y: string } }
+    const handle = (e: FallbackEvent<Events>) => {
+      if (e.event === 'a') {
+        expectTypeOf(e.data).toEqualTypeOf<{ x: number }>()
+      } else {
+        expectTypeOf(e.data).toEqualTypeOf<{ y: string }>()
+      }
+    }
+    handle({ event: 'a', data: { x: 1 }, origin: 'sse' })
+  })
+})

--- a/packages/sse-fallback/src/binding.ts
+++ b/packages/sse-fallback/src/binding.ts
@@ -1,0 +1,309 @@
+import type {
+  EventPayloadMap,
+  FallbackBindingConfig,
+  InferContractEvents,
+  InferContractSnapshot,
+  InferLegacyEvents,
+  InferLegacySnapshot,
+} from './bindingTypes.ts'
+import type { TransportRequest } from './transport.ts'
+
+/**
+ * Symbol under which a binding is stamped on its contract(s), so server-side
+ * tooling can later introspect bindings without a package dependency in
+ * either direction (`Symbol.for` — shared across duplicate package copies).
+ */
+export const FALLBACK_BINDING_SYMBOL = Symbol.for('opinionated-machine.sse-fallback.binding')
+
+/** Request parameters supplied when subscribing. */
+export type FallbackRequestParams = {
+  pathParams?: Record<string, string | number>
+  queryParams?: Record<string, string | number | boolean | undefined>
+  headers?: Record<string, string>
+  /** Request body for payload (POST/PUT/PATCH) contracts. */
+  body?: unknown
+}
+
+/**
+ * A normalized fallback binding: the client core's single input shape.
+ * Produced by {@link defineFallbackBinding} (dual-mode contract — the
+ * primary form) or {@link bindFallbackContracts} (two separate contracts —
+ * the escape hatch); both normalize to a snapshot-request builder + a
+ * stream-request builder + the reconciliation config.
+ */
+export type FallbackBinding<
+  Snapshot = unknown,
+  Events extends EventPayloadMap = EventPayloadMap,
+  State = undefined,
+> = {
+  readonly config: FallbackBindingConfig<Snapshot, Events, State>
+  buildSnapshotRequest(params: FallbackRequestParams): TransportRequest
+  buildStreamRequest(params: FallbackRequestParams): TransportRequest
+}
+
+// ============================================================================
+// Contract introspection (structural — no runtime deps)
+// ============================================================================
+
+type ContractLike = {
+  method: string
+  pathResolver: (pathParams: Record<string, unknown>) => string
+  responsesByStatusCode?: Record<string, unknown>
+  /** Legacy contract markers */
+  isSSE?: boolean
+  isDualMode?: boolean
+  successResponseBodySchema?: unknown
+  serverSentEventSchemas?: unknown
+}
+
+const SUCCESS_STATUS_CODES = [200, 201, 202, 203, 206, 207, 208, 226]
+
+function isSseBodyDescriptor(value: unknown): boolean {
+  return (
+    typeof value === 'object' && value !== null && (value as { _tag?: unknown })._tag === 'SseBody'
+  )
+}
+
+type ResponseShape = { hasSse: boolean; hasNonSse: boolean }
+
+function inspectResponseEntry(entry: unknown, shape: ResponseShape): void {
+  const content = (entry as { content?: Record<string, unknown> }).content
+  if (!content || typeof content !== 'object') {
+    // A bare schema entry is a JSON response.
+    shape.hasNonSse = true
+    return
+  }
+  for (const descriptor of Object.values(content)) {
+    if (isSseBodyDescriptor(descriptor)) shape.hasSse = true
+    else shape.hasNonSse = true
+  }
+  if ((entry as { allowNoBody?: boolean }).allowNoBody) shape.hasNonSse = true
+}
+
+function inspectApiContractResponses(contract: ContractLike): ResponseShape {
+  const shape: ResponseShape = { hasSse: false, hasNonSse: false }
+  for (const code of SUCCESS_STATUS_CODES) {
+    const entry = contract.responsesByStatusCode?.[String(code)]
+    if (entry !== undefined) {
+      inspectResponseEntry(entry, shape)
+    }
+  }
+  return shape
+}
+
+function validateConfig(config: FallbackBindingConfig<never, EventPayloadMap, unknown>): void {
+  const hasMapper = config.snapshotToEvents !== undefined
+  const hasShorthand = config.snapshotEvent !== undefined
+  if (hasMapper === hasShorthand) {
+    throw new Error(
+      'FallbackBindingConfig requires exactly one of snapshotToEvents / snapshotEvent.',
+    )
+  }
+}
+
+/** Expand the `snapshotEvent` shorthand into `snapshotToEvents`. */
+function normalizeConfig<Snapshot, Events extends EventPayloadMap, State>(
+  config: FallbackBindingConfig<Snapshot, Events, State>,
+): FallbackBindingConfig<Snapshot, Events, State> {
+  validateConfig(config as FallbackBindingConfig<never, EventPayloadMap, unknown>)
+  if (config.snapshotEvent === undefined) return config
+  const eventName = config.snapshotEvent
+  return {
+    ...config,
+    snapshotToEvents: (snapshot) => [
+      { event: eventName, data: snapshot as Events[typeof eventName] },
+    ],
+  }
+}
+
+function stringifyQuery(
+  queryParams: FallbackRequestParams['queryParams'],
+): Record<string, string> | undefined {
+  if (!queryParams) return undefined
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(queryParams)) {
+    if (value === undefined) continue
+    out[key] = String(value)
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function buildRequest(contract: ContractLike, params: FallbackRequestParams): TransportRequest {
+  return {
+    path: contract.pathResolver(params.pathParams ?? {}),
+    method: contract.method,
+    ...(stringifyQuery(params.queryParams) ? { query: stringifyQuery(params.queryParams) } : {}),
+    ...(params.headers ? { headers: params.headers } : {}),
+    ...(params.body !== undefined ? { body: params.body } : {}),
+  }
+}
+
+function stampBinding(contract: object, binding: object): void {
+  Object.defineProperty(contract, FALLBACK_BINDING_SYMBOL, {
+    value: binding,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  })
+}
+
+/** Read a binding previously stamped on a contract, or `undefined`. */
+export function readFallbackBinding(contract: object): FallbackBinding | undefined {
+  return (contract as Record<symbol, FallbackBinding | undefined>)[FALLBACK_BINDING_SYMBOL]
+}
+
+// ============================================================================
+// Primary form: one dual-mode contract IS the binding
+// ============================================================================
+
+/**
+ * Declare a fallback binding on a dual-mode `defineApiContract` contract —
+ * one path serving JSON (the poll) and SSE (the push) via Accept
+ * negotiation. Snapshot and event types are inferred from the contract.
+ *
+ * @example
+ * ```ts
+ * export const uploadStatusBinding = defineFallbackBinding(uploadStatusContract, {
+ *   snapshotToEvents: (s) =>
+ *     s.status === 'completed' ? [{ event: 'uploadFinished', data: { result: s.result } }] : [],
+ *   version: { ofSnapshot: (s) => s.version },
+ *   terminalEvents: ['uploadFinished', 'uploadFailed'],
+ * })
+ * ```
+ */
+export function defineFallbackBinding<
+  TContract extends { method: string; pathResolver: (p: never) => string },
+  Snapshot = InferContractSnapshot<TContract>,
+  Events extends EventPayloadMap = InferContractEvents<TContract>,
+  State = undefined,
+>(
+  contract: TContract,
+  // NoInfer: Snapshot/Events come from the CONTRACT (via the defaults), never
+  // widened from whatever the config functions happen to mention.
+  config: FallbackBindingConfig<NoInfer<Snapshot>, NoInfer<Events>, State>,
+): FallbackBinding<Snapshot, Events, State> {
+  const contractLike = contract as unknown as ContractLike
+  const shape = inspectApiContractResponses(contractLike)
+  const isLegacyDual = contractLike.isDualMode === true
+  if (!isLegacyDual && !(shape.hasSse && shape.hasNonSse)) {
+    throw new Error(
+      'defineFallbackBinding requires a dual-mode contract (a success response with both an SSE and a non-SSE representation). ' +
+        'For separate poll/stream contracts use bindFallbackContracts; for legacy dual-mode contracts use fromLegacyDualModeContract.',
+    )
+  }
+
+  const normalized = normalizeConfig(config)
+  const binding: FallbackBinding<Snapshot, Events, State> = {
+    config: normalized,
+    buildSnapshotRequest: (params) => buildRequest(contractLike, params),
+    buildStreamRequest: (params) => buildRequest(contractLike, params),
+  }
+  stampBinding(contract, binding)
+  return binding
+}
+
+// ============================================================================
+// Escape hatch: two separate contracts
+// ============================================================================
+
+export type BindFallbackContractsOptions<Snapshot, Events extends EventPayloadMap, State> = {
+  /**
+   * Map the subscription params onto each contract's params when their
+   * request shapes differ. Defaults to passing params through unchanged.
+   */
+  mapParams?: {
+    toSnapshot?: (params: FallbackRequestParams) => FallbackRequestParams
+    toStream?: (params: FallbackRequestParams) => FallbackRequestParams
+  }
+} & FallbackBindingConfig<Snapshot, Events, State>
+
+/**
+ * Escape hatch: bind two PRE-EXISTING contracts — a plain REST contract (the
+ * poll) and an SSE contract (the push) on different paths. Prefer the
+ * single dual-mode contract form (`defineFallbackBinding`) for new
+ * endpoints: one contract cannot drift against itself.
+ */
+export function bindFallbackContracts<
+  TPoll extends { method: string; pathResolver: (p: never) => string },
+  TStream extends { method: string; pathResolver: (p: never) => string },
+  Snapshot = InferContractSnapshot<TPoll>,
+  Events extends EventPayloadMap = [InferContractEvents<TStream>] extends [never]
+    ? InferLegacyEvents<TStream>
+    : InferContractEvents<TStream>,
+  State = undefined,
+>(
+  poll: TPoll,
+  stream: TStream,
+  options: BindFallbackContractsOptions<NoInfer<Snapshot>, NoInfer<Events>, State>,
+): FallbackBinding<Snapshot, Events, State> {
+  const pollLike = poll as unknown as ContractLike
+  const streamLike = stream as unknown as ContractLike
+
+  const pollShape = inspectApiContractResponses(pollLike)
+  if (pollShape.hasSse) {
+    throw new Error(
+      'bindFallbackContracts: the poll contract must be a plain (non-SSE) contract — its SSE responses would never be used.',
+    )
+  }
+  const streamShape = inspectApiContractResponses(streamLike)
+  const streamIsLegacySse =
+    streamLike.isSSE === true ||
+    streamLike.isDualMode === true ||
+    streamLike.serverSentEventSchemas !== undefined
+  if (!streamShape.hasSse && !streamIsLegacySse) {
+    throw new Error(
+      'bindFallbackContracts: the stream contract must declare an SSE success response.',
+    )
+  }
+
+  const { mapParams, ...config } = options
+  const normalized = normalizeConfig(config as FallbackBindingConfig<Snapshot, Events, State>)
+  const toSnapshot = mapParams?.toSnapshot ?? ((params: FallbackRequestParams) => params)
+  const toStream = mapParams?.toStream ?? ((params: FallbackRequestParams) => params)
+
+  const binding: FallbackBinding<Snapshot, Events, State> = {
+    config: normalized,
+    buildSnapshotRequest: (params) => buildRequest(pollLike, toSnapshot(params)),
+    buildStreamRequest: (params) => buildRequest(streamLike, toStream(params)),
+  }
+  stampBinding(poll, binding)
+  stampBinding(stream, binding)
+  return binding
+}
+
+// ============================================================================
+// Legacy adapter
+// ============================================================================
+
+/**
+ * Declare a fallback binding on a legacy `buildSseContract` dual-mode
+ * contract (`successResponseBodySchema` + `serverSentEventSchemas`).
+ */
+export function fromLegacyDualModeContract<
+  TContract extends {
+    method: string
+    pathResolver: (p: never) => string
+    isDualMode: boolean
+  },
+  Snapshot = InferLegacySnapshot<TContract>,
+  Events extends EventPayloadMap = InferLegacyEvents<TContract>,
+  State = undefined,
+>(
+  contract: TContract,
+  config: FallbackBindingConfig<NoInfer<Snapshot>, NoInfer<Events>, State>,
+): FallbackBinding<Snapshot, Events, State> {
+  if (contract.isDualMode !== true) {
+    throw new Error(
+      'fromLegacyDualModeContract requires a legacy dual-mode contract (buildSseContract with successResponseBodySchema).',
+    )
+  }
+  const contractLike = contract as unknown as ContractLike
+  const normalized = normalizeConfig(config)
+  const binding: FallbackBinding<Snapshot, Events, State> = {
+    config: normalized,
+    buildSnapshotRequest: (params) => buildRequest(contractLike, params),
+    buildStreamRequest: (params) => buildRequest(contractLike, params),
+  }
+  stampBinding(contract, binding)
+  return binding
+}

--- a/packages/sse-fallback/src/bindingTypes.ts
+++ b/packages/sse-fallback/src/bindingTypes.ts
@@ -1,0 +1,298 @@
+/**
+ * Type layer for fallback bindings.
+ *
+ * Everything here is type-only or plain data — the package has no runtime
+ * dependencies. Zod and @lokalise/api-contracts appear as type-only imports
+ * (optional peers); runtime introspection of contracts is structural.
+ */
+import type { z } from 'zod/v4'
+
+// ============================================================================
+// Version handling
+// ============================================================================
+
+/** A comparable version: a monotonic number or a comparable string. */
+export type Version = number | string
+
+/**
+ * Declares how versions are extracted and ordered.
+ *
+ * The version is the correctness backbone of the fallback pattern: a single
+ * "deliver iff newer than the high-watermark" rule handles duplicate delivery
+ * (SSE + poll of the same update), the stale-poll race (a slow poll response
+ * arriving after a newer pushed event), and replay overlap after reconnect.
+ */
+export type VersionConfig<Snapshot, Event> =
+  | {
+      /** Extract the version from a poll snapshot body. */
+      ofSnapshot: (snapshot: Snapshot) => Version
+      /**
+       * Extract the version from a delivered event. Defaults to
+       * `Number(event.id)` when the SSE id is numeric — pair with the
+       * server-side `createEventIdSequence` or stamp ids explicitly.
+       * Return `undefined` for events that carry no version — they are
+       * delivered without advancing the watermark (at-least-once).
+       */
+      ofEvent?: (event: Event) => Version | undefined
+      /** Custom comparator. Defaults to numeric, falling back to lexicographic. */
+      compare?: (a: Version, b: Version) => number
+      /**
+       * Versions are consecutive integers per subscription scope. Enables
+       * client-side gap detection (seq N then N+2 → a repair poll is issued
+       * immediately instead of waiting for the deadman timer).
+       * @default false
+       */
+      dense?: boolean
+    }
+  /**
+   * Versionless mode: at-least-once, last-writer-wins. No dedup between
+   * channels beyond subscription termination, no gap detection, and the
+   * state layer is limited to full snapshot replacement. An adoption bridge
+   * for backends without versions — strongly prefer declaring versions.
+   */
+  | 'none'
+
+// ============================================================================
+// Events
+// ============================================================================
+
+/** Maps event name → parsed payload type. */
+export type EventPayloadMap = Record<string, unknown>
+
+/** An event as delivered to app code, regardless of the channel it used. */
+export type FallbackEvent<Events extends EventPayloadMap = EventPayloadMap> = {
+  [K in keyof Events & string]: {
+    event: K
+    data: Events[K]
+    /** SSE id when the event arrived over the stream. */
+    id?: string
+    /**
+     * Which channel produced the event. Present for observability — app
+     * logic SHOULD ignore it; channel transparency is the whole point.
+     */
+    origin: FallbackEventOrigin
+  }
+}[keyof Events & string]
+
+export type FallbackEventOrigin = 'sse' | 'poll'
+
+/** An event synthesized from a snapshot by `snapshotToEvents`. */
+export type SyntheticEvent<Events extends EventPayloadMap = EventPayloadMap> = {
+  [K in keyof Events & string]: { event: K; data: Events[K] }
+}[keyof Events & string]
+
+// ============================================================================
+// The binding configuration
+// ============================================================================
+
+/**
+ * Reconciliation + policy declaration for one dual-mode (or bound-pair)
+ * subscription. This is the one thing the framework cannot infer: how a REST
+ * snapshot relates to the SSE events. Everything downstream of this
+ * declaration — racing, canceling, dedup, reconnect, degradation — is
+ * transparent to app code.
+ */
+export type FallbackBindingConfig<Snapshot, Events extends EventPayloadMap, State = undefined> = {
+  /**
+   * Translate a poll snapshot into zero or more events, making poll results
+   * indistinguishable from pushed events for app code. Must be PURE — a
+   * function of the snapshot alone. Return `[]` when the snapshot carries no
+   * news (e.g. a job still pending); the poll still advances the watermark.
+   *
+   * Exactly one of `snapshotToEvents` / `snapshotEvent` is required.
+   */
+  snapshotToEvents?: (snapshot: Snapshot) => ReadonlyArray<SyntheticEvent<Events>>
+  /**
+   * Shorthand for the common case where the JSON snapshot body IS the
+   * payload of one state-carrying event: expands to
+   * `snapshotToEvents: (s) => [{ event: snapshotEvent, data: s }]`.
+   */
+  snapshotEvent?: keyof Events & string
+
+  /** Version extraction/ordering, or `'none'` (see {@link VersionConfig}). */
+  version: VersionConfig<Snapshot, FallbackEvent<Events>>
+
+  /**
+   * Events whose delivery completes the subscription (use case: await async
+   * completion). Timers are cancelled, in-flight requests aborted, and
+   * `events()` iterators complete.
+   */
+  terminalEvents?: ReadonlyArray<keyof Events & string>
+
+  /**
+   * Optional state layer (use case: initial load + hydration). When present,
+   * the subscription handle exposes `getState()` / `onStateChange()`.
+   * Snapshots REPLACE state via `init`; live events update it via `apply`.
+   * Events synthesized from a snapshot are not applied (the snapshot already
+   * subsumes them).
+   */
+  state?: {
+    init: (snapshot: Snapshot) => State
+    apply: (state: State, event: FallbackEvent<Events>) => State
+    /**
+     * On gap detection (dense versions): suppress `apply` until the next
+     * snapshot re-initializes state, so deltas are never applied out of
+     * order. Events still flow to event listeners.
+     * @default true
+     */
+    reinitOnGap?: boolean
+  }
+
+  /**
+   * Whether the server's Last-Event-ID replay is complete ('trusted') —
+   * skipping the reconciliation poll after a reconnect — or best-effort
+   * ('untrusted', default) — always polling after the stream reopens.
+   * @default 'untrusted'
+   */
+  replay?: 'trusted' | 'untrusted'
+
+  /** Per-binding policy defaults; overridable per subscription. */
+  policy?: Partial<FallbackPolicy>
+}
+
+// ============================================================================
+// Policy
+// ============================================================================
+
+export type BackoffConfig = {
+  baseMs: number
+  factor: number
+  maxMs: number
+}
+
+export type FallbackPolicy = {
+  /**
+   * Initial snapshot poll behavior:
+   * - `'eager'` (default): fetch a snapshot as soon as the stream opens
+   *   (hydration; also closes the startup race where the awaited activity
+   *   completed before the stream was established).
+   * - `'delayed'`: no initial poll; the first poll happens when the deadman
+   *   timer fires.
+   * - `'none'`: same as 'delayed' (kept distinct for future use).
+   */
+  initialPoll: 'eager' | 'delayed' | 'none'
+  /**
+   * Deadman delay: how long after the last DATA EVENT (heartbeats do not
+   * count — they prove transport liveness, not delivery) before a
+   * reconciliation poll fires.
+   */
+  deadmanDelayMs: number
+  /** Consecutive no-news polls stretch the deadman interval. */
+  deadmanIdleBackoff: { factor: number; maxMs: number }
+  /**
+   * Force-close the stream when NO BYTES (events, comments, heartbeats)
+   * arrive within this window — catches silently dead connections.
+   * `'off'` disables byte-level liveness (rely on the deadman alone).
+   */
+  staleConnectionTimeoutMs: number | 'off'
+  /** Backoff (full jitter) for failed polls. */
+  pollFailureBackoff: BackoffConfig
+  /** Backoff (full jitter) for SSE reconnect attempts; `retry:` hints override the base. */
+  sseRetryBackoff: BackoffConfig
+  /** Consecutive SSE connect failures before degrading to POLLING_ONLY. */
+  degradedAfterFailures: number
+  /** Poll cadence while degraded (SSE unavailable). */
+  degradedPollIntervalMs: number
+  /** Cap for background SSE retry while degraded. */
+  degradedSseRetryMaxMs: number
+  /** Max events buffered during hydration; overflow drops the buffer and refetches. */
+  hydrationBufferLimit: number
+  /**
+   * HTTP statuses on the stream or poll that stop the subscription instead
+   * of retrying (auth/authz/not-found are not transient).
+   */
+  unretryableStatuses: ReadonlyArray<number>
+}
+
+export const DEFAULT_POLICY: FallbackPolicy = {
+  initialPoll: 'eager',
+  deadmanDelayMs: 10_000,
+  deadmanIdleBackoff: { factor: 1.5, maxMs: 60_000 },
+  staleConnectionTimeoutMs: 60_000,
+  pollFailureBackoff: { baseMs: 1_000, factor: 2, maxMs: 30_000 },
+  sseRetryBackoff: { baseMs: 1_000, factor: 2, maxMs: 30_000 },
+  degradedAfterFailures: 3,
+  degradedPollIntervalMs: 15_000,
+  degradedSseRetryMaxMs: 60_000,
+  hydrationBufferLimit: 1_000,
+  unretryableStatuses: [401, 403, 404],
+}
+
+/** Preset for use case A — await async completion. */
+export const COMPLETION_POLICY: FallbackPolicy = DEFAULT_POLICY
+
+/** Preset for use case B — initial state load + live hydration. */
+export const LIVE_STATE_POLICY: FallbackPolicy = {
+  ...DEFAULT_POLICY,
+  deadmanDelayMs: 120_000,
+  deadmanIdleBackoff: { factor: 1.5, maxMs: 300_000 },
+  degradedPollIntervalMs: 60_000,
+}
+
+// ============================================================================
+// Contract type inference (type-only; structural)
+// ============================================================================
+
+type SseBodyLike<TSchemas> = { readonly _tag: 'SseBody'; readonly schemaByEventName: TSchemas }
+
+type EventsFromSchemaMap<TSchemas> = {
+  [K in keyof TSchemas]: TSchemas[K] extends z.ZodType ? z.output<TSchemas[K]> : never
+}
+
+type SseEventsOfContentMap<TContent> = {
+  [K in keyof TContent]: TContent[K] extends SseBodyLike<infer TSchemas>
+    ? EventsFromSchemaMap<TSchemas>
+    : never
+}[keyof TContent]
+
+type NonSseBodyOfContentMap<TContent> = {
+  [K in keyof TContent]: TContent[K] extends SseBodyLike<unknown>
+    ? never
+    : TContent[K] extends z.ZodType
+      ? z.output<TContent[K]>
+      : never
+}[keyof TContent]
+
+type SuccessStatusKey = 200 | 201 | 202 | 203 | 206 | 207 | 208 | 226
+
+type SuccessEntries<TContract> = TContract extends {
+  responsesByStatusCode: infer TResponses
+}
+  ? TResponses[Extract<keyof TResponses, SuccessStatusKey>]
+  : never
+
+/** Event payload map inferred from a `defineApiContract` contract's sseBody. */
+export type InferContractEvents<TContract> = Extract<
+  SuccessEntries<TContract> extends infer TEntry
+    ? TEntry extends { content: infer TContent }
+      ? SseEventsOfContentMap<TContent>
+      : never
+    : never,
+  EventPayloadMap
+>
+
+/** Snapshot (non-SSE JSON success body) inferred from a `defineApiContract` contract. */
+export type InferContractSnapshot<TContract> =
+  SuccessEntries<TContract> extends infer TEntry
+    ? TEntry extends { content: infer TContent }
+      ? NonSseBodyOfContentMap<TContent>
+      : TEntry extends z.ZodType
+        ? z.output<TEntry>
+        : never
+    : never
+
+/** Event payload map inferred from a legacy `buildSseContract` dual-mode contract. */
+export type InferLegacyEvents<TContract> = TContract extends {
+  serverSentEventSchemas: infer TSchemas
+}
+  ? EventsFromSchemaMap<TSchemas>
+  : never
+
+/** Snapshot inferred from a legacy dual-mode contract's success schema. */
+export type InferLegacySnapshot<TContract> = TContract extends {
+  successResponseBodySchema: infer TSchema
+}
+  ? TSchema extends z.ZodType
+    ? z.output<TSchema>
+    : never
+  : never

--- a/packages/sse-fallback/src/index.ts
+++ b/packages/sse-fallback/src/index.ts
@@ -1,0 +1,57 @@
+export {
+  type BindFallbackContractsOptions,
+  bindFallbackContracts,
+  defineFallbackBinding,
+  FALLBACK_BINDING_SYMBOL,
+  type FallbackBinding,
+  type FallbackRequestParams,
+  fromLegacyDualModeContract,
+  readFallbackBinding,
+} from './binding.ts'
+export {
+  type BackoffConfig,
+  COMPLETION_POLICY,
+  DEFAULT_POLICY,
+  type EventPayloadMap,
+  type FallbackBindingConfig,
+  type FallbackEvent,
+  type FallbackEventOrigin,
+  type FallbackPolicy,
+  type InferContractEvents,
+  type InferContractSnapshot,
+  type InferLegacyEvents,
+  type InferLegacySnapshot,
+  LIVE_STATE_POLICY,
+  type SyntheticEvent,
+  type Version,
+  type VersionConfig,
+} from './bindingTypes.ts'
+export {
+  defaultCompareVersions,
+  type EventOutcome,
+  type IncomingEvent,
+  Reconciler,
+  type SnapshotOutcome,
+} from './reconciler.ts'
+export { backoffDelay, ResettableTimer, sleep } from './scheduler.ts'
+export {
+  type ParsedSSEEvent,
+  type ParseSSEBufferResult,
+  parseSSEBuffer,
+} from './sseParser.ts'
+export {
+  type CreateResilientSubscriptionOptions,
+  createResilientSubscription,
+  type FallbackDiagnostics,
+  type ResilientSubscription,
+  type SubscriptionStatus,
+} from './subscription.ts'
+export {
+  type FallbackTransport,
+  type SnapshotResponse,
+  type StreamResponse,
+  type TestSnapshotCall,
+  type TestStreamHandle,
+  TestTransport,
+  type TransportRequest,
+} from './transport.ts'

--- a/packages/sse-fallback/src/reconciler.spec.ts
+++ b/packages/sse-fallback/src/reconciler.spec.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from 'vitest'
+import type { FallbackBindingConfig } from './bindingTypes.ts'
+import { defaultCompareVersions, Reconciler } from './reconciler.ts'
+
+type JobSnapshot = { status: 'pending' | 'completed'; result?: string; version: number }
+type JobEvents = {
+  progress: { percent: number }
+  done: { result: string }
+}
+
+const jobConfig: FallbackBindingConfig<JobSnapshot, JobEvents> = {
+  snapshotToEvents: (s) =>
+    s.status === 'completed' ? [{ event: 'done', data: { result: s.result as string } }] : [],
+  version: { ofSnapshot: (s) => s.version },
+  terminalEvents: ['done'],
+}
+
+function jobReconciler(overrides?: Partial<FallbackBindingConfig<JobSnapshot, JobEvents>>) {
+  return new Reconciler({ ...jobConfig, ...overrides }, { hydrationBufferLimit: 3 })
+}
+
+describe('Reconciler — version gate', () => {
+  it('delivers events with increasing versions and advances the watermark', () => {
+    const reconciler = jobReconciler()
+    const first = reconciler.handleEvent({ event: 'progress', data: { percent: 10 }, id: '1' })
+    const second = reconciler.handleEvent({ event: 'progress', data: { percent: 20 }, id: '2' })
+
+    expect(first.deliveries).toHaveLength(1)
+    expect(second.deliveries).toHaveLength(1)
+    expect(first.duplicate).toBe(false)
+    expect(second.duplicate).toBe(false)
+  })
+
+  it('drops events at or below the watermark (duplicate delivery)', () => {
+    const reconciler = jobReconciler()
+    reconciler.handleEvent({ event: 'progress', data: { percent: 20 }, id: '2' })
+
+    const replayOfOlder = reconciler.handleEvent({
+      event: 'progress',
+      data: { percent: 10 },
+      id: '1',
+    })
+    const replayOfSame = reconciler.handleEvent({
+      event: 'progress',
+      data: { percent: 20 },
+      id: '2',
+    })
+
+    expect(replayOfOlder.duplicate).toBe(true)
+    expect(replayOfOlder.deliveries).toHaveLength(0)
+    expect(replayOfSame.duplicate).toBe(true)
+  })
+
+  it('drops a stale snapshot arriving after a newer event (the stale-poll race)', () => {
+    const reconciler = jobReconciler()
+    // SSE delivered version 10 while a poll was in flight...
+    reconciler.handleEvent({ event: 'progress', data: { percent: 99 }, id: '10' })
+    // ...and the slow poll response describes version 9.
+    const outcome = reconciler.handleSnapshot({ status: 'completed', result: 'STALE', version: 9 })
+
+    expect(outcome.stale).toBe(true)
+    expect(outcome.deliveries).toHaveLength(0)
+    expect(outcome.terminated).toBe(false)
+  })
+
+  it('advances the watermark on a snapshot with no synthesized events', () => {
+    const reconciler = jobReconciler()
+    const pending = reconciler.handleSnapshot({ status: 'pending', version: 5 })
+    expect(pending.deliveries).toHaveLength(0)
+    expect(pending.advanced).toBe(true)
+
+    // The poll proved state at v5 — older events must now be droppable.
+    const older = reconciler.handleEvent({ event: 'progress', data: { percent: 10 }, id: '4' })
+    expect(older.duplicate).toBe(true)
+  })
+
+  it('delivers events without extractable versions but does not advance the watermark', () => {
+    const reconciler = jobReconciler()
+    reconciler.handleEvent({ event: 'progress', data: { percent: 10 }, id: '3' })
+
+    const unversioned = reconciler.handleEvent({ event: 'progress', data: { percent: 11 } })
+    expect(unversioned.deliveries).toHaveLength(1)
+
+    // Watermark unchanged: id 3 is still the high-water mark.
+    const older = reconciler.handleEvent({ event: 'progress', data: { percent: 9 }, id: '2' })
+    expect(older.duplicate).toBe(true)
+  })
+})
+
+describe('Reconciler — terminal events', () => {
+  it('terminates on a pushed terminal event and drops everything after', () => {
+    const reconciler = jobReconciler()
+    const done = reconciler.handleEvent({ event: 'done', data: { result: 'ok' }, id: '5' })
+    expect(done.terminated).toBe(true)
+
+    const late = reconciler.handleEvent({ event: 'progress', data: { percent: 100 }, id: '6' })
+    expect(late.deliveries).toHaveLength(0)
+    const lateSnapshot = reconciler.handleSnapshot({
+      status: 'completed',
+      result: 'ok',
+      version: 7,
+    })
+    expect(lateSnapshot.deliveries).toHaveLength(0)
+  })
+
+  it('terminates on a poll-synthesized terminal event (transparent completion)', () => {
+    const reconciler = jobReconciler()
+    const outcome = reconciler.handleSnapshot({ status: 'completed', result: 'ok', version: 3 })
+    expect(outcome.deliveries).toEqual([{ event: 'done', data: { result: 'ok' }, origin: 'poll' }])
+    expect(outcome.terminated).toBe(true)
+  })
+})
+
+describe('Reconciler — hydration (subscribe-first, buffer, fetch)', () => {
+  it('buffers events during hydration and flushes only those newer than the snapshot', () => {
+    const reconciler = jobReconciler()
+    reconciler.beginHydration()
+
+    // Live events arrive while the snapshot fetch is in flight.
+    expect(
+      reconciler.handleEvent({ event: 'progress', data: { percent: 40 }, id: '4' }).buffered,
+    ).toBe(true)
+    expect(
+      reconciler.handleEvent({ event: 'progress', data: { percent: 60 }, id: '6' }).buffered,
+    ).toBe(true)
+
+    // Snapshot at version 5: subsumes v4, is older than v6.
+    const outcome = reconciler.handleSnapshot({ status: 'pending', version: 5 })
+    expect(outcome.hydrationCompleted).toBe(true)
+    expect(outcome.deliveries).toEqual([
+      { event: 'progress', data: { percent: 60 }, id: '6', origin: 'sse' },
+    ])
+  })
+
+  it('reports overflow so the caller can drop-and-refetch', () => {
+    const reconciler = jobReconciler() // hydrationBufferLimit: 3
+    reconciler.beginHydration()
+    for (let i = 1; i <= 3; i++) {
+      reconciler.handleEvent({ event: 'progress', data: { percent: i }, id: String(i) })
+    }
+    const overflowing = reconciler.handleEvent({ event: 'progress', data: { percent: 4 }, id: '4' })
+    expect(overflowing.bufferOverflow).toBe(true)
+    expect(reconciler.isHydrating).toBe(true)
+
+    // A later snapshot still completes hydration.
+    const outcome = reconciler.handleSnapshot({ status: 'pending', version: 10 })
+    expect(outcome.hydrationCompleted).toBe(true)
+  })
+})
+
+describe('Reconciler — gap detection (dense versions)', () => {
+  it('detects a sequence gap, still delivers the newer event, never regresses', () => {
+    const reconciler = jobReconciler({
+      version: { ofSnapshot: (s) => s.version, dense: true },
+    })
+    reconciler.handleEvent({ event: 'progress', data: { percent: 10 }, id: '1' })
+    const gapped = reconciler.handleEvent({ event: 'progress', data: { percent: 30 }, id: '3' })
+
+    expect(gapped.gap).toEqual({ from: 1, to: 3 })
+    expect(gapped.deliveries).toHaveLength(1)
+
+    // Watermark is 3 — the missing 2 can no longer sneak in.
+    const missing = reconciler.handleEvent({ event: 'progress', data: { percent: 20 }, id: '2' })
+    expect(missing.duplicate).toBe(true)
+  })
+
+  it('does not flag consecutive versions as gaps', () => {
+    const reconciler = jobReconciler({
+      version: { ofSnapshot: (s) => s.version, dense: true },
+    })
+    reconciler.handleEvent({ event: 'progress', data: { percent: 10 }, id: '1' })
+    const next = reconciler.handleEvent({ event: 'progress', data: { percent: 20 }, id: '2' })
+    expect(next.gap).toBeUndefined()
+  })
+})
+
+describe('Reconciler — state layer', () => {
+  type CounterState = { revision: number; items: string[] }
+  type CounterSnapshot = { revision: number; items: string[] }
+  type CounterEvents = { itemAdded: { revision: number; item: string } }
+
+  const stateConfig: FallbackBindingConfig<CounterSnapshot, CounterEvents, CounterState> = {
+    snapshotEvent: undefined,
+    snapshotToEvents: () => [],
+    version: {
+      ofSnapshot: (s) => s.revision,
+      ofEvent: (e) => e.data.revision,
+      dense: true,
+    },
+    state: {
+      init: (s) => ({ revision: s.revision, items: [...s.items] }),
+      apply: (state, e) => ({
+        revision: e.data.revision,
+        items: [...state.items, e.data.item],
+      }),
+    },
+  }
+
+  function stateReconciler() {
+    return new Reconciler(stateConfig, { hydrationBufferLimit: 10 })
+  }
+
+  it('initializes state from a snapshot and applies live deltas', () => {
+    const reconciler = stateReconciler()
+    reconciler.handleSnapshot({ revision: 1, items: ['a'] })
+    reconciler.handleEvent({ event: 'itemAdded', data: { revision: 2, item: 'b' } })
+
+    expect(reconciler.getState()).toEqual({ revision: 2, items: ['a', 'b'] })
+  })
+
+  it('replaces (not merges) state on a newer snapshot', () => {
+    const reconciler = stateReconciler()
+    reconciler.handleSnapshot({ revision: 1, items: ['a'] })
+    reconciler.handleEvent({ event: 'itemAdded', data: { revision: 2, item: 'b' } })
+    reconciler.handleSnapshot({ revision: 5, items: ['fresh'] })
+
+    expect(reconciler.getState()).toEqual({ revision: 5, items: ['fresh'] })
+  })
+
+  it('suspends delta application across a gap until the repair snapshot', () => {
+    const reconciler = stateReconciler()
+    reconciler.handleSnapshot({ revision: 1, items: ['a'] })
+
+    // revision 3 arrives without revision 2 — applying it would corrupt state.
+    const gapped = reconciler.handleEvent({ event: 'itemAdded', data: { revision: 3, item: 'c' } })
+    expect(gapped.gap).toBeDefined()
+    // Event still flows to event listeners...
+    expect(gapped.deliveries).toHaveLength(1)
+    // ...but state was NOT advanced past the gap.
+    expect(reconciler.getState()).toEqual({ revision: 1, items: ['a'] })
+
+    // The repair snapshot re-initializes state and lifts the suspension.
+    reconciler.handleSnapshot({ revision: 3, items: ['a', 'b', 'c'] })
+    expect(reconciler.getState()).toEqual({ revision: 3, items: ['a', 'b', 'c'] })
+    reconciler.handleEvent({ event: 'itemAdded', data: { revision: 4, item: 'd' } })
+    expect(reconciler.getState()).toEqual({ revision: 4, items: ['a', 'b', 'c', 'd'] })
+  })
+
+  it('does not double-apply snapshot-synthesized events to state', () => {
+    type SnapEvents = { stateChanged: CounterSnapshot }
+    const reconciler = new Reconciler<CounterSnapshot, SnapEvents, CounterState>(
+      {
+        snapshotEvent: 'stateChanged',
+        version: { ofSnapshot: (s) => s.revision },
+        state: {
+          init: (s) => ({ revision: s.revision, items: [...s.items] }),
+          apply: (state) => {
+            throw new Error(
+              `apply must not run for synthesized events (state rev ${state.revision})`,
+            )
+          },
+        },
+      },
+      { hydrationBufferLimit: 10 },
+    )
+
+    const outcome = reconciler.handleSnapshot({ revision: 1, items: ['a'] })
+    expect(outcome.deliveries).toEqual([
+      { event: 'stateChanged', data: { revision: 1, items: ['a'] }, origin: 'poll' },
+    ])
+    expect(reconciler.getState()).toEqual({ revision: 1, items: ['a'] })
+  })
+})
+
+describe('Reconciler — versionless mode', () => {
+  it('delivers everything at-least-once and relies on termination for dedup', () => {
+    const reconciler = new Reconciler<JobSnapshot, JobEvents, undefined>(
+      { ...jobConfig, version: 'none' },
+      { hydrationBufferLimit: 10 },
+    )
+    const first = reconciler.handleEvent({ event: 'progress', data: { percent: 10 } })
+    const repeat = reconciler.handleEvent({ event: 'progress', data: { percent: 10 } })
+    expect(first.deliveries).toHaveLength(1)
+    expect(repeat.deliveries).toHaveLength(1) // at-least-once: no gate
+
+    const done = reconciler.handleSnapshot({ status: 'completed', result: 'ok', version: 0 })
+    expect(done.terminated).toBe(true)
+    // The duplicate terminal from the other channel is dropped by termination.
+    const lateDone = reconciler.handleEvent({ event: 'done', data: { result: 'ok' } })
+    expect(lateDone.deliveries).toHaveLength(0)
+  })
+})
+
+describe('defaultCompareVersions', () => {
+  it('compares numbers numerically', () => {
+    expect(defaultCompareVersions(2, 10)).toBe(-1)
+    expect(defaultCompareVersions(10, 2)).toBe(1)
+    expect(defaultCompareVersions(5, 5)).toBe(0)
+  })
+
+  it('compares numeric strings numerically (avoids "10" < "2")', () => {
+    expect(defaultCompareVersions('2', '10')).toBe(-1)
+    expect(defaultCompareVersions('10', '2')).toBe(1)
+  })
+
+  it('falls back to lexicographic for non-numeric strings', () => {
+    expect(defaultCompareVersions('a', 'b')).toBe(-1)
+    expect(defaultCompareVersions('b', 'a')).toBe(1)
+    expect(defaultCompareVersions('a', 'a')).toBe(0)
+  })
+})

--- a/packages/sse-fallback/src/reconciler.ts
+++ b/packages/sse-fallback/src/reconciler.ts
@@ -1,0 +1,342 @@
+import type {
+  EventPayloadMap,
+  FallbackBindingConfig,
+  FallbackEvent,
+  Version,
+} from './bindingTypes.ts'
+
+/**
+ * The reconciler is the pure correctness core of the fallback pattern: a
+ * version-gated event pipeline with a high-watermark, hydration buffering,
+ * and gap detection. It owns NO timers and NO transport — the subscription
+ * wires those around it — which keeps every race testable synchronously.
+ *
+ * The single delivery rule: an item (event or snapshot) with version `v` is
+ * delivered iff `v` is greater than the high-watermark; delivery advances
+ * the watermark. That one rule simultaneously handles duplicate delivery
+ * (SSE event + poll snapshot of the same update), the stale-poll race (a
+ * slow poll response arriving AFTER a newer pushed event is dropped at
+ * arrival time), and replay overlap after reconnection.
+ */
+
+export type IncomingEvent = {
+  event: string
+  data: unknown
+  id?: string
+}
+
+export type EventOutcome<Events extends EventPayloadMap> = {
+  deliveries: Array<FallbackEvent<Events>>
+  /** Event was at/below the watermark and dropped. */
+  duplicate: boolean
+  /** Event was buffered (hydration in progress). */
+  buffered: boolean
+  /** Hydration buffer overflowed — caller must refetch the snapshot. */
+  bufferOverflow: boolean
+  /** A sequence gap was detected (dense versions) — caller should poll now. */
+  gap?: { from: Version; to: Version }
+  /** A terminal event was delivered — the subscription is complete. */
+  terminated: boolean
+  /** New state value when the state layer applied the event. */
+  state?: { value: unknown }
+}
+
+export type SnapshotOutcome<Events extends EventPayloadMap> = {
+  deliveries: Array<FallbackEvent<Events>>
+  /** Snapshot was at/below the watermark and dropped entirely. */
+  stale: boolean
+  /** The watermark (or versionless equivalent) advanced — the poll carried news. */
+  advanced: boolean
+  /** Hydration completed with this snapshot (buffered events were flushed). */
+  hydrationCompleted: boolean
+  terminated: boolean
+  state?: { value: unknown }
+}
+
+export class Reconciler<Snapshot, Events extends EventPayloadMap, State> {
+  private readonly config: FallbackBindingConfig<Snapshot, Events, State>
+  private readonly snapshotToEvents: (
+    snapshot: Snapshot,
+  ) => ReadonlyArray<{ event: string; data: unknown }>
+  private readonly terminalSet: ReadonlySet<string>
+  private highWatermark: Version | null = null
+  private hydrationBuffer: IncomingEvent[] | null = null
+  private readonly hydrationBufferLimit: number
+  private stateValue: State | undefined
+  private stateInitialized = false
+  private stateSuspended = false
+  private terminated = false
+
+  constructor(
+    config: FallbackBindingConfig<Snapshot, Events, State>,
+    options: { hydrationBufferLimit: number },
+  ) {
+    this.config = config
+    const shorthandEvent = config.snapshotEvent
+    this.snapshotToEvents =
+      config.snapshotToEvents ??
+      (shorthandEvent !== undefined
+        ? (snapshot) => [{ event: shorthandEvent, data: snapshot }]
+        : () => [])
+    this.terminalSet = new Set(config.terminalEvents ?? [])
+    this.hydrationBufferLimit = options.hydrationBufferLimit
+  }
+
+  get isTerminated(): boolean {
+    return this.terminated
+  }
+
+  get isHydrating(): boolean {
+    return this.hydrationBuffer !== null
+  }
+
+  getState(): State | undefined {
+    return this.stateValue
+  }
+
+  /** Start buffering live events until the next snapshot arrives. */
+  beginHydration(): void {
+    if (this.terminated) return
+    this.hydrationBuffer = []
+  }
+
+  /** Abandon hydration buffering (e.g. hydration poll failed terminally). */
+  abandonHydration(): void {
+    this.hydrationBuffer = null
+  }
+
+  handleEvent(incoming: IncomingEvent): EventOutcome<Events> {
+    const outcome: EventOutcome<Events> = {
+      deliveries: [],
+      duplicate: false,
+      buffered: false,
+      bufferOverflow: false,
+      terminated: false,
+    }
+    if (this.terminated) return outcome
+
+    if (this.hydrationBuffer !== null) {
+      if (this.hydrationBuffer.length >= this.hydrationBufferLimit) {
+        // Drop the buffer; the caller refetches the snapshot, which subsumes
+        // everything dropped (or is older than still-flowing live events,
+        // which the version gate handles either way).
+        this.hydrationBuffer = []
+        outcome.bufferOverflow = true
+        return outcome
+      }
+      this.hydrationBuffer.push(incoming)
+      outcome.buffered = true
+      return outcome
+    }
+
+    this.gateAndDeliver(incoming, 'sse', outcome)
+    return outcome
+  }
+
+  handleSnapshot(snapshot: Snapshot): SnapshotOutcome<Events> {
+    const outcome: SnapshotOutcome<Events> = {
+      deliveries: [],
+      stale: false,
+      advanced: false,
+      hydrationCompleted: false,
+      terminated: false,
+    }
+    if (this.terminated) return outcome
+
+    const versioned = this.config.version !== 'none'
+    const snapshotVersion = versioned
+      ? (this.config.version as { ofSnapshot: (s: Snapshot) => Version }).ofSnapshot(snapshot)
+      : null
+
+    if (
+      versioned &&
+      snapshotVersion !== null &&
+      this.highWatermark !== null &&
+      this.compare(snapshotVersion, this.highWatermark) <= 0
+    ) {
+      // The stale-poll race: everything this snapshot describes has already
+      // been delivered (or superseded) through the stream.
+      outcome.stale = true
+      // One exception: while the state layer is gap-suspended, a snapshot AT
+      // the watermark is exactly the repair we polled for — the gapped event
+      // advanced the watermark to its own version, so the repair snapshot
+      // legitimately arrives with an equal version. Re-initialize state and
+      // lift the suspension (events stay dropped — nothing new to deliver).
+      if (
+        this.stateSuspended &&
+        this.config.state &&
+        this.compare(snapshotVersion, this.highWatermark) === 0
+      ) {
+        this.stateValue = this.config.state.init(snapshot)
+        this.stateInitialized = true
+        this.stateSuspended = false
+        outcome.state = { value: this.stateValue }
+      }
+      this.finishHydration(snapshotVersion, outcome)
+      return outcome
+    }
+
+    // Deliver the snapshot: state layer first (replacement semantics), then
+    // synthesized events. Synthetic events are NOT applied to state — the
+    // snapshot already subsumes them.
+    if (this.config.state) {
+      this.stateValue = this.config.state.init(snapshot)
+      this.stateInitialized = true
+      this.stateSuspended = false
+      outcome.state = { value: this.stateValue }
+    }
+
+    const synthetic = this.snapshotToEvents(snapshot)
+    for (const event of synthetic) {
+      const delivered = {
+        ...event,
+        origin: 'poll',
+      } as FallbackEvent<Events>
+      outcome.deliveries.push(delivered)
+      if (this.terminalSet.has(event.event)) {
+        this.terminated = true
+        outcome.terminated = true
+      }
+    }
+
+    // An empty synthetic list still advances the watermark: the poll proved
+    // the state at snapshotVersion, so later stale arrivals must be droppable.
+    if (versioned && snapshotVersion !== null) {
+      this.highWatermark = snapshotVersion
+    }
+    outcome.advanced = true
+
+    this.finishHydration(snapshotVersion, outcome)
+    return outcome
+  }
+
+  private finishHydration(snapshotVersion: Version | null, outcome: SnapshotOutcome<Events>): void {
+    if (this.hydrationBuffer === null) return
+    const buffered = this.hydrationBuffer
+    this.hydrationBuffer = null
+    outcome.hydrationCompleted = true
+
+    // Flush buffered live events newer than the snapshot, in arrival order.
+    // Everything at or below the snapshot version is subsumed by it.
+    for (const incoming of buffered) {
+      if (this.terminated) break
+      const eventOutcome: EventOutcome<Events> = {
+        deliveries: [],
+        duplicate: false,
+        buffered: false,
+        bufferOverflow: false,
+        terminated: false,
+      }
+      this.gateAndDeliver(incoming, 'sse', eventOutcome)
+      outcome.deliveries.push(...eventOutcome.deliveries)
+      if (eventOutcome.state) outcome.state = eventOutcome.state
+      if (eventOutcome.terminated) outcome.terminated = true
+    }
+    // snapshotVersion is already the watermark, so gateAndDeliver dropped
+    // anything the snapshot subsumed. (Parameter kept for readability.)
+    void snapshotVersion
+  }
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: the version gate is the correctness core — splitting it would scatter the invariants it guards
+  private gateAndDeliver(
+    incoming: IncomingEvent,
+    origin: 'sse' | 'poll',
+    outcome: EventOutcome<Events>,
+  ): void {
+    const versioned = this.config.version !== 'none'
+    let version: Version | undefined
+    if (versioned) {
+      version = this.extractEventVersion(incoming)
+      if (version !== undefined && this.highWatermark !== null) {
+        const comparison = this.compare(version, this.highWatermark)
+        if (comparison <= 0) {
+          outcome.duplicate = true
+          return
+        }
+        const gap = this.detectGap(this.highWatermark, version)
+        if (gap) {
+          outcome.gap = gap
+          if (this.config.state && (this.config.state.reinitOnGap ?? true)) {
+            // Deltas must not be applied across a gap; the repair snapshot
+            // re-initializes state.
+            this.stateSuspended = true
+          }
+        }
+      }
+    }
+
+    const delivered = {
+      event: incoming.event,
+      data: incoming.data,
+      ...(incoming.id !== undefined ? { id: incoming.id } : {}),
+      origin,
+    } as FallbackEvent<Events>
+    outcome.deliveries.push(delivered)
+
+    if (this.config.state && this.stateInitialized && !this.stateSuspended) {
+      this.stateValue = this.config.state.apply(this.stateValue as State, delivered)
+      outcome.state = { value: this.stateValue }
+    }
+
+    if (versioned && version !== undefined) {
+      this.highWatermark = version
+    }
+
+    if (this.terminalSet.has(incoming.event)) {
+      this.terminated = true
+      outcome.terminated = true
+    }
+  }
+
+  private extractEventVersion(incoming: IncomingEvent): Version | undefined {
+    const versionConfig = this.config.version
+    if (versionConfig === 'none') return undefined
+    if (versionConfig.ofEvent) {
+      return versionConfig.ofEvent({
+        event: incoming.event,
+        data: incoming.data,
+        ...(incoming.id !== undefined ? { id: incoming.id } : {}),
+        origin: 'sse',
+      } as FallbackEvent<Events>)
+    }
+    // Default: numeric SSE id (pair with server-side monotonic id stamping).
+    if (incoming.id === undefined || incoming.id === '') return undefined
+    const numeric = Number(incoming.id)
+    return Number.isNaN(numeric) ? undefined : numeric
+  }
+
+  private compare(a: Version, b: Version): number {
+    const versionConfig = this.config.version
+    if (versionConfig !== 'none' && versionConfig.compare) {
+      return versionConfig.compare(a, b)
+    }
+    return defaultCompareVersions(a, b)
+  }
+
+  private detectGap(watermark: Version, next: Version): { from: Version; to: Version } | undefined {
+    const versionConfig = this.config.version
+    if (versionConfig === 'none' || !versionConfig.dense) return undefined
+    const watermarkNumber = toNumeric(watermark)
+    const nextNumber = toNumeric(next)
+    if (watermarkNumber === undefined || nextNumber === undefined) return undefined
+    return nextNumber > watermarkNumber + 1 ? { from: watermark, to: next } : undefined
+  }
+}
+
+function toNumeric(version: Version): number | undefined {
+  if (typeof version === 'number') return version
+  const numeric = Number(version)
+  return Number.isNaN(numeric) ? undefined : numeric
+}
+
+/** Numeric when both sides are numeric; lexicographic otherwise. */
+export function defaultCompareVersions(a: Version, b: Version): number {
+  const aNumber = toNumeric(a)
+  const bNumber = toNumeric(b)
+  if (aNumber !== undefined && bNumber !== undefined) {
+    return aNumber === bNumber ? 0 : aNumber < bNumber ? -1 : 1
+  }
+  const aString = String(a)
+  const bString = String(b)
+  return aString === bString ? 0 : aString < bString ? -1 : 1
+}

--- a/packages/sse-fallback/src/scheduler.ts
+++ b/packages/sse-fallback/src/scheduler.ts
@@ -1,0 +1,66 @@
+import type { BackoffConfig } from './bindingTypes.ts'
+
+/**
+ * Timer + backoff helpers. Browser-safe: uses global setTimeout/clearTimeout
+ * and calls Node's `unref` only when present.
+ */
+
+type TimerHandle = ReturnType<typeof setTimeout>
+
+/** A single named resettable timer. */
+export class ResettableTimer {
+  private handle: TimerHandle | undefined
+  private readonly onFire: () => void
+
+  constructor(onFire: () => void) {
+    this.onFire = onFire
+  }
+
+  /** (Re)arm the timer; a previously armed timeout is cancelled. */
+  arm(delayMs: number): void {
+    this.clear()
+    this.handle = setTimeout(this.onFire, delayMs)
+    // Don't keep a Node process alive for fallback timers (no-op in browsers).
+    ;(this.handle as { unref?: () => void }).unref?.()
+  }
+
+  clear(): void {
+    if (this.handle !== undefined) {
+      clearTimeout(this.handle)
+      this.handle = undefined
+    }
+  }
+
+  get isArmed(): boolean {
+    return this.handle !== undefined
+  }
+}
+
+/**
+ * Full-jitter exponential backoff: `random() * min(cap, base * factor^attempt)`.
+ * Jitter prevents a thundering herd after a shared outage.
+ */
+export function backoffDelay(config: BackoffConfig, attempt: number, random: () => number): number {
+  const ceiling = Math.min(config.maxMs, config.baseMs * config.factor ** attempt)
+  return Math.max(0, Math.floor(random() * ceiling))
+}
+
+/** Sleep that resolves early (with `false`) when the signal aborts. */
+export function sleep(delayMs: number, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve(false)
+      return
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve(true)
+    }, delayMs)
+    ;(timer as { unref?: () => void }).unref?.()
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve(false)
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/packages/sse-fallback/src/sseParser.ts
+++ b/packages/sse-fallback/src/sseParser.ts
@@ -1,0 +1,88 @@
+/**
+ * SSE (Server-Sent Events) parsing utilities, per the W3C spec.
+ *
+ * Vendored from `opinionated-machine`'s `lib/sse/sseParser.ts` so this
+ * package stays dependency-free and browser-safe. The wire format is a
+ * frozen spec — behavioral divergence risk is negligible.
+ *
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html
+ */
+
+/**
+ * Parse a single SSE line and update the event state.
+ * Returns true if a complete event was found (empty line with data).
+ */
+function parseSSELine(
+  line: string,
+  currentEvent: Partial<ParsedSSEEvent>,
+  dataLines: string[],
+): boolean {
+  if (line.startsWith('id:')) {
+    currentEvent.id = line.slice(3).trim()
+  } else if (line.startsWith('event:')) {
+    currentEvent.event = line.slice(6).trim()
+  } else if (line.startsWith('data:')) {
+    dataLines.push(line.slice(5).trim())
+  } else if (line.startsWith('retry:')) {
+    currentEvent.retry = Number.parseInt(line.slice(6).trim(), 10)
+  } else if (line === '' && dataLines.length > 0) {
+    return true // Event complete
+  }
+  // Comment lines (starting with :) are implicitly ignored
+  return false
+}
+
+/** A parsed SSE event. */
+export type ParsedSSEEvent = {
+  /** Event ID (feeds Last-Event-ID reconnection). */
+  id?: string
+  /** Event type name; servers may omit it (defaults to 'message'). */
+  event?: string
+  /** Event data payload as a string (multi-line data joined with newlines). */
+  data: string
+  /** Reconnection delay hint in milliseconds. */
+  retry?: number
+}
+
+/** Result of incremental SSE buffer parsing. */
+export type ParseSSEBufferResult = {
+  /** Complete events parsed from the buffer */
+  events: ParsedSSEEvent[]
+  /** Remaining incomplete data to prepend to next chunk */
+  remaining: string
+}
+
+/**
+ * Parse SSE events incrementally from a buffer.
+ *
+ * Designed for streaming: append each chunk to a buffer, call this, process
+ * the returned events, and carry `remaining` into the next iteration.
+ */
+export function parseSSEBuffer(buffer: string): ParseSSEBufferResult {
+  const events: ParsedSSEEvent[] = []
+  const lines = buffer.split('\n')
+
+  let currentEvent: Partial<ParsedSSEEvent> = {}
+  let dataLines: string[] = []
+  let lastCompleteEventEnd = 0
+  let currentPosition = 0
+
+  for (const line of lines) {
+    currentPosition += line.length + 1 // +1 for the \n
+
+    if (parseSSELine(line, currentEvent, dataLines)) {
+      events.push({
+        ...currentEvent,
+        data: dataLines.join('\n'),
+      } as ParsedSSEEvent)
+      currentEvent = {}
+      dataLines = []
+      lastCompleteEventEnd = currentPosition
+    }
+  }
+
+  // Preserve any unconsumed content after the last complete event,
+  // including incomplete events with only id:/event:/retry: lines
+  const remaining = lastCompleteEventEnd < buffer.length ? buffer.slice(lastCompleteEventEnd) : ''
+  return { events, remaining }
+}

--- a/packages/sse-fallback/src/subscription.spec.ts
+++ b/packages/sse-fallback/src/subscription.spec.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FallbackBinding } from './binding.ts'
+import type { FallbackBindingConfig, FallbackEvent, FallbackPolicy } from './bindingTypes.ts'
+import { createResilientSubscription } from './subscription.ts'
+import { type TestSnapshotCall, type TestStreamHandle, TestTransport } from './transport.ts'
+
+type Snap = { status: 'pending' | 'completed'; result?: string; version: number }
+type Events = { progress: { percent: number }; done: { result: string } }
+
+const TEST_POLICY: Partial<FallbackPolicy> = {
+  initialPoll: 'eager',
+  deadmanDelayMs: 1_000,
+  deadmanIdleBackoff: { factor: 1, maxMs: 1_000 },
+  staleConnectionTimeoutMs: 5_000,
+  pollFailureBackoff: { baseMs: 100, factor: 1, maxMs: 100 },
+  sseRetryBackoff: { baseMs: 100, factor: 1, maxMs: 100 },
+  degradedAfterFailures: 2,
+  degradedPollIntervalMs: 2_000,
+  degradedSseRetryMaxMs: 100,
+  hydrationBufferLimit: 3,
+}
+
+function makeBinding(
+  overrides?: Partial<FallbackBindingConfig<Snap, Events, undefined>>,
+): FallbackBinding<Snap, Events, undefined> {
+  return {
+    config: {
+      snapshotToEvents: (s) =>
+        s.status === 'completed' ? [{ event: 'done', data: { result: s.result as string } }] : [],
+      version: { ofSnapshot: (s) => s.version },
+      terminalEvents: ['done'],
+      ...overrides,
+    },
+    buildSnapshotRequest: () => ({ path: '/job', method: 'get' }),
+    buildStreamRequest: () => ({ path: '/job', method: 'get' }),
+  }
+}
+
+type Harness = {
+  transport: TestTransport
+  streams: TestStreamHandle[]
+  snapshots: TestSnapshotCall[]
+}
+
+function makeHarness(): Harness {
+  const transport = new TestTransport()
+  const streams: TestStreamHandle[] = []
+  const snapshots: TestSnapshotCall[] = []
+  transport.onStreamConnect = (stream) => streams.push(stream)
+  transport.onSnapshot = (call) => snapshots.push(call)
+  return { transport, streams, snapshots }
+}
+
+const flush = () => vi.advanceTimersByTimeAsync(0)
+
+describe('createResilientSubscription', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('use case A: SSE wins the race — the scheduled poll never fires again after the terminal event', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    const completion = sub.waitFor('done')
+    await flush()
+
+    expect(streams).toHaveLength(1)
+    expect(snapshots).toHaveLength(1) // eager hydration poll
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+    expect(sub.status).toBe('live')
+
+    streams[0]?.pushEvent('done', { result: 'ok' }, { id: '1' })
+    await flush()
+
+    await expect(completion).resolves.toEqual({ result: 'ok' })
+    expect(sub.status).toBe('stopped')
+
+    // All timers cancelled: no more polls, ever.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(transport.snapshotCalls).toHaveLength(1)
+  })
+
+  it('use case A: the deadman poll delivers the completion when SSE is silent', async () => {
+    const { transport, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    const completion = sub.waitFor('done')
+    const origins: string[] = []
+    sub.onEvent((event) => origins.push(event.origin))
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+
+    // Silence — the deadman fires a reconciliation poll.
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(snapshots).toHaveLength(2)
+    snapshots[1]?.respond({ status: 'completed', result: 'late', version: 5 })
+    await flush()
+
+    await expect(completion).resolves.toEqual({ result: 'late' })
+    expect(origins).toEqual(['poll'])
+    expect(sub.status).toBe('stopped')
+  })
+
+  it('resets the deadman on data events but NOT on heartbeats', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+
+    // A data event at t=800 resets the deadman...
+    await vi.advanceTimersByTimeAsync(800)
+    streams[0]?.pushEvent('progress', { percent: 10 }, { id: '1' })
+    await flush()
+    // ...so no poll at t=1000...
+    await vi.advanceTimersByTimeAsync(800)
+    expect(snapshots).toHaveLength(1)
+    // ...but one at t=1800 (1000ms after the event).
+    await vi.advanceTimersByTimeAsync(250)
+    expect(snapshots).toHaveLength(2)
+    snapshots[1]?.respond({ status: 'pending', version: 1 })
+    await flush()
+
+    // Heartbeats do NOT reset the deadman: transport liveness is not
+    // delivery correctness — the fallback must fire even on healthy streams.
+    await vi.advanceTimersByTimeAsync(800)
+    streams[0]?.pushHeartbeat()
+    await flush()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(snapshots).toHaveLength(3)
+  })
+
+  it('force-closes a silently dead stream at staleConnectionTimeout and reconnects', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+    expect(streams).toHaveLength(1)
+
+    // Heartbeats keep the connection alive past the stale window...
+    await vi.advanceTimersByTimeAsync(4_000)
+    streams[0]?.pushHeartbeat()
+    await flush()
+    await vi.advanceTimersByTimeAsync(4_000)
+    expect(transport.streamConnects).toHaveLength(1)
+
+    // ...but total silence trips the watchdog: force-close + reconnect.
+    await vi.advanceTimersByTimeAsync(1_200)
+    await flush()
+    expect(transport.streamConnects).toHaveLength(2)
+    expect(sub.status).not.toBe('stopped')
+  })
+
+  it('drops a stale poll response arriving after a newer pushed event (cannot falsely complete)', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const staleSnapshots: number[] = []
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+      diagnostics: { onStaleSnapshot: () => staleSnapshots.push(1) },
+    })
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+
+    // Deadman poll goes out but its response is slow...
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(snapshots).toHaveLength(2)
+
+    // ...meanwhile SSE delivers version 10...
+    streams[0]?.pushEvent('progress', { percent: 99 }, { id: '10' })
+    await flush()
+
+    // ...and the poll finally answers with an OLD completed snapshot (v9).
+    snapshots[1]?.respond({ status: 'completed', result: 'STALE', version: 9 })
+    await flush()
+
+    expect(staleSnapshots).toHaveLength(1)
+    // The stale snapshot did NOT complete the subscription.
+    expect(sub.status).toBe('live')
+  })
+
+  it('sends Last-Event-ID on reconnect and issues a reconciliation poll (untrusted replay)', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+
+    streams[0]?.pushEvent('progress', { percent: 50 }, { id: '7' })
+    await flush()
+
+    // Server closes the stream.
+    streams[0]?.close()
+    await flush()
+    expect(sub.status).toBe('reconnecting')
+    // Immediate reconciliation poll on drop.
+    expect(snapshots).toHaveLength(2)
+    snapshots[1]?.respond({ status: 'pending', version: 7 })
+
+    // Reconnect happens after the retry backoff, carrying Last-Event-ID.
+    await vi.advanceTimersByTimeAsync(150)
+    expect(streams).toHaveLength(2)
+    expect(streams[1]?.lastEventIdReceived).toBe('7')
+    expect(sub.status).toBe('live')
+
+    // Another poll after the reconnect (untrusted replay).
+    await flush()
+    expect(snapshots.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('degrades to POLLING_ONLY after repeated connect failures and recovers when SSE returns', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    transport.denyNextStreamConnect({ error: new Error('refused') })
+    transport.denyNextStreamConnect({ error: new Error('refused') })
+
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    await flush()
+    // First connect failed; retry after backoff; second fails too → degraded.
+    await vi.advanceTimersByTimeAsync(150)
+    await flush()
+    expect(sub.status).toBe('polling')
+
+    // Polls keep flowing while degraded.
+    for (const call of [...snapshots]) call.respond({ status: 'pending', version: 0 })
+    snapshots.length = 0
+    await vi.advanceTimersByTimeAsync(2_100)
+    expect(snapshots.length).toBeGreaterThanOrEqual(1)
+    for (const call of [...snapshots]) call.respond({ status: 'pending', version: 0 })
+
+    // Background SSE retry eventually reconnects; the (first successful)
+    // connect starts eager hydration — answering its snapshot goes live.
+    await vi.advanceTimersByTimeAsync(200)
+    await flush()
+    expect(streams.length).toBeGreaterThanOrEqual(1)
+    for (const call of [...snapshots]) call.respond({ status: 'pending', version: 0 })
+    await flush()
+    expect(sub.status).toBe('live')
+  })
+
+  it('stops on unretryable poll statuses (404)', async () => {
+    const { transport, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    const completion = sub.waitFor('done')
+    completion.catch(() => {}) // assertion below; avoid unhandled rejection
+    await flush()
+
+    snapshots[0]?.respond({ error: 'not found' }, 404)
+    await flush()
+
+    expect(sub.status).toBe('stopped')
+    await expect(completion).rejects.toThrow(/stopped/)
+  })
+
+  it('hydrates subscribe-first: buffers live events, snapshot first, then only newer events', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const delivered: Array<FallbackEvent<Events>> = []
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    sub.onEvent((event) => delivered.push(event))
+    await flush()
+    expect(sub.status).toBe('connecting')
+
+    // Live events arrive while the hydration snapshot is still in flight.
+    streams[0]?.pushEvent('progress', { percent: 40 }, { id: '4' })
+    streams[0]?.pushEvent('progress', { percent: 60 }, { id: '6' })
+    await flush()
+    expect(delivered).toHaveLength(0) // buffered
+
+    // Snapshot at v5 subsumes v4; v6 is flushed after it.
+    snapshots[0]?.respond({ status: 'pending', version: 5 })
+    await flush()
+
+    expect(sub.status).toBe('live')
+    expect(delivered).toEqual([
+      { event: 'progress', data: { percent: 60 }, id: '6', origin: 'sse' },
+    ])
+  })
+
+  it('polls immediately on a version gap (dense mode) instead of waiting for the deadman', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const gaps: Array<{ from: unknown; to: unknown }> = []
+    createResilientSubscription(
+      makeBinding({ version: { ofSnapshot: (s) => s.version, dense: true } }),
+      {
+        transport,
+        policy: TEST_POLICY,
+        random: () => 1,
+        diagnostics: { onGap: (gap) => gaps.push(gap) },
+      },
+    )
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 1 })
+    await flush()
+
+    // Version 3 arrives without 2 — the repair poll fires with NO timer advance.
+    streams[0]?.pushEvent('progress', { percent: 30 }, { id: '3' })
+    await flush()
+
+    expect(gaps).toEqual([{ from: 1, to: 3 }])
+    expect(snapshots).toHaveLength(2)
+  })
+
+  it('exposes a uniform async-iterable regardless of the delivering channel', async () => {
+    const { transport, streams, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    const collected: Array<FallbackEvent<Events>> = []
+    const iteration = (async () => {
+      for await (const event of sub.events()) {
+        collected.push(event)
+      }
+    })()
+
+    await flush()
+    snapshots[0]?.respond({ status: 'pending', version: 0 })
+    await flush()
+
+    streams[0]?.pushEvent('progress', { percent: 10 }, { id: '1' })
+    await flush()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    snapshots[1]?.respond({ status: 'completed', result: 'ok', version: 2 })
+    await flush()
+
+    await iteration // completes on the terminal event
+    expect(collected).toEqual([
+      { event: 'progress', data: { percent: 10 }, id: '1', origin: 'sse' },
+      { event: 'done', data: { result: 'ok' }, origin: 'poll' },
+    ])
+  })
+
+  it('stop() aborts in-flight work and completes iterators', async () => {
+    const { transport, snapshots } = makeHarness()
+    const sub = createResilientSubscription(makeBinding(), {
+      transport,
+      policy: TEST_POLICY,
+      random: () => 1,
+    })
+    const iteration = (async () => {
+      const seen: unknown[] = []
+      for await (const event of sub.events()) seen.push(event)
+      return seen
+    })()
+    await flush()
+    expect(snapshots).toHaveLength(1)
+
+    sub.stop()
+    await expect(iteration).resolves.toEqual([])
+    expect(sub.status).toBe('stopped')
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(transport.snapshotCalls).toHaveLength(1)
+    expect(transport.streamConnects).toHaveLength(1)
+  })
+})

--- a/packages/sse-fallback/src/subscription.ts
+++ b/packages/sse-fallback/src/subscription.ts
@@ -1,0 +1,603 @@
+import type { FallbackBinding, FallbackRequestParams } from './binding.ts'
+import type { EventPayloadMap, FallbackEvent, FallbackPolicy, Version } from './bindingTypes.ts'
+import { DEFAULT_POLICY } from './bindingTypes.ts'
+import { Reconciler } from './reconciler.ts'
+import { backoffDelay, ResettableTimer, sleep } from './scheduler.ts'
+import { parseSSEBuffer } from './sseParser.ts'
+import type { FallbackTransport } from './transport.ts'
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export type SubscriptionStatus = 'connecting' | 'live' | 'reconnecting' | 'polling' | 'stopped'
+
+/**
+ * Observability hooks — all optional, all no-ops by default. None of these
+ * affect delivery semantics; they exist so applications can meter the
+ * fallback machinery (gap rate, duplicate rate, poll errors).
+ */
+export type FallbackDiagnostics = {
+  onGap?: (gap: { from: Version; to: Version }) => void
+  onDuplicate?: (event: string) => void
+  onStaleSnapshot?: () => void
+  onPollError?: (error: unknown) => void
+  onStreamError?: (error: unknown) => void
+}
+
+export type CreateResilientSubscriptionOptions = {
+  transport: FallbackTransport
+  params?: FallbackRequestParams
+  policy?: Partial<FallbackPolicy>
+  diagnostics?: FallbackDiagnostics
+  signal?: AbortSignal
+  /** Injectable randomness for deterministic backoff in tests. */
+  random?: () => number
+}
+
+export type ResilientSubscription<
+  Events extends EventPayloadMap = EventPayloadMap,
+  State = undefined,
+> = {
+  /** Uniform event stream — SSE-pushed, replayed, and poll-synthesized alike. */
+  events(): AsyncIterable<FallbackEvent<Events>>
+  /** Callback-style event consumption; returns an unsubscribe function. */
+  onEvent(listener: (event: FallbackEvent<Events>) => void): () => void
+  /** Latest reduced state — only meaningful when the binding declares `state`. */
+  getState(): State | undefined
+  onStateChange(listener: (state: State) => void): () => void
+  readonly status: SubscriptionStatus
+  onStatusChange(listener: (status: SubscriptionStatus) => void): () => void
+  /** Force an immediate reconciliation poll + connection check. */
+  nudge(): void
+  /** Stop the subscription: cancel timers, abort in-flight requests. */
+  stop(): void
+  /**
+   * Await the first delivery of a specific event (use case: await async
+   * completion). Resolves identically whether the event traveled over SSE,
+   * replay, or a fallback poll.
+   */
+  waitFor<K extends keyof Events & string>(
+    event: K,
+    opts?: { timeoutMs?: number },
+  ): Promise<Events[K]>
+  /** Await the first terminal event (any of the binding's terminalEvents). */
+  waitForTerminal(opts?: { timeoutMs?: number }): Promise<FallbackEvent<Events>>
+}
+
+// ============================================================================
+// Implementation
+// ============================================================================
+
+type IteratorFeed<Events extends EventPayloadMap> = {
+  push: (event: FallbackEvent<Events>) => void
+  finish: () => void
+}
+
+class ResilientSubscriptionImpl<Snapshot, Events extends EventPayloadMap, State> {
+  private readonly binding: FallbackBinding<Snapshot, Events, State>
+  private readonly transport: FallbackTransport
+  private readonly params: FallbackRequestParams
+  private readonly policy: FallbackPolicy
+  private readonly diagnostics: FallbackDiagnostics
+  private readonly random: () => number
+  private readonly reconciler: Reconciler<Snapshot, Events, State>
+
+  private readonly abortController = new AbortController()
+  private currentStreamAbort: AbortController | undefined
+
+  private statusValue: SubscriptionStatus = 'connecting'
+  private stopped = false
+  private streamConnected = false
+  private lastEventId: string | undefined
+  private serverRetryHintMs: number | undefined
+  private consecutiveConnectFailures = 0
+  private degraded = false
+
+  private pollInFlight = false
+  private pollQueued = false
+  private pollFailures = 0
+  private idlePolls = 0
+
+  private readonly deadman = new ResettableTimer(() => this.schedulePoll())
+  private readonly staleConnection = new ResettableTimer(() => this.onStaleConnection())
+
+  private readonly eventListeners = new Set<(event: FallbackEvent<Events>) => void>()
+  private readonly stateListeners = new Set<(state: State) => void>()
+  private readonly statusListeners = new Set<(status: SubscriptionStatus) => void>()
+  private readonly iteratorFeeds = new Set<IteratorFeed<Events>>()
+
+  constructor(
+    binding: FallbackBinding<Snapshot, Events, State>,
+    options: CreateResilientSubscriptionOptions,
+  ) {
+    this.binding = binding
+    this.transport = options.transport
+    this.params = options.params ?? {}
+    this.policy = { ...DEFAULT_POLICY, ...binding.config.policy, ...options.policy }
+    this.diagnostics = options.diagnostics ?? {}
+    this.random = options.random ?? Math.random
+    this.reconciler = new Reconciler(binding.config, {
+      hydrationBufferLimit: this.policy.hydrationBufferLimit,
+    })
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        this.stop()
+        return
+      }
+      options.signal.addEventListener('abort', () => this.stop(), { once: true })
+    }
+
+    void this.runStreamLoop()
+    if (this.policy.initialPoll !== 'eager') {
+      // No hydration poll — the deadman provides the fallback cadence.
+      this.armDeadman()
+    }
+  }
+
+  // --------------------------------------------------------------------
+  // Public surface
+  // --------------------------------------------------------------------
+
+  get status(): SubscriptionStatus {
+    return this.statusValue
+  }
+
+  getState(): State | undefined {
+    return this.reconciler.getState()
+  }
+
+  onEvent(listener: (event: FallbackEvent<Events>) => void): () => void {
+    this.eventListeners.add(listener)
+    return () => this.eventListeners.delete(listener)
+  }
+
+  onStateChange(listener: (state: State) => void): () => void {
+    this.stateListeners.add(listener)
+    return () => this.stateListeners.delete(listener)
+  }
+
+  onStatusChange(listener: (status: SubscriptionStatus) => void): () => void {
+    this.statusListeners.add(listener)
+    return () => this.statusListeners.delete(listener)
+  }
+
+  events(): AsyncIterable<FallbackEvent<Events>> {
+    const queue: Array<FallbackEvent<Events>> = []
+    let notify: (() => void) | undefined
+    let done = this.stopped
+
+    const feed: IteratorFeed<Events> = {
+      push: (event) => {
+        queue.push(event)
+        notify?.()
+      },
+      finish: () => {
+        done = true
+        notify?.()
+      },
+    }
+    this.iteratorFeeds.add(feed)
+
+    const feeds = this.iteratorFeeds
+    return {
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<FallbackEvent<Events>>> {
+            while (true) {
+              const item = queue.shift()
+              if (item !== undefined) return { value: item, done: false }
+              if (done) {
+                feeds.delete(feed)
+                return { value: undefined, done: true }
+              }
+              await new Promise<void>((resolve) => {
+                notify = resolve
+              })
+              notify = undefined
+            }
+          },
+          return(): Promise<IteratorResult<FallbackEvent<Events>>> {
+            feeds.delete(feed)
+            done = true
+            return Promise.resolve({ value: undefined, done: true })
+          },
+        }
+      },
+    }
+  }
+
+  waitFor<K extends keyof Events & string>(
+    event: K,
+    opts?: { timeoutMs?: number },
+  ): Promise<Events[K]> {
+    return this.waitMatching((delivered) => delivered.event === event, opts).then(
+      (delivered) => delivered.data as Events[K],
+    )
+  }
+
+  waitForTerminal(opts?: { timeoutMs?: number }): Promise<FallbackEvent<Events>> {
+    const terminal = new Set(this.binding.config.terminalEvents ?? [])
+    return this.waitMatching((delivered) => terminal.has(delivered.event), opts)
+  }
+
+  nudge(): void {
+    if (this.stopped) return
+    this.schedulePoll()
+    // If the stream looks dead, force a reconnect check too.
+    if (this.streamConnected && this.policy.staleConnectionTimeoutMs !== 'off') {
+      // Byte-activity watchdog stays authoritative; nothing else to do here.
+      return
+    }
+  }
+
+  stop(): void {
+    if (this.stopped) return
+    this.stopped = true
+    this.deadman.clear()
+    this.staleConnection.clear()
+    this.currentStreamAbort?.abort()
+    this.abortController.abort()
+    this.setStatus('stopped')
+    for (const feed of this.iteratorFeeds) feed.finish()
+    this.iteratorFeeds.clear()
+  }
+
+  // --------------------------------------------------------------------
+  // Stream loop
+  // --------------------------------------------------------------------
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: the connect/consume/reconnect loop is a single state machine — splitting it would obscure the transitions
+  private async runStreamLoop(): Promise<void> {
+    let firstConnect = true
+    while (!this.stopped) {
+      const streamAbort = new AbortController()
+      this.currentStreamAbort = streamAbort
+      const onMasterAbort = () => streamAbort.abort()
+      this.abortController.signal.addEventListener('abort', onMasterAbort, { once: true })
+
+      let connectFailed = false
+      try {
+        const response = await this.transport.openStream(
+          this.binding.buildStreamRequest(this.params),
+          { signal: streamAbort.signal, lastEventId: this.lastEventId },
+        )
+        if (this.stopped) return
+
+        const contentType = response.headers['content-type'] ?? ''
+        if (
+          response.status !== 200 ||
+          (contentType && !contentType.includes('text/event-stream'))
+        ) {
+          connectFailed = true
+          this.diagnostics.onStreamError?.(
+            new Error(`SSE connect failed with status ${response.status}`),
+          )
+          if (this.policy.unretryableStatuses.includes(response.status)) {
+            this.stop()
+            return
+          }
+        } else {
+          // Connected.
+          this.consecutiveConnectFailures = 0
+          this.degraded = false
+          this.serverRetryHintMs = undefined
+
+          if (firstConnect) {
+            if (this.policy.initialPoll === 'eager') {
+              // Subscribe-first hydration: buffer live events until the
+              // snapshot lands — zero missed-event window.
+              this.reconciler.beginHydration()
+              this.schedulePoll()
+            } else {
+              this.setStatus('live')
+            }
+          } else {
+            this.setStatus('live')
+            if ((this.binding.config.replay ?? 'untrusted') === 'untrusted') {
+              // Events during the outage are lost unless the server replays
+              // them completely — reconcile via a poll.
+              this.schedulePoll()
+            }
+          }
+          firstConnect = false
+
+          this.armStaleConnection()
+          await this.consumeStream(response.chunks)
+          if (this.stopped || this.reconciler.isTerminated) return
+          // Stream ended (server close, stale-abort, or network) — fall
+          // through to the reconnect path.
+        }
+      } catch (error) {
+        if (this.stopped) return
+        connectFailed = !this.streamConnected
+        this.diagnostics.onStreamError?.(error)
+      } finally {
+        this.staleConnection.clear()
+        this.streamConnected = false
+        this.abortController.signal.removeEventListener('abort', onMasterAbort)
+      }
+
+      if (this.stopped || this.reconciler.isTerminated) return
+
+      if (connectFailed) {
+        this.consecutiveConnectFailures += 1
+      }
+      if (this.consecutiveConnectFailures >= this.policy.degradedAfterFailures) {
+        if (!this.degraded) {
+          this.degraded = true
+          this.setStatus('polling')
+          // Degraded cadence applies from the next deadman arm.
+          this.armDeadman()
+        }
+      } else {
+        this.setStatus('reconnecting')
+      }
+
+      // The stream just dropped — data may have been lost; poll now.
+      this.schedulePoll()
+
+      const backoffConfig = this.degraded
+        ? { ...this.policy.sseRetryBackoff, maxMs: this.policy.degradedSseRetryMaxMs }
+        : this.policy.sseRetryBackoff
+      const delay =
+        this.serverRetryHintMs !== undefined && !connectFailed
+          ? this.serverRetryHintMs
+          : backoffDelay(backoffConfig, this.consecutiveConnectFailures, this.random)
+      const proceed = await sleep(delay, this.abortController.signal)
+      if (!proceed) return
+    }
+  }
+
+  private async consumeStream(chunks: AsyncIterable<string>): Promise<void> {
+    this.streamConnected = true
+    let buffer = ''
+    for await (const chunk of chunks) {
+      if (this.stopped || this.reconciler.isTerminated) return
+      // ANY bytes (heartbeat comments included) prove transport liveness.
+      this.armStaleConnection()
+      buffer += chunk
+      const parsed = parseSSEBuffer(buffer)
+      buffer = parsed.remaining
+      for (const event of parsed.events) {
+        this.handleParsedEvent(event)
+        if (this.stopped || this.reconciler.isTerminated) return
+      }
+    }
+  }
+
+  private handleParsedEvent(parsed: {
+    id?: string
+    event?: string
+    data: string
+    retry?: number
+  }): void {
+    if (parsed.retry !== undefined && !Number.isNaN(parsed.retry)) {
+      this.serverRetryHintMs = parsed.retry
+    }
+    if (parsed.id !== undefined && parsed.id !== '') {
+      this.lastEventId = parsed.id
+    }
+
+    let data: unknown
+    try {
+      data = JSON.parse(parsed.data)
+    } catch (error) {
+      this.diagnostics.onStreamError?.(error)
+      return
+    }
+
+    // A data event (not a heartbeat) — reset the deadman.
+    this.idlePolls = 0
+    this.armDeadman()
+
+    const outcome = this.reconciler.handleEvent({
+      event: parsed.event ?? 'message',
+      data,
+      ...(parsed.id !== undefined ? { id: parsed.id } : {}),
+    })
+    if (outcome.duplicate) {
+      this.diagnostics.onDuplicate?.(parsed.event ?? 'message')
+    }
+    if (outcome.bufferOverflow) {
+      // Hydration buffer overflowed — drop-and-refetch.
+      this.schedulePoll()
+    }
+    if (outcome.gap) {
+      this.diagnostics.onGap?.(outcome.gap)
+      // A gap is a loss, not a reorder — polling is the only repair.
+      this.schedulePoll()
+    }
+    this.deliver(outcome.deliveries, outcome.state)
+    if (outcome.terminated) {
+      this.stop()
+    }
+  }
+
+  private onStaleConnection(): void {
+    // No bytes at all within the window: the connection is silently dead
+    // (the original incident class). Force-close; the stream loop reconnects
+    // and polls immediately.
+    this.currentStreamAbort?.abort()
+  }
+
+  private armStaleConnection(): void {
+    if (this.policy.staleConnectionTimeoutMs === 'off') return
+    this.staleConnection.arm(this.policy.staleConnectionTimeoutMs)
+  }
+
+  // --------------------------------------------------------------------
+  // Polling
+  // --------------------------------------------------------------------
+
+  private schedulePoll(): void {
+    if (this.stopped || this.reconciler.isTerminated) return
+    if (this.pollInFlight) {
+      this.pollQueued = true
+      return
+    }
+    void this.executePoll()
+  }
+
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: poll execution coordinates gating, status transitions, failure backoff, and coalescing in one place
+  private async executePoll(): Promise<void> {
+    this.pollInFlight = true
+    try {
+      const response = await this.transport.fetchSnapshot(
+        this.binding.buildSnapshotRequest(this.params),
+        { signal: this.abortController.signal },
+      )
+      if (this.stopped || this.reconciler.isTerminated) return
+
+      if (response.status < 200 || response.status >= 300) {
+        this.diagnostics.onPollError?.(
+          new Error(`Snapshot poll failed with status ${response.status}`),
+        )
+        if (this.policy.unretryableStatuses.includes(response.status)) {
+          this.stop()
+          return
+        }
+        this.pollFailures += 1
+        this.deadman.arm(
+          backoffDelay(this.policy.pollFailureBackoff, this.pollFailures, this.random),
+        )
+        return
+      }
+
+      this.pollFailures = 0
+      const outcome = this.reconciler.handleSnapshot(response.body as Snapshot)
+      if (outcome.stale) {
+        this.diagnostics.onStaleSnapshot?.()
+      }
+      this.deliver(outcome.deliveries, outcome.state)
+      if (outcome.hydrationCompleted && !this.stopped) {
+        // Hydration can complete while 'connecting' (normal startup) or
+        // 'polling' (first successful connect after starting degraded).
+        this.setStatus(this.streamConnected ? 'live' : 'reconnecting')
+      }
+      if (outcome.terminated) {
+        this.stop()
+        return
+      }
+
+      if (outcome.deliveries.length > 0) {
+        this.idlePolls = 0
+      } else {
+        this.idlePolls += 1
+      }
+      this.armDeadman()
+    } catch (error) {
+      if (this.stopped) return
+      this.diagnostics.onPollError?.(error)
+      this.pollFailures += 1
+      this.deadman.arm(backoffDelay(this.policy.pollFailureBackoff, this.pollFailures, this.random))
+    } finally {
+      this.pollInFlight = false
+      if (this.pollQueued && !this.stopped && !this.reconciler.isTerminated) {
+        this.pollQueued = false
+        void this.executePoll()
+      }
+    }
+  }
+
+  private armDeadman(): void {
+    if (this.stopped || this.reconciler.isTerminated) return
+    if (this.degraded) {
+      this.deadman.arm(this.policy.degradedPollIntervalMs)
+      return
+    }
+    const { factor, maxMs } = this.policy.deadmanIdleBackoff
+    const delay = Math.min(this.policy.deadmanDelayMs * factor ** this.idlePolls, maxMs)
+    this.deadman.arm(delay)
+  }
+
+  // --------------------------------------------------------------------
+  // Delivery + listeners
+  // --------------------------------------------------------------------
+
+  private deliver(
+    deliveries: ReadonlyArray<FallbackEvent<Events>>,
+    state: { value: unknown } | undefined,
+  ): void {
+    for (const event of deliveries) {
+      for (const listener of this.eventListeners) listener(event)
+      for (const feed of this.iteratorFeeds) feed.push(event)
+    }
+    if (state !== undefined) {
+      for (const listener of this.stateListeners) listener(state.value as State)
+    }
+  }
+
+  private setStatus(status: SubscriptionStatus): void {
+    if (this.statusValue === status) return
+    this.statusValue = status
+    for (const listener of this.statusListeners) listener(status)
+  }
+
+  private waitMatching(
+    matches: (event: FallbackEvent<Events>) => boolean,
+    opts?: { timeoutMs?: number },
+  ): Promise<FallbackEvent<Events>> {
+    return new Promise((resolve, reject) => {
+      if (this.stopped) {
+        reject(new Error('Subscription is stopped'))
+        return
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const offStatus = this.onStatusChange((status) => {
+        if (status === 'stopped') {
+          cleanup()
+          reject(new Error('Subscription stopped before the awaited event arrived'))
+        }
+      })
+      const offEvent = this.onEvent((event) => {
+        if (!matches(event)) return
+        cleanup()
+        resolve(event)
+      })
+      const cleanup = () => {
+        offEvent()
+        offStatus()
+        if (timer !== undefined) clearTimeout(timer)
+      }
+      if (opts?.timeoutMs !== undefined) {
+        timer = setTimeout(() => {
+          cleanup()
+          reject(new Error(`Timed out after ${opts.timeoutMs}ms waiting for event`))
+        }, opts.timeoutMs)
+        ;(timer as { unref?: () => void }).unref?.()
+      }
+    })
+  }
+}
+
+/**
+ * Create a resilient subscription: SSE as the low-latency channel, short
+ * polls as the correctness backbone. See the package README for the state
+ * machine and reconciliation semantics.
+ */
+export function createResilientSubscription<
+  Snapshot,
+  Events extends EventPayloadMap,
+  State = undefined,
+>(
+  binding: FallbackBinding<Snapshot, Events, State>,
+  options: CreateResilientSubscriptionOptions,
+): ResilientSubscription<Events, State> {
+  const impl = new ResilientSubscriptionImpl(binding, options)
+  return {
+    events: () => impl.events(),
+    onEvent: (listener) => impl.onEvent(listener),
+    getState: () => impl.getState(),
+    onStateChange: (listener) => impl.onStateChange(listener),
+    get status() {
+      return impl.status
+    },
+    onStatusChange: (listener) => impl.onStatusChange(listener),
+    nudge: () => impl.nudge(),
+    stop: () => impl.stop(),
+    waitFor: (event, opts) => impl.waitFor(event, opts),
+    waitForTerminal: (opts) => impl.waitForTerminal(opts),
+  }
+}

--- a/packages/sse-fallback/src/transport.ts
+++ b/packages/sse-fallback/src/transport.ts
@@ -1,0 +1,220 @@
+/**
+ * Transport seam: the core owns no HTTP. Implementations wrap fetch (browser,
+ * via @lokalise/frontend-http-client), undici (Node), or scripted fixtures
+ * (tests). Response-body validation (zod) belongs in the transport wrapper,
+ * keeping this package dependency-free.
+ */
+
+/** A channel-agnostic request description built from the binding + params. */
+export type TransportRequest = {
+  /** Resolved path (path params already substituted), no query string. */
+  path: string
+  /** Lowercase HTTP method from the contract. */
+  method: string
+  /** Query parameters, already stringified. */
+  query?: Record<string, string>
+  /** Extra request headers (auth etc. belongs in the transport itself). */
+  headers?: Record<string, string>
+  /** Request body for payload contracts. */
+  body?: unknown
+}
+
+export type SnapshotResponse = {
+  status: number
+  headers: Record<string, string>
+  /** Parsed response body (transport decides how; typically response.json()). */
+  body: unknown
+}
+
+export type StreamResponse = {
+  status: number
+  headers: Record<string, string>
+  /**
+   * Decoded text chunks as they arrive — INCLUDING comment/heartbeat frames.
+   * The core parses SSE framing itself (vendored parser) and uses per-chunk
+   * arrival as byte-level liveness. Iteration ends when the stream closes;
+   * it throws on a mid-stream network error.
+   */
+  chunks: AsyncIterable<string>
+}
+
+export type FallbackTransport = {
+  /**
+   * Fetch a snapshot (the JSON branch). Resolves with status/body even for
+   * non-2xx responses; rejects only on network-level failure.
+   */
+  fetchSnapshot(request: TransportRequest, opts: { signal: AbortSignal }): Promise<SnapshotResponse>
+  /**
+   * Open the SSE branch. Resolves once response headers are received;
+   * rejects only on network-level failure. A non-200 status (or a
+   * non-`text/event-stream` content type) is a CONNECT FAILURE the core
+   * counts toward degradation.
+   */
+  openStream(
+    request: TransportRequest,
+    opts: { signal: AbortSignal; lastEventId?: string },
+  ): Promise<StreamResponse>
+}
+
+// ============================================================================
+// TestTransport — scripted transport for deterministic tests
+// ============================================================================
+
+type PendingChunk =
+  | { kind: 'chunk'; text: string }
+  | { kind: 'close' }
+  | { kind: 'error'; error: Error }
+
+type StreamController = {
+  push(chunk: PendingChunk): void
+  aborted: boolean
+}
+
+export type TestStreamHandle = {
+  /** Emit a complete SSE event frame. */
+  pushEvent(event: string, data: unknown, opts?: { id?: string; retry?: number }): void
+  /** Emit a heartbeat comment frame (byte activity without a data event). */
+  pushHeartbeat(): void
+  /** Emit a raw text chunk verbatim. */
+  pushRaw(text: string): void
+  /** End the stream normally (server close). */
+  close(): void
+  /** Fail the stream mid-flight (network error). */
+  fail(error?: Error): void
+  readonly lastEventIdReceived: string | undefined
+  readonly request: TransportRequest
+}
+
+export type TestSnapshotCall = {
+  request: TransportRequest
+  respond(body: unknown, status?: number): void
+  fail(error?: Error): void
+}
+
+/**
+ * Scripted {@link FallbackTransport} for unit tests. Pairs with fake timers:
+ * snapshot calls and stream connects are surfaced through the `onSnapshot` /
+ * `onStreamConnect` hooks (or the corresponding queues), and streams are
+ * driven manually via {@link TestStreamHandle}.
+ */
+export class TestTransport implements FallbackTransport {
+  /** Called for every snapshot fetch; respond synchronously or later. */
+  onSnapshot?: (call: TestSnapshotCall) => void
+  /** Called for every stream connect attempt after it is accepted. */
+  onStreamConnect?: (stream: TestStreamHandle) => void
+  /** Statuses (or an Error) to reject/deny the next N stream connects with. */
+  private readonly connectDenials: Array<{ status?: number; error?: Error }> = []
+  readonly snapshotCalls: TransportRequest[] = []
+  readonly streamConnects: TransportRequest[] = []
+
+  /** Queue a denial for the next stream connect (non-200 status or network error). */
+  denyNextStreamConnect(denial: { status?: number; error?: Error }): void {
+    this.connectDenials.push(denial)
+  }
+
+  fetchSnapshot(
+    request: TransportRequest,
+    opts: { signal: AbortSignal },
+  ): Promise<SnapshotResponse> {
+    this.snapshotCalls.push(request)
+    return new Promise<SnapshotResponse>((resolve, reject) => {
+      if (opts.signal.aborted) {
+        reject(new Error('aborted'))
+        return
+      }
+      opts.signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+      const call: TestSnapshotCall = {
+        request,
+        respond: (body, status = 200) => resolve({ status, headers: {}, body }),
+        fail: (error) => reject(error ?? new Error('snapshot network failure')),
+      }
+      if (this.onSnapshot) {
+        this.onSnapshot(call)
+      } else {
+        reject(new Error('TestTransport.onSnapshot is not configured'))
+      }
+    })
+  }
+
+  openStream(
+    request: TransportRequest,
+    opts: { signal: AbortSignal; lastEventId?: string },
+  ): Promise<StreamResponse> {
+    this.streamConnects.push(request)
+
+    const denial = this.connectDenials.shift()
+    if (denial?.error) {
+      return Promise.reject(denial.error)
+    }
+    if (denial?.status !== undefined) {
+      return Promise.resolve({
+        status: denial.status,
+        headers: {},
+        chunks: emptyChunks(),
+      })
+    }
+
+    const queue: PendingChunk[] = []
+    let notify: (() => void) | undefined
+    const controller: StreamController = {
+      aborted: false,
+      push: (chunk) => {
+        queue.push(chunk)
+        notify?.()
+      },
+    }
+    opts.signal.addEventListener(
+      'abort',
+      () => {
+        controller.aborted = true
+        notify?.()
+      },
+      { once: true },
+    )
+
+    const handle: TestStreamHandle = {
+      pushEvent: (event, data, eventOpts) => {
+        let frame = ''
+        if (eventOpts?.id !== undefined) frame += `id: ${eventOpts.id}\n`
+        frame += `event: ${event}\ndata: ${JSON.stringify(data)}\n`
+        if (eventOpts?.retry !== undefined) frame += `retry: ${eventOpts.retry}\n`
+        controller.push({ kind: 'chunk', text: `${frame}\n` })
+      },
+      pushHeartbeat: () => controller.push({ kind: 'chunk', text: ': heartbeat\n\n' }),
+      pushRaw: (text) => controller.push({ kind: 'chunk', text }),
+      close: () => controller.push({ kind: 'close' }),
+      fail: (error) =>
+        controller.push({ kind: 'error', error: error ?? new Error('stream network failure') }),
+      lastEventIdReceived: opts.lastEventId,
+      request,
+    }
+
+    const chunks = (async function* (): AsyncGenerator<string, void, unknown> {
+      while (true) {
+        if (controller.aborted) return
+        const next = queue.shift()
+        if (!next) {
+          await new Promise<void>((resolve) => {
+            notify = resolve
+          })
+          notify = undefined
+          continue
+        }
+        if (next.kind === 'close') return
+        if (next.kind === 'error') throw next.error
+        yield next.text
+      }
+    })()
+
+    this.onStreamConnect?.(handle)
+    return Promise.resolve({
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+      chunks,
+    })
+  }
+}
+
+async function* emptyChunks(): AsyncGenerator<string, void, unknown> {
+  // no chunks — used for denied connects
+}

--- a/packages/sse-fallback/tsconfig.build.json
+++ b/packages/sse-fallback/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": ["./tsconfig.json", "@lokalise/tsconfig/build-public-lib"],
+    "compilerOptions": {
+        "lib": ["ES2022", "DOM"],
+        "types": []
+    },
+    "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/packages/sse-fallback/tsconfig.json
+++ b/packages/sse-fallback/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "declaration": true,
+        "declarationMap": true,
+        "noEmit": true,
+        "lib": ["ES2022", "DOM"],
+        "types": []
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/sse-fallback/vitest.config.ts
+++ b/packages/sse-fallback/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+// biome-ignore lint/style/noDefaultExport: vite expects default export
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    typecheck: {
+      enabled: true,
+      include: ['src/**/*.spec.ts'],
+    },
+    testTimeout: 10000,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,33 @@ importers:
         specifier: ^4.0.18
         version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@22.20.1)(yaml@2.9.0))
 
+  packages/sse-fallback:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.4
+        version: 2.4.4
+      '@lokalise/api-contracts':
+        specifier: ^7.1.0
+        version: 7.1.0(zod@4.4.3)
+      '@lokalise/biome-config':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@lokalise/tsconfig':
+        specifier: ^3.1.0
+        version: 3.1.0
+      rimraf:
+        specifier: ^6.1.2
+        version: 6.1.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@22.20.1)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
   packages/sse-rooms-redis:
     devDependencies:
       '@biomejs/biome':
@@ -784,9 +811,6 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
@@ -2113,8 +2137,6 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.3: {}
-
   fast-uri@3.1.5: {}
 
   fast-uri@4.1.2: {}
@@ -2284,7 +2306,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.5
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color

--- a/test/api-contracts/api.rooms.e2e.spec.ts
+++ b/test/api-contracts/api.rooms.e2e.spec.ts
@@ -1,0 +1,201 @@
+import { defineApiContract, sseBody } from '@lokalise/api-contracts'
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod/v4'
+import { defineEvent, SSEHttpClient, SSERoomBroadcaster, SSERoomManager } from '../../index.js'
+import { buildApiRoute } from '../../lib/api-contracts/index.ts'
+import { createSSETestServer, type SSETestServerWithResources } from '../sseTestServerFactory.js'
+
+/**
+ * Rooms in the modern api-contracts path (buildApiRoute + options.sseRooms).
+ *
+ * The flagship dual-mode pattern for the polling-fallback feature: the SSE
+ * branch of a dual-mode route joins a room and receives broadcasts pushed by
+ * a domain service, while the sync branch of the SAME route answers JSON
+ * polls. Previously session.rooms was a silent no-op stub in this path.
+ */
+
+const messageEvent = defineEvent('message', z.object({ from: z.string(), text: z.string() }))
+
+const roomStreamContract = defineApiContract({
+  method: 'get',
+  summary: 'Dual-mode room stream',
+  pathResolver: ({ roomId }) => `/api/rooms-modern/${roomId}/stream`,
+  requestPathParamsSchema: z.object({ roomId: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({ roomId: z.string(), source: z.string() }),
+        'text/event-stream': sseBody({
+          message: z.object({ from: z.string(), text: z.string() }),
+        }),
+      },
+    },
+  },
+})
+
+describe('buildApiRoute rooms E2E (dual-mode + keepAlive + sseRooms)', () => {
+  let server: SSETestServerWithResources<undefined>
+  let broadcaster: SSERoomBroadcaster
+
+  beforeEach(async () => {
+    const sseRoomManager = new SSERoomManager()
+    broadcaster = new SSERoomBroadcaster({ sseRoomManager })
+
+    server = await createSSETestServer(
+      (app) => {
+        app.route(
+          buildApiRoute(
+            roomStreamContract,
+            {
+              nonSse: async (request) => ({
+                status: 200,
+                body: { roomId: request.params.roomId, source: 'poll' },
+              }),
+              sse: (request, sse) => {
+                const session = sse.start('keepAlive')
+                session.rooms.join(`room:${request.params.roomId}`)
+              },
+            },
+            { sseRooms: broadcaster },
+          ),
+        )
+      },
+      {
+        configureApp: (app) => {
+          app.setValidatorCompiler(validatorCompiler)
+          app.setSerializerCompiler(serializerCompiler)
+        },
+        setup: () => undefined,
+      },
+    )
+  })
+
+  afterEach(async () => {
+    await server.close()
+  })
+
+  it(
+    'delivers room broadcasts to a session opened via buildApiRoute',
+    { timeout: 10000 },
+    async () => {
+      const client = await SSEHttpClient.connect(server.baseUrl, '/api/rooms-modern/alpha/stream')
+
+      // Wait until the server-side session has joined the room
+      await vi.waitFor(() => {
+        expect(broadcaster.getConnectionCountInRoom('room:alpha')).toBe(1)
+      })
+
+      const eventsPromise = client.collectEvents(1, 5000)
+      const delivered = await broadcaster.broadcastToRoom('room:alpha', messageEvent, {
+        from: 'service',
+        text: 'hello room',
+      })
+      expect(delivered).toBe(1)
+
+      const events = await eventsPromise
+      expect(events).toHaveLength(1)
+      expect(events[0]!.event).toBe('message')
+      expect(JSON.parse(events[0]!.data)).toEqual({ from: 'service', text: 'hello room' })
+
+      client.close()
+    },
+  )
+
+  it('scopes broadcasts to the joined room', { timeout: 10000 }, async () => {
+    const clientAlpha = await SSEHttpClient.connect(
+      server.baseUrl,
+      '/api/rooms-modern/alpha/stream',
+    )
+    const clientBeta = await SSEHttpClient.connect(server.baseUrl, '/api/rooms-modern/beta/stream')
+
+    await vi.waitFor(() => {
+      expect(broadcaster.getConnectionCountInRoom('room:alpha')).toBe(1)
+      expect(broadcaster.getConnectionCountInRoom('room:beta')).toBe(1)
+    })
+
+    const alphaEvents = clientAlpha.collectEvents(1, 5000)
+    const delivered = await broadcaster.broadcastToRoom('room:alpha', messageEvent, {
+      from: 'service',
+      text: 'alpha only',
+    })
+    expect(delivered).toBe(1)
+
+    const events = await alphaEvents
+    expect(JSON.parse(events[0]!.data)).toEqual({ from: 'service', text: 'alpha only' })
+
+    clientAlpha.close()
+    clientBeta.close()
+  })
+
+  it(
+    'answers JSON polls on the same route while a room session is live',
+    { timeout: 10000 },
+    async () => {
+      const client = await SSEHttpClient.connect(server.baseUrl, '/api/rooms-modern/alpha/stream')
+      await vi.waitFor(() => {
+        expect(broadcaster.getConnectionCountInRoom('room:alpha')).toBe(1)
+      })
+
+      // Cross-branch: an Accept: application/json request to the same path
+      // is served by the sync handler — the deadman-poll side of the pattern.
+      const pollResponse = await server.app.inject({
+        method: 'GET',
+        url: '/api/rooms-modern/alpha/stream',
+        headers: { accept: 'application/json' },
+      })
+      expect(pollResponse.statusCode).toBe(200)
+      expect(pollResponse.headers['content-type']).toContain('application/json')
+      expect(JSON.parse(pollResponse.body)).toEqual({ roomId: 'alpha', source: 'poll' })
+
+      // The room membership is unaffected by the poll
+      expect(broadcaster.getConnectionCountInRoom('room:alpha')).toBe(1)
+
+      client.close()
+    },
+  )
+
+  it('cleans up room membership when the client disconnects', { timeout: 10000 }, async () => {
+    const client = await SSEHttpClient.connect(server.baseUrl, '/api/rooms-modern/alpha/stream')
+    await vi.waitFor(() => {
+      expect(broadcaster.getConnectionCountInRoom('room:alpha')).toBe(1)
+    })
+
+    client.close()
+
+    await vi.waitFor(() => {
+      expect(broadcaster.getConnectionCountInRoom('room:alpha')).toBe(0)
+    })
+
+    // Broadcasting into the now-empty room delivers to nobody
+    const delivered = await broadcaster.broadcastToRoom('room:alpha', messageEvent, {
+      from: 'service',
+      text: 'anyone there?',
+    })
+    expect(delivered).toBe(0)
+  })
+
+  it('delivers to multiple sessions in the same room', { timeout: 10000 }, async () => {
+    const clientA = await SSEHttpClient.connect(server.baseUrl, '/api/rooms-modern/shared/stream')
+    const clientB = await SSEHttpClient.connect(server.baseUrl, '/api/rooms-modern/shared/stream')
+
+    await vi.waitFor(() => {
+      expect(broadcaster.getConnectionCountInRoom('room:shared')).toBe(2)
+    })
+
+    const eventsA = clientA.collectEvents(1, 5000)
+    const eventsB = clientB.collectEvents(1, 5000)
+
+    const delivered = await broadcaster.broadcastToRoom('room:shared', messageEvent, {
+      from: 'service',
+      text: 'both of you',
+    })
+    expect(delivered).toBe(2)
+
+    expect(JSON.parse((await eventsA)[0]!.data)).toEqual({ from: 'service', text: 'both of you' })
+    expect(JSON.parse((await eventsB)[0]!.data)).toEqual({ from: 'service', text: 'both of you' })
+
+    clientA.close()
+    clientB.close()
+  })
+})

--- a/test/sse/sse.acceptNegotiation.e2e.spec.ts
+++ b/test/sse/sse.acceptNegotiation.e2e.spec.ts
@@ -1,0 +1,320 @@
+import { buildSseContract, defineApiContract, sseBody } from '@lokalise/api-contracts'
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import {
+  AbstractDualModeController,
+  AbstractSSEController,
+  type BuildFastifyDualModeRoutesReturnType,
+  type BuildFastifySSERoutesReturnType,
+  buildFastifyRoute,
+  buildHandler,
+} from '../../index.js'
+import { buildApiRoute } from '../../lib/api-contracts/index.ts'
+import { createSSETestServer, type SSETestServerWithResources } from '../sseTestServerFactory.js'
+
+/**
+ * Accept-negotiation matrix for SSE-only and dual-mode routes under
+ * @fastify/sse 0.6 route kinds.
+ *
+ * SSE-only routes use kind 'only' (lenient gate): `*` / missing Accept
+ * streams, explicit refusal of text/event-stream gets a 406.
+ * Dual-mode routes use kind 'manual': the plugin does no negotiation and
+ * determineMode() (q-value aware, honors defaultMode) decides sync vs SSE.
+ *
+ * These tests deliberately send Accept headers the rest of the suite never
+ * sends (missing, `*`, `q=0`) — the old `sse: true` (kind 'legacy') setup
+ * crashed on several of them.
+ */
+
+// ---------------------------------------------------------------------------
+// Modern api-contracts fixtures
+// ---------------------------------------------------------------------------
+
+const modernSseContract = defineApiContract({
+  method: 'get',
+  summary: 'Accept matrix — modern SSE-only',
+  pathResolver: () => '/api/modern/stream',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }),
+      },
+    },
+  },
+})
+
+const modernDualContract = defineApiContract({
+  method: 'get',
+  summary: 'Accept matrix — modern dual',
+  pathResolver: () => '/api/modern/dual',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({ source: z.string() }),
+        'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }),
+      },
+    },
+  },
+})
+
+const modernDualSseDefaultContract = defineApiContract({
+  method: 'get',
+  summary: 'Accept matrix — modern dual, SSE default',
+  pathResolver: () => '/api/modern/dual-sse-default',
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({ source: z.string() }),
+        'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }),
+      },
+    },
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Legacy contract fixtures
+// ---------------------------------------------------------------------------
+
+const legacySseContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/api/legacy/stream',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+const legacyDualContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/api/legacy/dual',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  successResponseBodySchema: z.object({ source: z.string() }),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+const legacyDualSseDefaultContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/api/legacy/dual-sse-default',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  successResponseBodySchema: z.object({ source: z.string() }),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+class LegacyStreamController extends AbstractSSEController<{
+  stream: typeof legacySseContract
+}> {
+  buildSSERoutes(): BuildFastifySSERoutesReturnType<{ stream: typeof legacySseContract }> {
+    return { stream: this.handleStream }
+  }
+
+  private handleStream = buildHandler(legacySseContract, {
+    sse: async (_request, sse) => {
+      const session = sse.start('autoClose')
+      await session.send('tick', { n: 1 })
+    },
+  })
+}
+
+class LegacyDualController extends AbstractDualModeController<{
+  dual: typeof legacyDualContract
+  dualSseDefault: typeof legacyDualSseDefaultContract
+}> {
+  buildDualModeRoutes(): BuildFastifyDualModeRoutesReturnType<{
+    dual: typeof legacyDualContract
+    dualSseDefault: typeof legacyDualSseDefaultContract
+  }> {
+    return { dual: this.handleDual, dualSseDefault: this.handleDualSseDefault }
+  }
+
+  private handleDual = buildHandler(legacyDualContract, {
+    sync: async () => ({ source: 'json' }),
+    sse: async (_request, sse) => {
+      const session = sse.start('autoClose')
+      await session.send('tick', { n: 1 })
+    },
+  })
+
+  private handleDualSseDefault = buildHandler(
+    legacyDualSseDefaultContract,
+    {
+      sync: async () => ({ source: 'json' }),
+      sse: async (_request, sse) => {
+        const session = sse.start('autoClose')
+        await session.send('tick', { n: 1 })
+      },
+    },
+    { defaultMode: 'sse' },
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Accept negotiation E2E (SSE-only and dual-mode)', () => {
+  let server: SSETestServerWithResources<undefined>
+
+  beforeAll(async () => {
+    const legacyStreamController = new LegacyStreamController({})
+    const legacyDualController = new LegacyDualController({})
+
+    server = await createSSETestServer(
+      (app) => {
+        app.route(
+          buildApiRoute(modernSseContract, async (_request, sse) => {
+            const session = sse.start('autoClose')
+            await session.send('tick', { n: 1 })
+          }),
+        )
+        app.route(
+          buildApiRoute(modernDualContract, {
+            nonSse: async () => ({ status: 200, body: { source: 'json' } }),
+            sse: async (_request, sse) => {
+              const session = sse.start('autoClose')
+              await session.send('tick', { n: 1 })
+            },
+          }),
+        )
+        app.route(
+          buildApiRoute(
+            modernDualSseDefaultContract,
+            {
+              nonSse: async () => ({ status: 200, body: { source: 'json' } }),
+              sse: async (_request, sse) => {
+                const session = sse.start('autoClose')
+                await session.send('tick', { n: 1 })
+              },
+            },
+            { defaultMode: 'sse' },
+          ),
+        )
+        for (const routeConfig of Object.values(legacyStreamController.buildSSERoutes())) {
+          app.route(buildFastifyRoute(legacyStreamController, routeConfig))
+        }
+        for (const routeConfig of Object.values(legacyDualController.buildDualModeRoutes())) {
+          app.route(buildFastifyRoute(legacyDualController, routeConfig))
+        }
+      },
+      {
+        configureApp: (app) => {
+          app.setValidatorCompiler(validatorCompiler)
+          app.setSerializerCompiler(serializerCompiler)
+        },
+        setup: () => undefined,
+      },
+    )
+  })
+
+  afterAll(async () => {
+    await server.close()
+  })
+
+  const inject = (url: string, accept?: string) =>
+    server.app.inject({
+      method: 'GET',
+      url,
+      headers: accept === undefined ? {} : { accept },
+    })
+
+  describe.each([
+    ['modern', '/api/modern/stream'],
+    ['legacy', '/api/legacy/stream'],
+  ])('SSE-only route (%s path)', (_generation, url) => {
+    it('streams when Accept is text/event-stream', async () => {
+      const response = await inject(url, 'text/event-stream')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+      expect(response.body).toContain('event: tick')
+    })
+
+    it('streams when Accept header is missing', async () => {
+      const response = await inject(url)
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+      expect(response.body).toContain('event: tick')
+    })
+
+    it('streams when Accept is */*', async () => {
+      const response = await inject(url, '*/*')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+    })
+
+    it('returns 406 when Accept refuses SSE (application/json)', async () => {
+      const response = await inject(url, 'application/json')
+      expect(response.statusCode).toBe(406)
+    })
+
+    it('returns 406 when Accept rejects SSE explicitly (q=0)', async () => {
+      const response = await inject(url, 'text/event-stream;q=0')
+      expect(response.statusCode).toBe(406)
+    })
+  })
+
+  describe.each([
+    ['modern', '/api/modern/dual'],
+    ['legacy', '/api/legacy/dual'],
+  ])('dual-mode route, defaultMode json (%s path)', (_generation, url) => {
+    it('returns JSON when Accept is application/json', async () => {
+      const response = await inject(url, 'application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('application/json')
+      expect(JSON.parse(response.body)).toEqual({ source: 'json' })
+    })
+
+    it('streams when Accept is text/event-stream', async () => {
+      const response = await inject(url, 'text/event-stream')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+      expect(response.body).toContain('event: tick')
+    })
+
+    it('returns JSON (default) when Accept header is missing', async () => {
+      const response = await inject(url)
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('application/json')
+      expect(JSON.parse(response.body)).toEqual({ source: 'json' })
+    })
+
+    it('returns JSON (default) when Accept is */*', async () => {
+      const response = await inject(url, '*/*')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('application/json')
+    })
+
+    it('prefers SSE when q-values rank it higher', async () => {
+      const response = await inject(url, 'application/json;q=0.5, text/event-stream;q=0.9')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+    })
+  })
+
+  describe.each([
+    ['modern', '/api/modern/dual-sse-default'],
+    ['legacy', '/api/legacy/dual-sse-default'],
+  ])('dual-mode route, defaultMode sse (%s path)', (_generation, url) => {
+    it('streams when Accept header is missing', async () => {
+      const response = await inject(url)
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+      expect(response.body).toContain('event: tick')
+    })
+
+    it('streams when Accept is */* (crashed under kind legacy)', async () => {
+      const response = await inject(url, '*/*')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('text/event-stream')
+    })
+
+    it('still returns JSON when Accept explicitly asks for application/json', async () => {
+      const response = await inject(url, 'application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.headers['content-type']).toContain('application/json')
+    })
+  })
+})

--- a/test/sse/sse.heartbeat.e2e.spec.ts
+++ b/test/sse/sse.heartbeat.e2e.spec.ts
@@ -1,0 +1,257 @@
+import FastifySSEPlugin from '@fastify/sse'
+import { buildSseContract, defineApiContract, sseBody } from '@lokalise/api-contracts'
+import { createContainer } from 'awilix'
+import fastify, { type FastifyInstance } from 'fastify'
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod/v4'
+import {
+  AbstractModule,
+  AbstractSSEController,
+  asSSEControllerClass,
+  type BuildFastifySSERoutesReturnType,
+  buildFastifyRoute,
+  buildHandler,
+  type DependencyInjectionOptions,
+  DIContext,
+  type MandatoryNameAndRegistrationPair,
+  SSEHttpClient,
+  SSETestServer,
+} from '../../index.js'
+import { buildApiRoute } from '../../lib/api-contracts/index.ts'
+
+/**
+ * Per-route heartbeat E2E under @fastify/sse 0.6.
+ *
+ * The plugin only supports a plugin-level heartbeat interval; route-level
+ * intervals are implemented by a framework-managed timer (the plugin's own
+ * heartbeat is disabled per route via `heartbeat: false`). These tests pin:
+ * - route-level intervals actually emit heartbeats (previously a silent no-op),
+ * - `heartbeatInterval: false` silences a route even when the plugin-level
+ *   heartbeat is fast,
+ * - registration-time intervals (DIContext.registerSSERoutes options —
+ *   previously written to a config location the plugin never read) work,
+ * - the plugin-level default still applies to routes without overrides.
+ *
+ * Server A runs the plugin heartbeat at 60s, so any heartbeat observed within
+ * the sub-second test window must come from the framework timer.
+ * Server B runs the plugin heartbeat at 100ms to prove disabling works.
+ */
+
+const modernFrameworkContract = defineApiContract({
+  method: 'get',
+  summary: 'Heartbeat — modern framework timer',
+  pathResolver: () => '/hb/framework-modern',
+  responsesByStatusCode: {
+    200: { content: { 'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }) } },
+  },
+})
+
+const modernDisabledContract = defineApiContract({
+  method: 'get',
+  summary: 'Heartbeat — disabled',
+  pathResolver: () => '/hb/disabled',
+  responsesByStatusCode: {
+    200: { content: { 'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }) } },
+  },
+})
+
+const modernPluginDefaultContract = defineApiContract({
+  method: 'get',
+  summary: 'Heartbeat — plugin default',
+  pathResolver: () => '/hb/plugin-default',
+  responsesByStatusCode: {
+    200: { content: { 'text/event-stream': sseBody({ tick: z.object({ n: z.number() }) }) } },
+  },
+})
+
+const legacyFrameworkContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/hb/framework-legacy',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+const registrationContract = buildSseContract({
+  method: 'get',
+  pathResolver: () => '/hb/registration',
+  requestPathParamsSchema: z.object({}),
+  requestQuerySchema: z.object({}),
+  requestHeaderSchema: z.object({}),
+  serverSentEventSchemas: { tick: z.object({ n: z.number() }) },
+})
+
+class LegacyHeartbeatController extends AbstractSSEController<{
+  stream: typeof legacyFrameworkContract
+}> {
+  buildSSERoutes(): BuildFastifySSERoutesReturnType<{ stream: typeof legacyFrameworkContract }> {
+    return { stream: this.handleStream }
+  }
+
+  private handleStream = buildHandler(
+    legacyFrameworkContract,
+    {
+      sse: (_request, sse) => {
+        sse.start('keepAlive')
+      },
+    },
+    { heartbeatInterval: 100 },
+  )
+}
+
+class RegistrationHeartbeatController extends AbstractSSEController<{
+  stream: typeof registrationContract
+}> {
+  buildSSERoutes(): BuildFastifySSERoutesReturnType<{ stream: typeof registrationContract }> {
+    return { stream: this.handleStream }
+  }
+
+  private handleStream = buildHandler(registrationContract, {
+    sse: (_request, sse) => {
+      sse.start('keepAlive')
+    },
+  })
+}
+
+class RegistrationHeartbeatModule extends AbstractModule {
+  resolveDependencies() {
+    return {}
+  }
+
+  override resolveControllers(
+    diOptions: DependencyInjectionOptions,
+  ): MandatoryNameAndRegistrationPair<unknown> {
+    return {
+      registrationHeartbeatController: asSSEControllerClass(RegistrationHeartbeatController, {
+        diOptions,
+      }),
+    }
+  }
+}
+
+async function startServer(
+  pluginHeartbeatMs: number,
+  registerRoutes: (app: FastifyInstance) => void,
+): Promise<SSETestServer> {
+  const app = fastify()
+  await app.register(FastifySSEPlugin as unknown as Parameters<typeof app.register>[0], {
+    heartbeatInterval: pluginHeartbeatMs,
+  })
+  app.setValidatorCompiler(validatorCompiler)
+  app.setSerializerCompiler(serializerCompiler)
+  registerRoutes(app)
+  return SSETestServer.start(app)
+}
+
+/**
+ * Connect to a keepAlive SSE route and count `: heartbeat` comment frames
+ * observed within the given window.
+ */
+async function countHeartbeats(baseUrl: string, path: string, windowMs: number): Promise<number> {
+  const client = await SSEHttpClient.connect(baseUrl, path)
+  let count = 0
+  client.onRawChunk = (chunk) => {
+    count += chunk.split(': heartbeat').length - 1
+  }
+  const abort = new AbortController()
+  const timer = setTimeout(() => abort.abort(), windowMs)
+  try {
+    for await (const _event of client.events(abort.signal)) {
+      // no data events are expected — iterating drains the stream so
+      // onRawChunk observes heartbeat comment frames
+    }
+  } finally {
+    clearTimeout(timer)
+    client.close()
+  }
+  return count
+}
+
+describe('SSE heartbeat E2E', () => {
+  describe('framework-managed route-level heartbeats (plugin heartbeat at 60s)', () => {
+    let server: SSETestServer
+    let context: DIContext<object, object>
+
+    beforeAll(async () => {
+      const container = createContainer({ injectionMode: 'PROXY' })
+      context = new DIContext<object, object>(container, {}, {})
+      context.registerDependencies({ modules: [new RegistrationHeartbeatModule()] }, undefined)
+
+      const legacyController = new LegacyHeartbeatController({})
+      server = await startServer(60_000, (app) => {
+        app.route(
+          buildApiRoute(
+            modernFrameworkContract,
+            (_request, sse) => {
+              sse.start('keepAlive')
+            },
+            { heartbeatInterval: 100 },
+          ),
+        )
+        for (const routeConfig of Object.values(legacyController.buildSSERoutes())) {
+          app.route(buildFastifyRoute(legacyController, routeConfig))
+        }
+        context.registerSSERoutes(app, { heartbeatInterval: 100 })
+      })
+    })
+
+    afterAll(async () => {
+      await context.destroy()
+      await server.close()
+    })
+
+    it('modern route with heartbeatInterval: 100 emits framework heartbeats', async () => {
+      const count = await countHeartbeats(server.baseUrl, '/hb/framework-modern', 550)
+      expect(count).toBeGreaterThanOrEqual(2)
+    })
+
+    it('legacy route with heartbeatInterval: 100 emits framework heartbeats', async () => {
+      const count = await countHeartbeats(server.baseUrl, '/hb/framework-legacy', 550)
+      expect(count).toBeGreaterThanOrEqual(2)
+    })
+
+    it('registration-time heartbeatInterval (registerSSERoutes options) emits heartbeats', async () => {
+      const count = await countHeartbeats(server.baseUrl, '/hb/registration', 550)
+      expect(count).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('disabling and plugin defaults (plugin heartbeat at 100ms)', () => {
+    let server: SSETestServer
+
+    beforeAll(async () => {
+      server = await startServer(100, (app) => {
+        app.route(
+          buildApiRoute(
+            modernDisabledContract,
+            (_request, sse) => {
+              sse.start('keepAlive')
+            },
+            { heartbeatInterval: false },
+          ),
+        )
+        app.route(
+          buildApiRoute(modernPluginDefaultContract, (_request, sse) => {
+            sse.start('keepAlive')
+          }),
+        )
+      })
+    })
+
+    afterAll(async () => {
+      await server.close()
+    })
+
+    it('heartbeatInterval: false silences the route despite a fast plugin heartbeat', async () => {
+      const count = await countHeartbeats(server.baseUrl, '/hb/disabled', 550)
+      expect(count).toBe(0)
+    })
+
+    it('routes without overrides still get the plugin-level heartbeat', async () => {
+      const count = await countHeartbeats(server.baseUrl, '/hb/plugin-default', 550)
+      expect(count).toBeGreaterThanOrEqual(2)
+    })
+  })
+})

--- a/test/sse/sseFallback.integration.e2e.spec.ts
+++ b/test/sse/sseFallback.integration.e2e.spec.ts
@@ -1,0 +1,386 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { defineApiContract, sseBody } from '@lokalise/api-contracts'
+import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod/v4'
+import {
+  createEventIdSequence,
+  defineEvent,
+  type EventIdSequence,
+  SSERoomBroadcaster,
+  SSERoomManager,
+} from '../../index.js'
+import { buildApiRoute } from '../../lib/api-contracts/index.ts'
+import {
+  createResilientSubscription,
+  defineFallbackBinding,
+  type FallbackPolicy,
+  type FallbackTransport,
+} from '../../packages/sse-fallback/src/index.ts'
+import { createSSETestServer, type SSETestServerWithResources } from '../sseTestServerFactory.js'
+
+/**
+ * End-to-end integration of @opinionated-machine/sse-fallback against the
+ * real server machinery: a dual-mode `buildApiRoute` route whose sync branch
+ * answers polls from a job store while its SSE branch joins a room that a
+ * "domain service" broadcasts into with monotonic event ids.
+ */
+
+// ---------------------------------------------------------------------------
+// Server fixtures
+// ---------------------------------------------------------------------------
+
+type Job = { status: 'pending' | 'completed'; result?: string; version: number }
+
+const progressEvent = defineEvent('progress', z.object({ percent: z.number() }))
+const doneEvent = defineEvent('done', z.object({ result: z.string() }))
+
+const jobContract = defineApiContract({
+  method: 'get',
+  summary: 'Job status (dual-mode)',
+  pathResolver: ({ jobId }) => `/api/fallback-jobs/${jobId}`,
+  requestPathParamsSchema: z.object({ jobId: z.string() }),
+  responsesByStatusCode: {
+    200: {
+      content: {
+        'application/json': z.object({
+          status: z.enum(['pending', 'completed']),
+          result: z.string().optional(),
+          version: z.number(),
+        }),
+        'text/event-stream': sseBody({
+          progress: z.object({ percent: z.number() }),
+          done: z.object({ result: z.string() }),
+        }),
+      },
+    },
+  },
+})
+
+const jobBinding = defineFallbackBinding(jobContract, {
+  snapshotToEvents: (s) =>
+    s.status === 'completed' ? [{ event: 'done', data: { result: s.result as string } }] : [],
+  version: { ofSnapshot: (s) => s.version },
+  terminalEvents: ['done'],
+})
+
+/** In-memory job store + broadcaster — the "domain service" side. */
+class JobService {
+  private readonly jobs = new Map<string, Job>()
+  private readonly sequences = new Map<string, EventIdSequence>()
+  private readonly broadcaster: SSERoomBroadcaster
+
+  constructor(broadcaster: SSERoomBroadcaster) {
+    this.broadcaster = broadcaster
+  }
+
+  create(jobId: string): void {
+    this.jobs.set(jobId, { status: 'pending', version: 0 })
+    this.sequences.set(jobId, createEventIdSequence({ epoch: '0' }))
+  }
+
+  get(jobId: string): Job {
+    return this.jobs.get(jobId) ?? { status: 'pending', version: 0 }
+  }
+
+  private nextVersion(jobId: string): { version: number; id: string } {
+    const job = this.jobs.get(jobId) as Job
+    job.version += 1
+    const seq = this.sequences.get(jobId) as EventIdSequence
+    return { version: job.version, id: seq.next() }
+  }
+
+  async progress(jobId: string, percent: number): Promise<void> {
+    const { version } = this.nextVersion(jobId)
+    // Stamp the raw version as the SSE id so the client's default
+    // `Number(id)` version extraction lines up with the snapshot version.
+    await this.broadcaster.broadcastToRoom(
+      `job:${jobId}`,
+      progressEvent,
+      { percent },
+      {
+        id: String(version),
+      },
+    )
+  }
+
+  async complete(jobId: string, result: string): Promise<void> {
+    const job = this.jobs.get(jobId) as Job
+    const { version } = this.nextVersion(jobId)
+    job.status = 'completed'
+    job.result = result
+    await this.broadcaster.broadcastToRoom(
+      `job:${jobId}`,
+      doneEvent,
+      { result },
+      {
+        id: String(version),
+      },
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch-based transport (what frontend-http-client would implement)
+// ---------------------------------------------------------------------------
+
+function createFetchTransport(baseUrl: string): FallbackTransport {
+  const toUrl = (request: { path: string; query?: Record<string, string> }) => {
+    const url = new URL(request.path, baseUrl)
+    for (const [key, value] of Object.entries(request.query ?? {})) {
+      url.searchParams.set(key, value)
+    }
+    return url
+  }
+
+  return {
+    async fetchSnapshot(request, { signal }) {
+      const response = await fetch(toUrl(request), {
+        method: request.method.toUpperCase(),
+        headers: { accept: 'application/json', ...request.headers },
+        signal,
+      })
+      return {
+        status: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+        body: await response.json().catch(() => undefined),
+      }
+    },
+    async openStream(request, { signal, lastEventId }) {
+      const response = await fetch(toUrl(request), {
+        method: request.method.toUpperCase(),
+        headers: {
+          accept: 'text/event-stream',
+          ...(lastEventId !== undefined ? { 'last-event-id': lastEventId } : {}),
+          ...request.headers,
+        },
+        signal,
+      })
+      const body = response.body
+      const chunks = (async function* (): AsyncGenerator<string, void, unknown> {
+        if (!body) return
+        const reader = body.getReader()
+        const decoder = new TextDecoder()
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) return
+            yield decoder.decode(value, { stream: true })
+          }
+        } finally {
+          reader.releaseLock()
+        }
+      })()
+      return {
+        status: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+        chunks,
+      }
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const FAST_POLICY: Partial<FallbackPolicy> = {
+  deadmanDelayMs: 400,
+  deadmanIdleBackoff: { factor: 1, maxMs: 400 },
+  staleConnectionTimeoutMs: 'off',
+  sseRetryBackoff: { baseMs: 50, factor: 1, maxMs: 50 },
+  pollFailureBackoff: { baseMs: 50, factor: 1, maxMs: 50 },
+}
+
+describe('sse-fallback integration (real server, real HTTP)', () => {
+  let server: SSETestServerWithResources<undefined>
+  let broadcaster: SSERoomBroadcaster
+  let jobService: JobService
+
+  beforeEach(async () => {
+    const sseRoomManager = new SSERoomManager()
+    broadcaster = new SSERoomBroadcaster({ sseRoomManager })
+    jobService = new JobService(broadcaster)
+
+    server = await createSSETestServer(
+      (app) => {
+        app.route(
+          buildApiRoute(
+            jobContract,
+            {
+              nonSse: async (request) => ({
+                status: 200,
+                body: jobService.get(request.params.jobId),
+              }),
+              sse: (request, sse) => {
+                const session = sse.start('keepAlive')
+                session.rooms.join(`job:${request.params.jobId}`)
+              },
+            },
+            { sseRooms: broadcaster },
+          ),
+        )
+      },
+      {
+        configureApp: (app) => {
+          app.setValidatorCompiler(validatorCompiler)
+          app.setSerializerCompiler(serializerCompiler)
+        },
+        setup: () => undefined,
+      },
+    )
+  })
+
+  afterEach(async () => {
+    await server.close()
+  })
+
+  it('delivers the completion over SSE push (happy path)', { timeout: 10000 }, async () => {
+    jobService.create('j1')
+    const sub = createResilientSubscription(jobBinding, {
+      transport: createFetchTransport(server.baseUrl),
+      params: { pathParams: { jobId: 'j1' } },
+      policy: FAST_POLICY,
+    })
+    try {
+      const completion = sub.waitFor('done', { timeoutMs: 5000 })
+      // Wait for the SSE branch to join the room, then push.
+      await vi.waitFor(() => {
+        expect(broadcaster.getConnectionCountInRoom('job:j1')).toBe(1)
+      })
+      await jobService.progress('j1', 50)
+      await jobService.complete('j1', 'pushed-result')
+
+      await expect(completion).resolves.toEqual({ result: 'pushed-result' })
+      expect(sub.status).toBe('stopped')
+    } finally {
+      sub.stop()
+    }
+  })
+
+  it(
+    'closes the startup race: a job completed before subscribing resolves via the eager poll',
+    { timeout: 10000 },
+    async () => {
+      jobService.create('j2')
+      await jobService.complete('j2', 'already-done')
+
+      const sub = createResilientSubscription(jobBinding, {
+        transport: createFetchTransport(server.baseUrl),
+        params: { pathParams: { jobId: 'j2' } },
+        policy: FAST_POLICY,
+      })
+      try {
+        const delivered = await sub.waitFor('done', { timeoutMs: 5000 })
+        expect(delivered).toEqual({ result: 'already-done' })
+      } finally {
+        sub.stop()
+      }
+    },
+  )
+
+  it(
+    'delivers the completion via the deadman poll when the push is missed',
+    { timeout: 10000 },
+    async () => {
+      jobService.create('j3')
+      const origins: string[] = []
+      const sub = createResilientSubscription(jobBinding, {
+        transport: createFetchTransport(server.baseUrl),
+        params: { pathParams: { jobId: 'j3' } },
+        policy: FAST_POLICY,
+      })
+      sub.onEvent((event) => origins.push(event.origin))
+      try {
+        const completion = sub.waitFor('done', { timeoutMs: 8000 })
+        await vi.waitFor(() => {
+          expect(broadcaster.getConnectionCountInRoom('job:j3')).toBe(1)
+        })
+
+        // Simulate a missed notification: the job completes but the broadcast
+        // targets a room nobody re-broadcasts (local-only miss) — here we just
+        // mutate the store without broadcasting.
+        const job = jobService.get('j3')
+        job.status = 'completed'
+        job.result = 'polled-result'
+        job.version += 1
+
+        await expect(completion).resolves.toEqual({ result: 'polled-result' })
+        expect(origins.at(-1)).toBe('poll')
+      } finally {
+        sub.stop()
+      }
+    },
+  )
+
+  it(
+    'survives a silently-dead stream via the stale watchdog and still completes',
+    { timeout: 15000 },
+    async () => {
+      jobService.create('j4')
+      const sub = createResilientSubscription(jobBinding, {
+        transport: createFetchTransport(server.baseUrl),
+        params: { pathParams: { jobId: 'j4' } },
+        policy: {
+          ...FAST_POLICY,
+          // No heartbeats arrive within 700ms (plugin default is 30s), so the
+          // watchdog force-closes and reconnects — the original incident class.
+          staleConnectionTimeoutMs: 700,
+          deadmanDelayMs: 60_000, // keep the deadman out of this test
+          deadmanIdleBackoff: { factor: 1, maxMs: 60_000 },
+        },
+      })
+      try {
+        const completion = sub.waitFor('done', { timeoutMs: 10_000 })
+
+        // First connection joins, gets force-closed by the watchdog, and the
+        // client reconnects — wait until the server has seen a NEW connection
+        // after the old one left.
+        await vi.waitFor(() => {
+          expect(broadcaster.getConnectionCountInRoom('job:j4')).toBe(1)
+        })
+        await vi.waitFor(
+          () => {
+            expect(sub.status === 'reconnecting' || sub.status === 'live').toBe(true)
+          },
+          { timeout: 5000 },
+        )
+
+        // Eventually a (re)connected stream is in the room; push the completion.
+        await vi.waitFor(
+          () => {
+            expect(broadcaster.getConnectionCountInRoom('job:j4')).toBeGreaterThanOrEqual(1)
+          },
+          { timeout: 5000 },
+        )
+        await jobService.complete('j4', 'after-reconnect')
+
+        await expect(completion).resolves.toEqual({ result: 'after-reconnect' })
+      } finally {
+        sub.stop()
+      }
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Browser-safety guard for the sse-fallback package sources
+// ---------------------------------------------------------------------------
+
+describe('sse-fallback browser safety', () => {
+  it('has no node:/fastify/server-only imports in its source tree', () => {
+    const srcDir = join(__dirname, '..', '..', 'packages', 'sse-fallback', 'src')
+    const offenders: string[] = []
+    for (const file of readdirSync(srcDir)) {
+      if (!file.endsWith('.ts') || file.endsWith('.spec.ts')) continue
+      const content = readFileSync(join(srcDir, file), 'utf8')
+      for (const forbidden of ["from 'node:", "from 'fastify", "from 'awilix", 'require(']) {
+        if (content.includes(forbidden)) {
+          offenders.push(`${file}: ${forbidden}`)
+        }
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Context

Downstream systems relying on push notifications (websockets today) occasionally fail to establish or silently lose connections, missing crucial notifications (e.g. "upload finished") that gate workflow progression. This PR lays the foundation for **SSE with a transparent polling fallback**: the client subscribes to the SSE branch of a dual-mode contract and keeps a deadman timer — when no data event arrives within the window, it polls the JSON branch of the same route. A version gate reconciles the two channels so app code sees exactly one uniform event stream.

Design doc summary: polling is the correctness backbone (bounded staleness, guaranteed), SSE is the latency optimization. Two independent failure detectors: a byte-level `staleConnection` watchdog (catches silently dead connections — the original incident class) and a data-event-only `deadman` (catches healthy-but-wrong streams where a notification was genuinely dropped).

## What's in here

### New package: `@opinionated-machine/sse-fallback`
Browser-safe, **zero runtime dependencies** (enforced by a source check). `defineFallbackBinding(contract, config)` declares the one thing that can't be inferred — how a poll snapshot relates to SSE events (snapshot→events mapping, version extraction, terminal events, optional state reducer) — on a dual-mode contract, with `bindFallbackContracts` (separate contracts) and `fromLegacyDualModeContract` escape hatches. `createResilientSubscription` runs the state machine: subscribe-first hydration (zero missed-event window), version-gated delivery (handles duplicates, the stale-poll race, and replay overlap with one rule), Last-Event-ID reconnects, gap detection with instant repair polls, degradation to pure polling with background SSE recovery. Ships a scripted `TestTransport` for deterministic fake-timer tests. Intended to be wrapped by `@lokalise/frontend-http-client`.

### @fastify/sse 0.6 adaptation (bugfix prerequisite)
The 0.5→0.6 bump had silently broken things this feature depends on:
- Per-route and registration-time `heartbeatInterval` were **silent no-ops** (0.6 only supports a plugin-level interval; the registration path wrote config where the plugin never read it). Restored via a framework-managed heartbeat timer; type widened to `number | false`.
- Routes defaulted to kind `'legacy'` with a strict Accept gate: a missing `Accept` header or `*/*` **crashed** SSE-only routes, and `defaultMode: 'sse'` crashed on ambiguous Accepts. Now: SSE-only routes use kind `'only'` (lenient gate, clean 406 on explicit refusal), dual-mode routes use `'manual'` (the framework's q-value-aware `determineMode()` is the single negotiator). New Accept-matrix e2e tests un-mask the blind spot (the suite previously always sent `Accept: text/event-stream`).

### Rooms in the modern api-contracts path
`session.rooms.join()/leave()` were silent no-op stubs in `buildApiRoute` sessions — the flagship serving pattern (sync branch answers polls while a domain service broadcasts into a room the SSE branch joined) was impossible. New `sseRooms: SSERoomBroadcaster` route option + `ApiSseConnectionRegistry` wire real room operations, broadcast delivery, and close cleanup.

### Gateway streaming support
Gateway defaults were killing streams: Envoy's 15s route timeout and 5-minute stream idle timeout reset SSE connections, and `timeouts.idle` was silently ignored by **all three** generators despite being documented. Now: routes from SSE/dual contracts carry a `streaming: 'sse' | 'dual'` manifest marker; Envoy maps `timeouts.idle` → route `idle_timeout` and disables both timeouts for streaming routes by default (+ new `EnvoyOptions.streamIdleTimeout`); Kong emits `response_buffering: false` and folds idle into the loosest-wins `read_timeout`; KrakenD uses the looser of request/idle. Legacy SSE/dual controllers can opt into the manifest via `includeStreamingControllers`. The Envoy docker-compose acceptance suite proves a marked streaming route survives a 3s event gap under a 2s listener idle timeout while an unmarked route is reset.

### Monotonic event ids
`createEventIdSequence()` / `compareEventIds()` — orderable ids for `Last-Event-ID` replay and the client version gate; epoch changes signal "resync via poll".

## Verification

- Root suite: **1433 tests** pass incl. typecheck (was 1322) — new suites: Accept-negotiation matrix (39), per-route heartbeats over real HTTP (5), rooms-in-api-path e2e (5), fallback-core unit+typecheck (92), full-stack fallback integration over real HTTP (5: SSE push, startup race, deadman recovery of a missed notification, stale-watchdog reconnect, browser-safety guard).
- All gateway package suites pass with refreshed snapshots; Envoy **docker acceptance suite passes against real Envoy** (6 tests incl. the two new streaming ones).
- `biome check` clean across the workspace; all packages build.
- Note: `sse-rooms-redis` integration spec requires a local Redis (pre-existing; untouched by this PR — it has its own `test:docker` script and CI workflow).

## Follow-ups (out of scope)
`@lokalise/frontend-http-client` wrapper (lives in shared-ts-libs), Redis-backed cross-node id sequences, SharedWorker connection-sharing transport, Kong/KrakenD streaming acceptance suites, upstream @fastify/sse PR for native per-route heartbeat intervals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resilient SSE subscriptions with automatic polling fallback, reconnection, state recovery, and stale-connection detection.
  * Added SSE room support for joining, leaving, isolated broadcasts, and connection cleanup.
  * Added monotonic SSE event IDs and improved event ordering.
  * Added streaming route support across Envoy, Kong, and KrakenD gateway configurations.

* **Improvements**
  * Added configurable framework-managed SSE heartbeats, including explicit disabling.
  * Improved Accept-header negotiation for SSE-only and dual-mode routes.
  * Added streaming timeout and buffering configuration guidance.

* **Documentation**
  * Expanded SSE, fallback, heartbeat, and gateway streaming documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->